### PR TITLE
feat: improve visual contrast in Applications History chart

### DIFF
--- a/frontend/src/features/maintainers/components/dashboard/ApplicationsChart.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/ApplicationsChart.tsx
@@ -102,8 +102,8 @@ export function ApplicationsChart({ data }: ApplicationsChartProps) {
                   <stop offset="100%" stopColor="#d4af37" stopOpacity={0.6} />
                 </linearGradient>
                 <linearGradient id="mergedGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#d4af37" stopOpacity={0.9} />
-                  <stop offset="100%" stopColor="#e8c468" stopOpacity={0.6} />
+                  <stop offset="0%" stopColor="#4fb37a" stopOpacity={0.9} />
+                  <stop offset="100%" stopColor="#2e6947" stopOpacity={0.6} />
                 </linearGradient>
               </defs>
             </BarChart>
@@ -119,7 +119,7 @@ export function ApplicationsChart({ data }: ApplicationsChartProps) {
             }`}>Applications</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-4 h-4 rounded-full bg-gradient-to-br from-[#d4af37] to-[#e8c468]" />
+            <div className="w-4 h-4 rounded-full bg-gradient-to-br from-[#4fb37a] to-[#2e6947]" />
             <span className={`text-[13px] font-semibold transition-colors ${
               theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
             }`}>Merged</span>


### PR DESCRIPTION
Description
This PR improves the visual accessibility and clarity of the Applications History chart in the Maintainer Dashboard.

Previously, both the "Applications" and "Merged" bars used very similar golden gradients, making it difficult to distinguish between total application volume and successful merges at a glance. We have introduced a Forest Emerald Green variant for the "Merged" status to provide better contrast and a more intuitive "success" indicator.

Changes
Updated mergedGradient in 
ApplicationsChart.tsx
 to use a premium green color scheme (#4fb37a → #2e6947).
Maintained the primary Brand Gold for the applicationsGradient (#c9983a → #d4af37).
Updated the legend indicators and gradients to match the new bar colors.
Verified the design works seamlessly in both Light and Dark themes.
Visual Verification
The changes were verified using a temporary preview section on the landing page to ensure the gradients blended correctly with the glassmorphism aesthetic.
<img width="1728" height="1002" alt="Screenshot 2026-01-23 at 02 27 33" src="https://github.com/user-attachments/assets/a7b48921-7748-4d0a-90e0-ba593803fe56" />

<img width="1728" height="1002" alt="Screenshot 2026-01-23 at 16 43 03" src="https://github.com/user-attachments/assets/08ba4dd9-e6de-422b-805b-079ccba8830a" />
<img width="1728" height="1002" alt="Screenshot 2026-01-23 at 16 43 15" src="https://github.com/user-attachments/assets/867a92a1-2011-4cad-8aa0-e1be48e0458a" />


Close #75 
