### PR TITLE
Add Network Selection and Risk Warning to Payment Methods is Fixed

### DIFF
--- a/frontend/src/features/settings/types/index.ts
+++ b/frontend/src/features/settings/types/index.ts
@@ -24,7 +24,7 @@ export interface BillingProfile {
 
 // Payment Method types
 export type CryptoType = 'usdc' | 'usdt' | 'xlm';
-export type EcosystemType = 'stellar';
+export type EcosystemType = 'stellar' | 'ethereum' | 'polygon';
 
 export interface PaymentMethod {
   id: number;


### PR DESCRIPTION
Closes #243

**Summary**
This PR updates the "Add Payment Method" modal to support multi-chain network selection. It introduces a network selector, implements token-specific constraints (e.g., locking XLM to Stellar), and adds a critical risk warning to prevent users from sending funds to the wrong network, reducing the risk of irreversible asset loss.

**Key Features Implemented:**
- Network Selection UI: Added a selector for Stellar, Ethereum, and Polygon networks in the payment method modal.
- Smart Constraints: Implemented logic to auto-select and lock the appropriate network based on the chosen token (e.g., selecting XLM forces Stellar).
- Risk Warning: Added a prominent warning alert regarding the permanent loss of funds if the wrong network is used.
- Type Definitions: Updated EcosystemType to support Ethereum and Polygon.

**How to Test:**
1. Navigate to Settings: Log in to the User Dashboard and go to the Settings page.
2. Access Billing: Switch to the Billing tab.
3. Select Profile: Click on a Billing Profile to view its details (or create one if none exist).
4. Go to Payment Methods: Inside the profile details, switch to the Payment Methods sub-tab.
5. Add Method: Click the "Add Payment Method" button.
6. Verify Network Selection:
    - Select XLM and confirm that Stellar is auto-selected and locked.
    - Select USDC or USDT and confirm you can toggle between Stellar , Ethereum , and Polygon .
7. Check Warning: Observe the yellow risk warning alert ("Selecting the wrong network...") displayed at the bottom of the modal.
8. Save: Try to save without a network (should be prevented) and then save with a valid network.

**Checklist:**
✅ Add network selection UI to the Add Payment Method modal
✅ Implement token-network constraints (e.g., XLM -> Stellar)
✅ Add risk warning alert for cross-chain transactions
✅ Update TypeScript definitions for new networks