### PR TITLE
test: convert SDK example scripts into smoke tests and integrate CI

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -113,4 +113,24 @@ jobs:
           ../scripts/test_deploy_failures.sh
           ../scripts/test_upgrade_failures.sh
 
-   
+  sdk-smoke-tests:
+    name: SDK Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          cd contracts/sdk
+          npm install
+
+      - name: Run smoke tests
+        run: |
+          cd contracts/sdk
+          npm run test:smoke

--- a/contracts/sdk/src/__tests__/smoke.test.ts
+++ b/contracts/sdk/src/__tests__/smoke.test.ts
@@ -54,12 +54,16 @@ describe('SDK Example Smoke Tests', () => {
         const result = await lockFundsExample(client, mockKeypair);
         expect(result).toBeDefined();
         //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledTimes(1);
+        //@ts-ignore - accessing private field
         expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [10000000n], mockKeypair);
     });
 
     it('should run release-funds example successfully', async () => {
         const result = await releaseFundsExample(client, mockKeypair);
         expect(result).toBe(3);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledTimes(1);
         //@ts-ignore - accessing private field
         expect(client.invokeContract).toHaveBeenCalledWith('trigger_program_releases', [], mockKeypair);
     });
@@ -74,20 +78,38 @@ describe('SDK Example Smoke Tests', () => {
         );
         expect(result).toBeDefined();
         //@ts-ignore - accessing private field
-        expect(client.invokeContract).toHaveBeenCalledWith('init_program', expect.anything(), mockKeypair);
+        expect(client.invokeContract).toHaveBeenCalledTimes(4); // init, lock, batch_payout, get_info
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenNthCalledWith(1, 'init_program', [mockProgramId, mockAuthorizedKey, mockTokenAddress], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenNthCalledWith(2, 'lock_program_funds', [50000000n], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenNthCalledWith(3, 'batch_payout', [expect.any(Array), expect.any(Array)], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenNthCalledWith(4, 'get_program_info', []);
     });
 
     it('should run batch-lock example successfully', async () => {
         const result = await batchLockExample(client, mockKeypair);
         expect(result).toBeDefined();
         //@ts-ignore - accessing private field
-        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', expect.anything(), mockKeypair);
+        expect(client.invokeContract).toHaveBeenCalledTimes(4); // 3 locks + 1 get_info
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [10000000n], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [20000000n], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [30000000n], mockKeypair);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledWith('get_program_info', []);
     });
 
     it('should run query-escrow example successfully', async () => {
         const result = await queryEscrowExample(client);
         expect(result).toBeDefined();
         expect(result.program_id).toBe(mockProgramId);
+        //@ts-ignore - accessing private field
+        expect(client.invokeContract).toHaveBeenCalledTimes(1);
         //@ts-ignore - accessing private field
         expect(client.invokeContract).toHaveBeenCalledWith('get_program_info', []);
     });

--- a/contracts/sdk/tsconfig.test.json
+++ b/contracts/sdk/tsconfig.test.json
@@ -1,8 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "examples/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This PR implements automated smoke tests for the SDK example scripts, satisfying issue #495.

### Changes 

- **Robust Smoke Tests**: Refined [contracts/sdk/src/__tests__/smoke.test.ts](cci:7://file:///home/maryjane/Desktop/workspace/job/drip/grainlify/contracts/sdk/src/__tests__/smoke.test.ts:0:0-0:0) to include precise assertions on contract call counts and parameters for all 5 example scripts.
- **Config Fix**: Updated [tsconfig.test.json](cci:7://file:///home/maryjane/Desktop/workspace/job/drip/grainlify/contracts/sdk/tsconfig.test.json:0:0-0:0) to include the `examples/` directory, resolving TypeScript `rootDir` lint errors during imports.
- **CI/CD Integration**: Added a dedicated `sdk-smoke-tests` job to [.github/workflows/contracts-ci.yml](cci:7://file:///home/maryjane/Desktop/workspace/job/drip/grainlify/.github/workflows/contracts-ci.yml:0:0-0:0) to ensure example scripts are verified on every PR.

### Verification 

- All 5 smoke tests pass: `npm run test:smoke`
- Full SDK test suite (203 tests) passes: `npm test`

Closes #495
