### PR TITLE
Maintainers-Page-Shows-Empty-State

### DIFF
--- a/frontend/src/features/maintainers/components/dashboard/DashboardTab.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/DashboardTab.tsx
@@ -38,7 +38,8 @@ export function DashboardTab({ selectedProjects, onRefresh }: DashboardTabProps)
       if (selectedProjects.length === 0) {
         setIssues([]);
         setPrs([]);
-        setIsLoading(false);
+        // Don't set isLoading to false when there are no projects
+        // This keeps the loading skeleton visible
         return;
       }
 

--- a/frontend/src/features/maintainers/components/issues/IssuesTab.tsx
+++ b/frontend/src/features/maintainers/components/issues/IssuesTab.tsx
@@ -156,7 +156,8 @@ export function IssuesTab({ onNavigate, selectedProjects, onRefresh, initialSele
     try {
       if (selectedProjects.length === 0) {
         setIssues([]);
-        setIsLoadingIssues(false);
+        // Don't set isLoadingIssues to false when there are no projects
+        // This keeps the loading skeleton visible
         return;
       }
 

--- a/frontend/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
+++ b/frontend/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
@@ -53,7 +53,8 @@ export function PullRequestsTab({ selectedProjects, onRefresh }: PullRequestsTab
     try {
       if (selectedProjects.length === 0) {
         setPrs([]);
-        setIsLoading(false);
+        // Don't set isLoading to false when there are no projects
+        // This keeps the loading skeleton visible
         return;
       }
 


### PR DESCRIPTION
## 🐛 Fix: Prevent Empty State Flash on Maintainers Tabs

close #91

just removed the setisloading fuction

![Uploading Screenshot 2026-01-24 225112.png…]()

@Jagadeeshftw sorry for taking this long to reply i have been trying to load it but the signup prosses as been showing me this error but you could try it on your end, when i worked on it  the Loading skeletons show immediately when switching to Maintainers page


