### PR TITLE
frontend: add GitHub icon to social media icons row in public profile

### DIFF
--- a/frontend/src/features/dashboard/pages/ProfilePage.tsx
+++ b/frontend/src/features/dashboard/pages/ProfilePage.tsx
@@ -624,6 +624,18 @@ export function ProfilePage({
                 {/* Social Media Links - Show all icons, dimmed if no link */}
                 {!isLoadingProfile && (
                   <div className="flex items-center gap-3 flex-wrap mb-4">
+                    {/* GitHub */}
+                    <a
+                      href={`https://github.com/${
+                        viewingUser?.login || user?.github?.login
+                      }`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-8 h-8 rounded-full bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border-2 border-[#c9983a]/50 flex items-center justify-center hover:scale-110 hover:shadow-[0_4px_12px_rgba(201,152,58,0.4)] transition-all duration-300"
+                      title="GitHub"
+                    >
+                      <Github className="w-4 h-4 text-[#c9983a]" />
+                    </a>
                     {/* Telegram */}
                     {profileData?.telegram ? (
                       <a


### PR DESCRIPTION
## Description
Added GitHub icon to the social media icons row in the public profile page.
Closes #50 

## Changes Made
- Added a GitHub icon to the social media icons section in ProfilePage.tsx
- Icon always displays for all users (since GitHub authentication is required)
- Links to user's GitHub profile: https://github.com/{login}
- Applied matching golden glassmorphism styling consistent with other social icons:
 * Golden gradient background and border
 * Hover effects with scale and shadow transitions
 * Proper sizing (8x8 rounded-full)
- Icon opens in new tab with security attributes (target="_blank" and rel="noopener noreferrer")
- Works correctly in both dark and light themes

<img width="1010" height="548" alt="Screenshot 2026-01-23 at 9 34 25 pm" src="https://github.com/user-attachments/assets/50f04cb1-ef17-437f-9c67-f24ae8c0d8be" />
