### PR TITLE
fix: leaderboard View Profile navigates to selected userfix: correct leaderboard View Profile navigation

### DIFF
--- a/frontend/src/features/leaderboard/pages/LeaderboardPage.tsx
+++ b/frontend/src/features/leaderboard/pages/LeaderboardPage.tsx
@@ -200,9 +200,8 @@ export function LeaderboardPage() {
           !isLoading &&
           leaderboardData.length === 0 && (
             <div
-              className={`text-center py-8 transition-colors ${
-                theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
-              }`}
+              className={`text-center py-8 transition-colors ${theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                }`}
             >
               No contributors yet. Be the first to contribute!
             </div>
@@ -243,7 +242,7 @@ export function LeaderboardPage() {
                 onUserClick={(username, userId) => {
                   // Navigate to profile page with user identifier
                   const identifier = userId || username;
-                  window.location.href = `/dashboard?tab=profile&user=${identifier}`;
+                  window.location.href = `/dashboard?page=profile&user=${encodeURIComponent(identifier)}`;
                 }}
               />
               {hasMore && (


### PR DESCRIPTION
Fixes #257

### What was fixed
- Corrected profile navigation to use selected user instead of logged-in user
- Updated URL parameter to match dashboard expectations
- Ensured UUID / username routing works correctly

### How to test
1. Go to Leaderboard → Contributors
2. Click "View Profile" for any user
3. Verify profile page opens for the selected user
4. Confirm it no longer redirects to logged-in user's profile
