### PR TITLE
 Prevent duplicate wallet entries for the same token

### DIFF
--- a/frontend/src/features/settings/components/billing/BillingTab.tsx
+++ b/frontend/src/features/settings/components/billing/BillingTab.tsx
@@ -277,6 +277,16 @@ export function BillingTab() {
   const handleAddPaymentMethod = (method: PaymentMethod) => {
     if (!selectedProfile) return;
 
+    // Checked for the  duplicate token type (secondary validation)
+    const existingWallet = selectedProfile.paymentMethods?.find(
+      pm => pm.cryptoType === method.cryptoType
+    );
+    
+    if (existingWallet) {
+      console.warn(`Duplicate wallet prevented: ${method.cryptoType} already exists`);
+      return;
+    }
+
     const updatedProfile = {
       ...selectedProfile,
       paymentMethods: [...(selectedProfile.paymentMethods || []), method],


### PR DESCRIPTION
Close #241 
implemented duplicate wallet prevention for issue #241 in the Grainlify payment methods section. Users can now only add one wallet per token type (USDC, USDT, XLM), preventing confusion and payout routing ambiguity.
closed #241 
<img width="1353" height="632" alt="Screenshot 2026-01-28 050043" src="https://github.com/user-attachments/assets/ed2e891f-e1b5-4368-902b-24607186d93a" />

<img width="301" height="540" alt="Screenshot 2026-01-28 050106" src="https://github.com/user-attachments/assets/7c2144fc-403a-4f95-b0cc-6e100de5e3a9" />


https://github.com/user-attachments/assets/0b3ff285-8898-48d6-81d8-48c54f68f571

