### PR TITLE
feat: standardize token decimals and rounding policy in contracts

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -4,6 +4,9 @@ mod events;
 mod invariants;
 #[cfg(test)]
 mod test_metadata;
+#[cfg(test)]
+mod test_token_math;
+pub mod token_math;
 
 mod test_cross_contract_interface;
 #[cfg(test)]
@@ -349,9 +352,7 @@ mod anti_abuse {
     }
 }
 
-#[allow(dead_code)]
-const BASIS_POINTS: i128 = 10_000;
-const MAX_FEE_RATE: i128 = 5_000; // 50% max fee
+const MAX_FEE_RATE: i128 = token_math::MAX_FEE_RATE;
 const MAX_BATCH_SIZE: u32 = 20;
 
 #[contracterror]
@@ -620,18 +621,10 @@ impl BountyEscrowContract {
         Ok(())
     }
 
-    /// Calculate fee amount based on rate (in basis points)
+    /// Calculate fee using floor rounding. Delegates to `token_math::calculate_fee`.
     #[allow(dead_code)]
     fn calculate_fee(amount: i128, fee_rate: i128) -> i128 {
-        if fee_rate == 0 {
-            return 0;
-        }
-        // Fee = (amount * fee_rate) / BASIS_POINTS
-        // Using checked arithmetic to prevent overflow
-        amount
-            .checked_mul(fee_rate)
-            .and_then(|x| x.checked_div(BASIS_POINTS))
-            .unwrap_or(0)
+        token_math::calculate_fee(amount, fee_rate)
     }
 
     /// Get fee configuration (internal helper)

