### PR TITLE
feat: show fallback description text for recommended projects

### DIFF
--- a/frontend/src/app/pages/DashboardComplete.tsx
+++ b/frontend/src/app/pages/DashboardComplete.tsx
@@ -524,7 +524,7 @@ function DiscoverPage() {
               }`}>{project.name}</h4>
               <p className={`text-[13px] mb-4 line-clamp-2 transition-colors ${
                 theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-              }`}>{project.description}</p>
+              }`}>{project.description?.trim() || "No description"}</p>
 
               <div className={`flex items-center space-x-4 text-[13px] mb-4 transition-colors ${
                 theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'

--- a/frontend/src/features/dashboard/pages/DiscoverPage.tsx
+++ b/frontend/src/features/dashboard/pages/DiscoverPage.tsx
@@ -486,7 +486,7 @@ export function DiscoverPage({
                     theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
                   }`}
                 >
-                  {project.description}
+                  {project.description?.trim() || "No description"}
                 </p>
 
                 <div


### PR DESCRIPTION
closes #240 

Display fallback text for projects without descriptions to prevent empty card content.


https://github.com/user-attachments/assets/a826ba71-87c5-4242-b17d-e115036c5f7a

