### PR TITLE
Fix Issue 95: Removed background color from selected filter items

### DIFF
--- a/frontend/src/shared/components/ui/Dropdown.tsx
+++ b/frontend/src/shared/components/ui/Dropdown.tsx
@@ -141,11 +141,7 @@ export function Dropdown({
                       key={idx}
                       onClick={() => onToggle(option.name)}
                       className={`w-full px-4 py-3 transition-all flex items-start justify-between group ${
-                        isSelected
-                          ? theme === 'dark'
-                            ? 'bg-[#c9983a]/[0.15] hover:bg-[#c9983a]/[0.22]'
-                            : 'bg-[#c9983a]/[0.12] hover:bg-[#c9983a]/[0.18]'
-                          : theme === 'dark'
+                        theme === 'dark'
                           ? 'hover:bg-white/[0.05]'
                           : 'hover:bg-black/[0.03]'
                       }`}


### PR DESCRIPTION
This PR updates the filter dropdowns to simplify selection styling:
Removed the golden background colors (bg-[#c9983a]/[0.15] and bg-[#c9983a]/[0.12]) from selected items in Dropdown.tsx.
Selected and unselected items now share the same background; only hover highlights remain.
Selection is now visually indicated solely by the checkbox checkmark, reducing visual clutter.

Closes #95.