--- a/contracts/bounty_escrow/contracts/escrow/src/test_token_math.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_token_math.rs
@@ -1,0 +1,247 @@
+#![cfg(test)]
+
+//! Tests for the `token_math` module: fee calculation with floor rounding,
+//! amount splitting invariant, decimal scaling, and base-unit conversion.
+
+use crate::token_math;
+
+// ===========================================================================
+// 1. calculate_fee — basic behaviour
+// ===========================================================================
+
+#[test]
+fn fee_zero_rate_returns_zero() {
+    assert_eq!(token_math::calculate_fee(1_000_000, 0), 0);
+}
+
+#[test]
+fn fee_zero_amount_returns_zero() {
+    assert_eq!(token_math::calculate_fee(0, 500), 0);
+}
+
+#[test]
+fn fee_exact_division() {
+    // 10_000 * 500 / 10_000 = 500
+    assert_eq!(token_math::calculate_fee(10_000, 500), 500);
+}
+
+#[test]
+fn fee_floor_rounds_down() {
+    // 999 * 100 / 10_000 = 9.99 → floor = 9
+    assert_eq!(token_math::calculate_fee(999, 100), 9);
+}
+
+#[test]
+fn fee_one_basis_point() {
+    // 10_000 * 1 / 10_000 = 1
+    assert_eq!(token_math::calculate_fee(10_000, 1), 1);
+}
+
+#[test]
+fn fee_max_rate() {
+    // 1_000 * 5_000 / 10_000 = 500 (50%)
+    assert_eq!(
+        token_math::calculate_fee(1_000, token_math::MAX_FEE_RATE),
+        500
+    );
+}
+
+#[test]
+fn fee_single_unit_amount() {
+    // 1 * 100 / 10_000 = 0.01 → floor = 0
+    assert_eq!(token_math::calculate_fee(1, 100), 0);
+}
+
+// ===========================================================================
+// 2. calculate_fee — multiple decimal scenarios
+// ===========================================================================
+
+#[test]
+fn fee_xlm_7_decimals() {
+    // 100 XLM = 100_0000000 stroops, 2% fee (200 bp)
+    let amount = 100_0000000_i128;
+    let fee = token_math::calculate_fee(amount, 200);
+    assert_eq!(fee, 2_0000000); // 2 XLM
+}
+
+#[test]
+fn fee_usdc_6_decimals() {
+    // 100 USDC = 100_000_000 (6 decimals), 2% fee (200 bp)
+    let amount = 100_000_000_i128;
+    let fee = token_math::calculate_fee(amount, 200);
+    assert_eq!(fee, 2_000_000); // 2 USDC
+}
+
+#[test]
+fn fee_low_decimal_token_2_decimals() {
+    // 100 tokens = 10_000 (2 decimals), 3% fee (300 bp)
+    let amount = 10_000_i128;
+    let fee = token_math::calculate_fee(amount, 300);
+    assert_eq!(fee, 300); // 3 tokens
+}
+
+#[test]
+fn fee_small_amount_high_decimals_floors_correctly() {
+    // 1 stroop (smallest XLM unit), 1% fee
+    let fee = token_math::calculate_fee(1, 100);
+    assert_eq!(fee, 0); // too small, floors to 0
+}
+
+// ===========================================================================
+// 3. split_amount — invariant: fee + net == amount
+// ===========================================================================
+
+#[test]
+fn split_invariant_exact() {
+    let amount = 10_000_i128;
+    let (fee, net) = token_math::split_amount(amount, 500);
+    assert_eq!(fee + net, amount);
+    assert_eq!(fee, 500);
+    assert_eq!(net, 9_500);
+}
+
+#[test]
+fn split_invariant_with_remainder() {
+    // 999 * 100 / 10_000 = 9 (floor). net = 990.
+    let amount = 999_i128;
+    let (fee, net) = token_math::split_amount(amount, 100);
+    assert_eq!(fee + net, amount);
+    assert_eq!(fee, 9);
+    assert_eq!(net, 990);
+}
+
+#[test]
+fn split_invariant_zero_fee() {
+    let amount = 5_000_i128;
+    let (fee, net) = token_math::split_amount(amount, 0);
+    assert_eq!(fee, 0);
+    assert_eq!(net, amount);
+    assert_eq!(fee + net, amount);
+}
+
+#[test]
+fn split_invariant_max_rate() {
+    let amount = 1_001_i128;
+    let (fee, net) = token_math::split_amount(amount, token_math::MAX_FEE_RATE);
+    assert_eq!(fee + net, amount);
+    // 1001 * 5000 / 10000 = 500 (floor)
+    assert_eq!(fee, 500);
+    assert_eq!(net, 501);
+}
+
+#[test]
+fn split_invariant_prime_amount() {
+    let amount = 997_i128;
+    let (fee, net) = token_math::split_amount(amount, 333);
+    assert_eq!(fee + net, amount);
+}
+
+#[test]
+fn split_invariant_large_amount() {
+    let amount = 1_000_000_000_0000000_i128; // 1 billion XLM in stroops
+    let (fee, net) = token_math::split_amount(amount, 250);
+    assert_eq!(fee + net, amount);
+}
+
+// ===========================================================================
+// 4. scale_amount — decimal conversion
+// ===========================================================================
+
+#[test]
+fn scale_same_decimals_is_identity() {
+    assert_eq!(token_math::scale_amount(12345, 7, 7), Some(12345));
+}
+
+#[test]
+fn scale_up_6_to_7() {
+    // 1_000_000 (6 dec) → 10_000_000 (7 dec)
+    assert_eq!(token_math::scale_amount(1_000_000, 6, 7), Some(10_000_000));
+}
+
+#[test]
+fn scale_down_7_to_6() {
+    // 10_000_005 (7 dec) → 1_000_000 (6 dec), floor
+    assert_eq!(token_math::scale_amount(10_000_005, 7, 6), Some(1_000_000));
+}
+
+#[test]
+fn scale_down_floors() {
+    // 19 (7 dec) → 1 (6 dec), floor of 1.9
+    assert_eq!(token_math::scale_amount(19, 7, 6), Some(1));
+}
+
+#[test]
+fn scale_down_sub_unit_floors_to_zero() {
+    // 9 (7 dec) → 0 (6 dec), 0.9 floors to 0
+    assert_eq!(token_math::scale_amount(9, 7, 6), Some(0));
+}
+
+#[test]
+fn scale_large_gap() {
+    // 1 (0 dec) → 10_000_000 (7 dec)
+    assert_eq!(token_math::scale_amount(1, 0, 7), Some(10_000_000));
+}
+
+#[test]
+fn scale_zero_amount() {
+    assert_eq!(token_math::scale_amount(0, 6, 7), Some(0));
+}
+
+// ===========================================================================
+// 5. to_base_units
+// ===========================================================================
+
+#[test]
+fn to_base_units_xlm() {
+    // 100 XLM → 100_0000000 stroops (7 decimals)
+    assert_eq!(token_math::to_base_units(100, 7), Some(1_000_000_000));
+}
+
+#[test]
+fn to_base_units_usdc() {
+    // 50 USDC → 50_000_000 (6 decimals)
+    assert_eq!(token_math::to_base_units(50, 6), Some(50_000_000));
+}
+
+#[test]
+fn to_base_units_zero_decimals() {
+    assert_eq!(token_math::to_base_units(42, 0), Some(42));
+}
+
+#[test]
+fn to_base_units_zero_amount() {
+    assert_eq!(token_math::to_base_units(0, 7), Some(0));
+}
+
+// ===========================================================================
+// 6. Boundary / edge cases
+// ===========================================================================
+
+#[test]
+fn fee_never_exceeds_amount() {
+    // Even at max rate, fee ≤ amount
+    for amount in [1_i128, 2, 3, 7, 99, 100, 999, 10_000, 1_000_000] {
+        let fee = token_math::calculate_fee(amount, token_math::MAX_FEE_RATE);
+        assert!(fee <= amount, "fee {} > amount {}", fee, amount);
+    }
+}
+
+#[test]
+fn split_net_never_negative() {
+    for amount in [1_i128, 2, 3, 7, 99, 100, 999, 10_000] {
+        let (fee, net) = token_math::split_amount(amount, token_math::MAX_FEE_RATE);
+        assert!(net >= 0, "net {} negative for amount {}", net, amount);
+        assert!(fee >= 0, "fee {} negative for amount {}", fee, amount);
+    }
+}
+
+#[test]
+fn fee_monotonic_with_amount() {
+    let rate = 250_i128;
+    let mut prev = 0_i128;
+    for amount in (0..=10_000_i128).step_by(100) {
+        let fee = token_math::calculate_fee(amount, rate);
+        assert!(fee >= prev, "fee decreased at amount {}", amount);
+        prev = fee;
+    }
+}

--- a/contracts/bounty_escrow/contracts/escrow/src/token_math.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/token_math.rs
@@ -1,0 +1,68 @@
+//! Token decimal scaling and fee rounding helpers.
+//!
+//! ## Rounding Policy
+//!
+//! All fee calculations use **floor (round-down)** rounding. This means the
+//! protocol never overcharges — any remainder from basis-point division stays
+//! with the payer rather than being collected as fee. The invariant
+//! `fee + net == gross` holds for every split.
+//!
+//! ## Token Decimals
+//!
+//! Stellar tokens can have different decimal places (e.g. 7 for XLM/stroops,
+//! 6 for USDC). The helpers here convert between decimal scales using floor
+//! rounding when scaling down (higher → lower precision).
+
+/// Basis-point denominator (1 bp = 0.01%).
+pub const BASIS_POINTS: i128 = 10_000;
+
+/// Maximum allowed fee rate in basis points (50%).
+pub const MAX_FEE_RATE: i128 = 5_000;
+
+/// Calculate fee using floor rounding.
+///
+/// `fee = floor(amount * fee_rate / BASIS_POINTS)`
+///
+/// Returns 0 when `fee_rate` is 0 or on overflow.
+pub fn calculate_fee(amount: i128, fee_rate: i128) -> i128 {
+    if fee_rate == 0 {
+        return 0;
+    }
+    amount
+        .checked_mul(fee_rate)
+        .and_then(|x| x.checked_div(BASIS_POINTS))
+        .unwrap_or(0)
+}
+
+/// Split `amount` into `(fee, net)` where `fee + net == amount`.
+///
+/// Fee is floored; any remainder from division stays in `net`.
+pub fn split_amount(amount: i128, fee_rate: i128) -> (i128, i128) {
+    let fee = calculate_fee(amount, fee_rate);
+    (fee, amount - fee)
+}
+
+/// Scale `amount` from `from_decimals` to `to_decimals`.
+///
+/// Uses floor rounding when scaling down. Returns `None` on overflow.
+pub fn scale_amount(amount: i128, from_decimals: u32, to_decimals: u32) -> Option<i128> {
+    if from_decimals == to_decimals {
+        return Some(amount);
+    }
+    if to_decimals > from_decimals {
+        let factor = 10_i128.checked_pow(to_decimals - from_decimals)?;
+        amount.checked_mul(factor)
+    } else {
+        let factor = 10_i128.checked_pow(from_decimals - to_decimals)?;
+        Some(amount / factor)
+    }
+}
+
+/// Convert a human-readable amount to the token's smallest unit.
+///
+/// E.g. `to_base_units(100, 7)` → `1_000_000_000` (100 XLM in stroops).
+/// Returns `None` on overflow.
+pub fn to_base_units(amount: i128, decimals: u32) -> Option<i128> {
+    let factor = 10_i128.checked_pow(decimals)?;
+    amount.checked_mul(factor)
+}

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -143,11 +143,14 @@
 // (after `mod anti_abuse;` and before the contract struct)
 
 mod claim_period;
+pub mod token_math;
 pub use claim_period::{ClaimRecord, ClaimStatus};
-#[cfg(test)]
-mod test_claim_period_expiry_cancellation;
 mod error_recovery;
 mod reentrancy_guard;
+#[cfg(test)]
+mod test_claim_period_expiry_cancellation;
+#[cfg(test)]
+mod test_token_math;
 
 #[cfg(test)]
 mod test_circuit_breaker_audit;
@@ -155,10 +158,10 @@ mod test_circuit_breaker_audit;
 #[cfg(test)]
 mod error_recovery_tests;
 
-#[cfg(test)]
-mod test_dispute_resolution;
 #[cfg(any())]
 mod reentrancy_tests;
+#[cfg(test)]
+mod test_dispute_resolution;
 
 #[cfg(test)]
 mod reentrancy_guard_standalone_test;
@@ -281,7 +284,7 @@ const PAUSE_STATE_CHANGED: Symbol = symbol_short!("PauseSt");
 const PROGRAM_REGISTRY: Symbol = symbol_short!("ProgReg");
 const PROGRAM_REGISTERED: Symbol = symbol_short!("ProgRgd");
 const FEE_CONFIG: Symbol = symbol_short!("FeeCfg");
-const BASIS_POINTS: i128 = 10_000;
+const BASIS_POINTS: i128 = token_math::BASIS_POINTS;
 
 // Storage keys
 const PROGRAM_DATA: Symbol = symbol_short!("ProgData");
@@ -355,7 +358,7 @@ pub struct ProgramData {
     pub remaining_balance: i128,
     pub authorized_payout_key: Address,
     pub payout_history: Vec<PayoutRecord>,
-    pub token_address: Address, // Token contract address for transfers
+    pub token_address: Address,  // Token contract address for transfers
     pub initial_liquidity: i128, // Initial liquidity provided by creator
 }
 
@@ -478,7 +481,6 @@ pub enum BatchError {
     DuplicateProgramId = 3,
 }
 
-
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultisigConfig {
@@ -518,7 +520,14 @@ impl ProgramEscrowContract {
         creator: Address,
         initial_liquidity: Option<i128>,
     ) -> ProgramData {
-        Self::initialize_program(env, program_id, authorized_payout_key, token_address, creator, initial_liquidity)
+        Self::initialize_program(
+            env,
+            program_id,
+            authorized_payout_key,
+            token_address,
+            creator,
+            initial_liquidity,
+        )
     }
 
     pub fn initialize_program(
@@ -673,16 +682,9 @@ impl ProgramEscrowContract {
         Ok(batch_size as u32)
     }
 
-    /// Calculate fee amount based on rate (in basis points)
+    /// Calculate fee using floor rounding. Delegates to `token_math::calculate_fee`.
     fn calculate_fee(amount: i128, fee_rate: i128) -> i128 {
-        if fee_rate == 0 {
-            return 0;
-        }
-        // Fee = (amount * fee_rate) / BASIS_POINTS
-        amount
-            .checked_mul(fee_rate)
-            .and_then(|x| x.checked_div(BASIS_POINTS))
-            .unwrap_or(0)
+        token_math::calculate_fee(amount, fee_rate)
     }
 
     /// Get fee configuration (internal helper)
@@ -786,14 +788,20 @@ impl ProgramEscrowContract {
     }
 
     pub fn get_program_release_schedules(env: Env) -> Vec<ProgramReleaseSchedule> {
-    env.storage()
-        .instance()
-        .get(&SCHEDULES)
-        .unwrap_or_else(|| Vec::new(&env))
-}
+        env.storage()
+            .instance()
+            .get(&SCHEDULES)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
 
     /// Update pause flags (admin only)
-    pub fn set_paused(env: Env, lock: Option<bool>, release: Option<bool>, refund: Option<bool>, reason: Option<String>) {
+    pub fn set_paused(
+        env: Env,
+        lock: Option<bool>,
+        release: Option<bool>,
+        refund: Option<bool>,
+        reason: Option<String>,
+    ) {
         if !env.storage().instance().has(&DataKey::Admin) {
             panic!("Not initialized");
         }
@@ -812,7 +820,13 @@ impl ProgramEscrowContract {
             flags.lock_paused = paused;
             env.events().publish(
                 (PAUSE_STATE_CHANGED,),
-                (symbol_short!("lock"), paused, admin.clone(), reason.clone(), timestamp),
+                (
+                    symbol_short!("lock"),
+                    paused,
+                    admin.clone(),
+                    reason.clone(),
+                    timestamp,
+                ),
             );
         }
 
@@ -820,7 +834,13 @@ impl ProgramEscrowContract {
             flags.release_paused = paused;
             env.events().publish(
                 (PAUSE_STATE_CHANGED,),
-                (symbol_short!("release"), paused, admin.clone(), reason.clone(), timestamp),
+                (
+                    symbol_short!("release"),
+                    paused,
+                    admin.clone(),
+                    reason.clone(),
+                    timestamp,
+                ),
             );
         }
 
@@ -828,12 +848,18 @@ impl ProgramEscrowContract {
             flags.refund_paused = paused;
             env.events().publish(
                 (PAUSE_STATE_CHANGED,),
-                (symbol_short!("refund"), paused, admin.clone(), reason.clone(), timestamp),
+                (
+                    symbol_short!("refund"),
+                    paused,
+                    admin.clone(),
+                    reason.clone(),
+                    timestamp,
+                ),
             );
         }
 
         let any_paused = flags.lock_paused || flags.release_paused || flags.refund_paused;
-        
+
         if any_paused {
             if flags.paused_at == 0 {
                 flags.paused_at = timestamp;
@@ -859,12 +885,16 @@ impl ProgramEscrowContract {
             panic!("Not paused");
         }
 
-        let program_data: ProgramData = env.storage().instance().get(&PROGRAM_DATA).unwrap_or_else(|| panic!("Program not initialized"));
+        let program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
         let token_client = token::TokenClient::new(&env, &program_data.token_address);
-        
+
         let contract_address = env.current_contract_address();
         let balance = token_client.balance(&contract_address);
-        
+
         if balance > 0 {
             token_client.transfer(&contract_address, &target, &balance);
             env.events().publish(
@@ -950,7 +980,9 @@ impl ProgramEscrowContract {
             max_operations,
             cooldown_period,
         };
-        env.storage().instance().set(&DataKey::RateLimitConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::RateLimitConfig, &config);
     }
 
     pub fn get_rate_limit_config(env: Env) -> RateLimitConfig {
@@ -976,10 +1008,14 @@ impl ProgramEscrowContract {
 
     pub fn set_whitelist(env: Env, _address: Address, _whitelisted: bool) {
         // Only admin can set whitelist
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap_or_else(|| panic!("Not initialized"));
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Not initialized"));
         admin.require_auth();
     }
- // ========================================================================
+    // ========================================================================
     // Payout Functions
     // ========================================================================
 
@@ -1201,53 +1237,53 @@ impl ProgramEscrowContract {
     }
 
     /// Create a release schedule entry that can be triggered at/after `release_timestamp`.
-   pub fn create_program_release_schedule(
-    env: Env,
-    recipient: Address,
-    amount: i128,
-    release_timestamp: u64,
-) -> ProgramReleaseSchedule {
-    let program_data: ProgramData = env
-        .storage()
-        .instance()
-        .get(&PROGRAM_DATA)
-        .unwrap_or_else(|| panic!("Program not initialized"));
+    pub fn create_program_release_schedule(
+        env: Env,
+        recipient: Address,
+        amount: i128,
+        release_timestamp: u64,
+    ) -> ProgramReleaseSchedule {
+        let program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
 
-    program_data.authorized_payout_key.require_auth();
+        program_data.authorized_payout_key.require_auth();
 
-    if amount <= 0 {
-        panic!("Amount must be greater than zero");
+        if amount <= 0 {
+            panic!("Amount must be greater than zero");
+        }
+
+        let mut schedules: Vec<ProgramReleaseSchedule> = env
+            .storage()
+            .instance()
+            .get(&SCHEDULES)
+            .unwrap_or_else(|| Vec::new(&env));
+        let schedule_id: u64 = env
+            .storage()
+            .instance()
+            .get(&NEXT_SCHEDULE_ID)
+            .unwrap_or(1_u64);
+
+        let schedule = ProgramReleaseSchedule {
+            schedule_id,
+            recipient,
+            amount,
+            release_timestamp,
+            released: false,
+            released_at: None,
+            released_by: None,
+        };
+        schedules.push_back(schedule.clone());
+
+        env.storage().instance().set(&SCHEDULES, &schedules);
+        env.storage()
+            .instance()
+            .set(&NEXT_SCHEDULE_ID, &(schedule_id + 1));
+
+        schedule
     }
-
-    let mut schedules: Vec<ProgramReleaseSchedule> = env
-        .storage()
-        .instance()
-        .get(&SCHEDULES)
-        .unwrap_or_else(|| Vec::new(&env));
-    let schedule_id: u64 = env
-        .storage()
-        .instance()
-        .get(&NEXT_SCHEDULE_ID)
-        .unwrap_or(1_u64);
-
-    let schedule = ProgramReleaseSchedule {
-        schedule_id,
-        recipient,
-        amount,
-        release_timestamp,
-        released: false,
-        released_at: None,
-        released_by: None,
-    };
-    schedules.push_back(schedule.clone());
-
-    env.storage().instance().set(&SCHEDULES, &schedules);
-    env.storage()
-        .instance()
-        .set(&NEXT_SCHEDULE_ID, &(schedule_id + 1));
-
-    schedule
-}
 
     /// Trigger all due schedules where `now >= release_timestamp`.
     pub fn trigger_program_releases(env: Env) -> u32 {
@@ -1352,11 +1388,21 @@ impl ProgramEscrowContract {
         Self::lock_program_funds(env, amount)
     }
 
-    pub fn single_payout_v2(env: Env, _program_id: String, recipient: Address, amount: i128) -> ProgramData {
+    pub fn single_payout_v2(
+        env: Env,
+        _program_id: String,
+        recipient: Address,
+        amount: i128,
+    ) -> ProgramData {
         Self::single_payout(env, recipient, amount)
     }
 
-    pub fn batch_payout_v2(env: Env, _program_id: String, recipients: Vec<Address>, amounts: Vec<i128>) -> ProgramData {
+    pub fn batch_payout_v2(
+        env: Env,
+        _program_id: String,
+        recipients: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> ProgramData {
         Self::batch_payout(env, recipients, amounts)
     }
 
@@ -1564,42 +1610,42 @@ impl ProgramEscrowContract {
     }
 
     /// Get aggregate statistics for the program
-  pub fn get_program_aggregate_stats(env: Env) -> ProgramAggregateStats {
-    let program_data: ProgramData = env
-        .storage()
-        .instance()
-        .get(&PROGRAM_DATA)
-        .unwrap_or_else(|| panic!("Program not initialized"));
-    let schedules: Vec<ProgramReleaseSchedule> = env
-        .storage()
-        .instance()
-        .get(&SCHEDULES)
-        .unwrap_or_else(|| Vec::new(&env));
+    pub fn get_program_aggregate_stats(env: Env) -> ProgramAggregateStats {
+        let program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
+        let schedules: Vec<ProgramReleaseSchedule> = env
+            .storage()
+            .instance()
+            .get(&SCHEDULES)
+            .unwrap_or_else(|| Vec::new(&env));
 
-    let mut scheduled_count = 0u32;
-    let mut released_count = 0u32;
+        let mut scheduled_count = 0u32;
+        let mut released_count = 0u32;
 
-    for i in 0..schedules.len() {
-        let schedule = schedules.get(i).unwrap();
-        if schedule.released {
-            released_count += 1;
-        } else {
-            scheduled_count += 1;
+        for i in 0..schedules.len() {
+            let schedule = schedules.get(i).unwrap();
+            if schedule.released {
+                released_count += 1;
+            } else {
+                scheduled_count += 1;
+            }
+        }
+
+        ProgramAggregateStats {
+            total_funds: program_data.total_funds,
+            remaining_balance: program_data.remaining_balance,
+            total_paid_out: program_data.total_funds - program_data.remaining_balance,
+            authorized_payout_key: program_data.authorized_payout_key.clone(),
+            payout_history: program_data.payout_history.clone(),
+            token_address: program_data.token_address.clone(),
+            payout_count: program_data.payout_history.len(),
+            scheduled_count,
+            released_count,
         }
     }
-
-    ProgramAggregateStats {
-        total_funds: program_data.total_funds,
-        remaining_balance: program_data.remaining_balance,
-        total_paid_out: program_data.total_funds - program_data.remaining_balance,
-        authorized_payout_key: program_data.authorized_payout_key.clone(),
-        payout_history: program_data.payout_history.clone(),
-        token_address: program_data.token_address.clone(),
-        payout_count: program_data.payout_history.len(),
-        scheduled_count,
-        released_count,
-    }
-}
 
     /// Get payouts by recipient
     pub fn get_payouts_by_recipient(
@@ -1706,10 +1752,7 @@ impl ProgramEscrowContract {
         results
     }
 
-    pub fn get_program_release_schedule(
-        env: Env,
-        schedule_id: u64,
-    ) -> ProgramReleaseSchedule {
+    pub fn get_program_release_schedule(env: Env, schedule_id: u64) -> ProgramReleaseSchedule {
         let schedules = Self::get_release_schedules(env);
         for s in schedules.iter() {
             if s.schedule_id == schedule_id {
@@ -1734,7 +1777,7 @@ impl ProgramEscrowContract {
     pub fn release_program_schedule_manual(env: Env, schedule_id: u64) {
         let mut schedules = Self::get_release_schedules(env.clone());
         let program_data = Self::get_program_info(env.clone());
-        
+
         program_data.authorized_payout_key.require_auth();
 
         let caller = program_data.authorized_payout_key.clone();
@@ -1748,11 +1791,11 @@ impl ProgramEscrowContract {
                 if s.released {
                     panic!("Already released");
                 }
-                
+
                 // Transfer funds
                 let token_client = token::Client::new(&env, &program_data.token_address);
                 token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
-                
+
                 s.released = true;
                 s.released_at = Some(now);
                 s.released_by = Some(caller.clone());
@@ -1762,11 +1805,11 @@ impl ProgramEscrowContract {
                 break;
             }
         }
-        
+
         if !found {
             panic!("Schedule not found");
         }
-        
+
         env.storage().instance().set(&SCHEDULES, &schedules);
 
         // Write to release history
@@ -1777,7 +1820,8 @@ impl ProgramEscrowContract {
                 .instance()
                 .set(&PROGRAM_DATA, &updated_program_data);
 
-            let mut history: Vec<ProgramReleaseHistory> = env.storage()
+            let mut history: Vec<ProgramReleaseHistory> = env
+                .storage()
                 .instance()
                 .get(&RELEASE_HISTORY)
                 .unwrap_or_else(|| Vec::new(&env));
@@ -1808,11 +1852,11 @@ impl ProgramEscrowContract {
                 if now < s.release_timestamp {
                     panic!("Not yet due");
                 }
-                
+
                 // Transfer funds
                 let token_client = token::Client::new(&env, &program_data.token_address);
                 token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
-                
+
                 s.released = true;
                 s.released_at = Some(now);
                 s.released_by = Some(env.current_contract_address());
@@ -1822,11 +1866,11 @@ impl ProgramEscrowContract {
                 break;
             }
         }
-        
+
         if !found {
             panic!("Schedule not found");
         }
-        
+
         env.storage().instance().set(&SCHEDULES, &schedules);
 
         // Write to release history
@@ -1837,7 +1881,8 @@ impl ProgramEscrowContract {
                 .instance()
                 .set(&PROGRAM_DATA, &updated_program_data);
 
-            let mut history: Vec<ProgramReleaseHistory> = env.storage()
+            let mut history: Vec<ProgramReleaseHistory> = env
+                .storage()
                 .instance()
                 .get(&RELEASE_HISTORY)
                 .unwrap_or_else(|| Vec::new(&env));

--- a/contracts/program-escrow/src/test_token_math.rs
+++ b/contracts/program-escrow/src/test_token_math.rs
@@ -1,0 +1,247 @@
+#![cfg(test)]
+
+//! Tests for the `token_math` module: fee calculation with floor rounding,
+//! amount splitting invariant, decimal scaling, and base-unit conversion.
+
+use crate::token_math;
+
+// ===========================================================================
+// 1. calculate_fee — basic behaviour
+// ===========================================================================
+
+#[test]
+fn fee_zero_rate_returns_zero() {
+    assert_eq!(token_math::calculate_fee(1_000_000, 0), 0);
+}
+
+#[test]
+fn fee_zero_amount_returns_zero() {
+    assert_eq!(token_math::calculate_fee(0, 500), 0);
+}
+
+#[test]
+fn fee_exact_division() {
+    // 10_000 * 500 / 10_000 = 500
+    assert_eq!(token_math::calculate_fee(10_000, 500), 500);
+}
+
+#[test]
+fn fee_floor_rounds_down() {
+    // 999 * 100 / 10_000 = 9.99 → floor = 9
+    assert_eq!(token_math::calculate_fee(999, 100), 9);
+}
+
+#[test]
+fn fee_one_basis_point() {
+    // 10_000 * 1 / 10_000 = 1
+    assert_eq!(token_math::calculate_fee(10_000, 1), 1);
+}
+
+#[test]
+fn fee_max_rate() {
+    // 1_000 * 5_000 / 10_000 = 500 (50%)
+    assert_eq!(
+        token_math::calculate_fee(1_000, token_math::MAX_FEE_RATE),
+        500
+    );
+}
+
+#[test]
+fn fee_single_unit_amount() {
+    // 1 * 100 / 10_000 = 0.01 → floor = 0
+    assert_eq!(token_math::calculate_fee(1, 100), 0);
+}
+
+// ===========================================================================
+// 2. calculate_fee — multiple decimal scenarios
+// ===========================================================================
+
+#[test]
+fn fee_xlm_7_decimals() {
+    // 100 XLM = 100_0000000 stroops, 2% fee (200 bp)
+    let amount = 100_0000000_i128;
+    let fee = token_math::calculate_fee(amount, 200);
+    assert_eq!(fee, 2_0000000); // 2 XLM
+}
+
+#[test]
+fn fee_usdc_6_decimals() {
+    // 100 USDC = 100_000_000 (6 decimals), 2% fee (200 bp)
+    let amount = 100_000_000_i128;
+    let fee = token_math::calculate_fee(amount, 200);
+    assert_eq!(fee, 2_000_000); // 2 USDC
+}
+
+#[test]
+fn fee_low_decimal_token_2_decimals() {
+    // 100 tokens = 10_000 (2 decimals), 3% fee (300 bp)
+    let amount = 10_000_i128;
+    let fee = token_math::calculate_fee(amount, 300);
+    assert_eq!(fee, 300); // 3 tokens
+}
+
+#[test]
+fn fee_small_amount_high_decimals_floors_correctly() {
+    // 1 stroop (smallest XLM unit), 1% fee
+    let fee = token_math::calculate_fee(1, 100);
+    assert_eq!(fee, 0); // too small, floors to 0
+}
+
+// ===========================================================================
+// 3. split_amount — invariant: fee + net == amount
+// ===========================================================================
+
+#[test]
+fn split_invariant_exact() {
+    let amount = 10_000_i128;
+    let (fee, net) = token_math::split_amount(amount, 500);
+    assert_eq!(fee + net, amount);
+    assert_eq!(fee, 500);
+    assert_eq!(net, 9_500);
+}
+
+#[test]
+fn split_invariant_with_remainder() {
+    // 999 * 100 / 10_000 = 9 (floor). net = 990.
+    let amount = 999_i128;
+    let (fee, net) = token_math::split_amount(amount, 100);
+    assert_eq!(fee + net, amount);
+    assert_eq!(fee, 9);
+    assert_eq!(net, 990);
+}
+
+#[test]
+fn split_invariant_zero_fee() {
+    let amount = 5_000_i128;
+    let (fee, net) = token_math::split_amount(amount, 0);
+    assert_eq!(fee, 0);
+    assert_eq!(net, amount);
+    assert_eq!(fee + net, amount);
+}
+
+#[test]
+fn split_invariant_max_rate() {
+    let amount = 1_001_i128;
+    let (fee, net) = token_math::split_amount(amount, token_math::MAX_FEE_RATE);
+    assert_eq!(fee + net, amount);
+    // 1001 * 5000 / 10000 = 500 (floor)
+    assert_eq!(fee, 500);
+    assert_eq!(net, 501);
+}
+
+#[test]
+fn split_invariant_prime_amount() {
+    let amount = 997_i128;
+    let (fee, net) = token_math::split_amount(amount, 333);
+    assert_eq!(fee + net, amount);
+}
+
+#[test]
+fn split_invariant_large_amount() {
+    let amount = 1_000_000_000_0000000_i128; // 1 billion XLM in stroops
+    let (fee, net) = token_math::split_amount(amount, 250);
+    assert_eq!(fee + net, amount);
+}
+
+// ===========================================================================
+// 4. scale_amount — decimal conversion
+// ===========================================================================
+
+#[test]
+fn scale_same_decimals_is_identity() {
+    assert_eq!(token_math::scale_amount(12345, 7, 7), Some(12345));
+}
+
+#[test]
+fn scale_up_6_to_7() {
+    // 1_000_000 (6 dec) → 10_000_000 (7 dec)
+    assert_eq!(token_math::scale_amount(1_000_000, 6, 7), Some(10_000_000));
+}
+
+#[test]
+fn scale_down_7_to_6() {
+    // 10_000_005 (7 dec) → 1_000_000 (6 dec), floor
+    assert_eq!(token_math::scale_amount(10_000_005, 7, 6), Some(1_000_000));
+}
+
+#[test]
+fn scale_down_floors() {
+    // 19 (7 dec) → 1 (6 dec), floor of 1.9
+    assert_eq!(token_math::scale_amount(19, 7, 6), Some(1));
+}
+
+#[test]
+fn scale_down_sub_unit_floors_to_zero() {
+    // 9 (7 dec) → 0 (6 dec), 0.9 floors to 0
+    assert_eq!(token_math::scale_amount(9, 7, 6), Some(0));
+}
+
+#[test]
+fn scale_large_gap() {
+    // 1 (0 dec) → 10_000_000 (7 dec)
+    assert_eq!(token_math::scale_amount(1, 0, 7), Some(10_000_000));
+}
+
+#[test]
+fn scale_zero_amount() {
+    assert_eq!(token_math::scale_amount(0, 6, 7), Some(0));
+}
+
+// ===========================================================================
+// 5. to_base_units
+// ===========================================================================
+
+#[test]
+fn to_base_units_xlm() {
+    // 100 XLM → 100_0000000 stroops (7 decimals)
+    assert_eq!(token_math::to_base_units(100, 7), Some(1_000_000_000));
+}
+
+#[test]
+fn to_base_units_usdc() {
+    // 50 USDC → 50_000_000 (6 decimals)
+    assert_eq!(token_math::to_base_units(50, 6), Some(50_000_000));
+}
+
+#[test]
+fn to_base_units_zero_decimals() {
+    assert_eq!(token_math::to_base_units(42, 0), Some(42));
+}
+
+#[test]
+fn to_base_units_zero_amount() {
+    assert_eq!(token_math::to_base_units(0, 7), Some(0));
+}
+
+// ===========================================================================
+// 6. Boundary / edge cases
+// ===========================================================================
+
+#[test]
+fn fee_never_exceeds_amount() {
+    // Even at max rate, fee ≤ amount
+    for amount in [1_i128, 2, 3, 7, 99, 100, 999, 10_000, 1_000_000] {
+        let fee = token_math::calculate_fee(amount, token_math::MAX_FEE_RATE);
+        assert!(fee <= amount, "fee {} > amount {}", fee, amount);
+    }
+}
+
+#[test]
+fn split_net_never_negative() {
+    for amount in [1_i128, 2, 3, 7, 99, 100, 999, 10_000] {
+        let (fee, net) = token_math::split_amount(amount, token_math::MAX_FEE_RATE);
+        assert!(net >= 0, "net {} negative for amount {}", net, amount);
+        assert!(fee >= 0, "fee {} negative for amount {}", fee, amount);
+    }
+}
+
+#[test]
+fn fee_monotonic_with_amount() {
+    let rate = 250_i128;
+    let mut prev = 0_i128;
+    for amount in (0..=10_000_i128).step_by(100) {
+        let fee = token_math::calculate_fee(amount, rate);
+        assert!(fee >= prev, "fee decreased at amount {}", amount);
+        prev = fee;
+    }
+}

--- a/contracts/program-escrow/src/token_math.rs
+++ b/contracts/program-escrow/src/token_math.rs
@@ -1,0 +1,68 @@
+//! Token decimal scaling and fee rounding helpers.
+//!
+//! ## Rounding Policy
+//!
+//! All fee calculations use **floor (round-down)** rounding. This means the
+//! protocol never overcharges — any remainder from basis-point division stays
+//! with the payer rather than being collected as fee. The invariant
+//! `fee + net == gross` holds for every split.
+//!
+//! ## Token Decimals
+//!
+//! Stellar tokens can have different decimal places (e.g. 7 for XLM/stroops,
+//! 6 for USDC). The helpers here convert between decimal scales using floor
+//! rounding when scaling down (higher → lower precision).
+
+/// Basis-point denominator (1 bp = 0.01%).
+pub const BASIS_POINTS: i128 = 10_000;
+
+/// Maximum allowed fee rate in basis points (50%).
+pub const MAX_FEE_RATE: i128 = 5_000;
+
+/// Calculate fee using floor rounding.
+///
+/// `fee = floor(amount * fee_rate / BASIS_POINTS)`
+///
+/// Returns 0 when `fee_rate` is 0 or on overflow.
+pub fn calculate_fee(amount: i128, fee_rate: i128) -> i128 {
+    if fee_rate == 0 {
+        return 0;
+    }
+    amount
+        .checked_mul(fee_rate)
+        .and_then(|x| x.checked_div(BASIS_POINTS))
+        .unwrap_or(0)
+}
+
+/// Split `amount` into `(fee, net)` where `fee + net == amount`.
+///
+/// Fee is floored; any remainder from division stays in `net`.
+pub fn split_amount(amount: i128, fee_rate: i128) -> (i128, i128) {
+    let fee = calculate_fee(amount, fee_rate);
+    (fee, amount - fee)
+}
+
+/// Scale `amount` from `from_decimals` to `to_decimals`.
+///
+/// Uses floor rounding when scaling down. Returns `None` on overflow.
+pub fn scale_amount(amount: i128, from_decimals: u32, to_decimals: u32) -> Option<i128> {
+    if from_decimals == to_decimals {
+        return Some(amount);
+    }
+    if to_decimals > from_decimals {
+        let factor = 10_i128.checked_pow(to_decimals - from_decimals)?;
+        amount.checked_mul(factor)
+    } else {
+        let factor = 10_i128.checked_pow(from_decimals - to_decimals)?;
+        Some(amount / factor)
+    }
+}
+
+/// Convert a human-readable amount to the token's smallest unit.
+///
+/// E.g. `to_base_units(100, 7)` → `1_000_000_000` (100 XLM in stroops).
+/// Returns `None` on overflow.
+pub fn to_base_units(amount: i128, decimals: u32) -> Option<i128> {
+    let factor = 10_i128.checked_pow(decimals)?;
+    amount.checked_mul(factor)
+}


### PR DESCRIPTION
Closes #587

## Summary
 different tokens may use different decimal scales,
and the contracts lacked a documented rounding policy for fee
calculations.

## Root Cause

Both `bounty_escrow` and `program-escrow` defined identical inline
`calculate_fee` functions using truncating integer division with no
documented policy and no shared code. There were no helpers for
splitting amounts (maintaining fee + net == gross), scaling between
token decimal places, or converting human-readable amounts to base
units.

## Changes

- Added `token_math` module to both escrow contracts with:
  - Documented floor (round-down) rounding policy
  - `calculate_fee(amount, fee_rate)` — basis-point fee with floor rounding
  - `split_amount(amount, fee_rate)` — returns `(fee, net)` with invariant `fee + net == amount`
  - `scale_amount(amount, from_decimals, to_decimals)` — decimal conversion with floor on scale-down
  - `to_base_units(amount, decimals)` — human-readable to smallest unit conversion
- Replaced inline `BASIS_POINTS` constant and `calculate_fee` with delegations to the module
- Both contracts now use the same rounding policy and helpers

## Testing

- 31 new unit tests per contract covering:
  - Zero/exact/floored fee calculations
  - XLM (7 dec), USDC (6 dec), low-decimal (2 dec) token scenarios
  - split_amount invariant (fee + net == amount) across many inputs
  - Decimal scaling up/down with floor rounding
  - Boundary cases (single-unit amounts, max fee rate, monotonicity)
- All 428 existing bounty_escrow tests continue to pass
- `cargo fmt --check` passes for both contracts
- `cargo check` passes for program-escrow with no new warnings

Closes #587