### PR TITLE
feat(bounty-escrow): multi-token fee tests

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -2211,13 +2211,20 @@ impl BountyEscrowContract {
         };
 
         // Net payout to contributor after release fee.
-        let net_payout = escrow.amount.checked_sub(release_fee).unwrap_or(escrow.amount);
+        let net_payout = escrow
+            .amount
+            .checked_sub(release_fee)
+            .unwrap_or(escrow.amount);
         if net_payout <= 0 {
             return Err(Error::InvalidAmount);
         }
 
         if release_fee > 0 {
-            client.transfer(&env.current_contract_address(), &fee_recipient, &release_fee);
+            client.transfer(
+                &env.current_contract_address(),
+                &fee_recipient,
+                &release_fee,
+            );
             events::emit_fee_collected(
                 &env,
                 events::FeeCollected {
@@ -2231,11 +2238,7 @@ impl BountyEscrowContract {
         }
 
         // Transfer net amount to contributor
-        client.transfer(
-            &env.current_contract_address(),
-            &contributor,
-            &net_payout,
-        );
+        client.transfer(&env.current_contract_address(), &contributor, &net_payout);
 
         escrow.status = EscrowStatus::Released;
         escrow.remaining_amount = 0;

--- a/contracts/bounty_escrow/contracts/escrow/src/test_multi_token_fees.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_multi_token_fees.rs
@@ -98,7 +98,10 @@ fn test_calculate_fee_ceiling_exact_division() {
 
 #[test]
 fn test_calculate_fee_zero_rate() {
-    assert_eq!(crate::BountyEscrowContract::calculate_fee_pub(1_000_000, 0), 0);
+    assert_eq!(
+        crate::BountyEscrowContract::calculate_fee_pub(1_000_000, 0),
+        0
+    );
 }
 
 #[test]
@@ -131,13 +134,9 @@ fn test_set_token_fee_config_invalid_lock_rate_rejected() {
 #[test]
 fn test_set_token_fee_config_invalid_release_rate_rejected() {
     let s = Suite::new();
-    let result = s.client.try_set_token_fee_config(
-        &s.token_id,
-        &0,
-        &10_001,
-        &s.fee_recipient,
-        &true,
-    );
+    let result =
+        s.client
+            .try_set_token_fee_config(&s.token_id, &0, &10_001, &s.fee_recipient, &true);
     assert_eq!(result.unwrap_err().unwrap(), Error::InvalidFeeRate);
 }
 
@@ -176,8 +175,7 @@ fn test_lock_fee_collected_correctly() {
 
     let gross = 1_000_000i128;
     s.fund_depositor(gross);
-    s.client
-        .lock_funds(&s.depositor, &1, &gross, &s.deadline());
+    s.client.lock_funds(&s.depositor, &1, &gross, &s.deadline());
 
     // fee = ceil(1_000_000 * 200 / 10_000) = ceil(20_000) = 20_000
     let expected_fee = 20_000i128;
@@ -205,7 +203,8 @@ fn test_lock_no_fee_when_rate_zero() {
 
     let amount = 500_000i128;
     s.fund_depositor(amount);
-    s.client.lock_funds(&s.depositor, &1, &amount, &s.deadline());
+    s.client
+        .lock_funds(&s.depositor, &1, &amount, &s.deadline());
 
     assert_eq!(s.balance(&s.fee_recipient), 0);
     assert_eq!(s.client.get_escrow_info(&1).amount, amount);
@@ -220,7 +219,8 @@ fn test_lock_no_fee_when_disabled() {
 
     let amount = 100_000i128;
     s.fund_depositor(amount);
-    s.client.lock_funds(&s.depositor, &1, &amount, &s.deadline());
+    s.client
+        .lock_funds(&s.depositor, &1, &amount, &s.deadline());
 
     assert_eq!(s.balance(&s.fee_recipient), 0);
     assert_eq!(s.client.get_escrow_info(&1).amount, amount);
@@ -289,7 +289,8 @@ fn test_per_token_config_overrides_global() {
 
     let amount = 100_000i128;
     s.fund_depositor(amount);
-    s.client.lock_funds(&s.depositor, &1, &amount, &s.deadline());
+    s.client
+        .lock_funds(&s.depositor, &1, &amount, &s.deadline());
 
     // Per-token 3% = 3_000 fee; global 1% would have been 1_000
     assert_eq!(
@@ -314,7 +315,8 @@ fn test_global_fee_used_when_no_token_config() {
 
     let amount = 100_000i128;
     s.fund_depositor(amount);
-    s.client.lock_funds(&s.depositor, &1, &amount, &s.deadline());
+    s.client
+        .lock_funds(&s.depositor, &1, &amount, &s.deadline());
 
     assert_eq!(s.balance(&s.fee_recipient), 1_000);
 }


### PR DESCRIPTION


---

## PR Description

**Title:** `feat(bounty-escrow): multi-token fee support with rounding-safe calculation`

**Closes:** #766
  closes #766
---

### Summary

This PR implements per-token fee configuration for the bounty escrow contract and fixes a critical rounding vulnerability in fee calculation that allowed a fee recipient to be bypassed entirely via dust-amount splitting.

---

### Problem

The contract had `FeeConfig` and `calculate_fee` but fees were **never actually collected** during `lock_funds` or `release_funds`. Beyond the missing wiring, the original `calculate_fee` used floor division — meaning a depositor could split a large deposit into many small amounts where each individually rounded down to a zero fee, paying nothing while still locking the full principal.

Additionally, there was no mechanism to configure different fee rates for different token types.

---

### Changes

**`lib.rs`**
- Added `TokenFeeConfig` struct: per-token `lock_fee_rate`, `release_fee_rate`, `fee_recipient`, `fee_enabled`
- Added `DataKey::TokenFeeConfig(Address)` storage key
- Fixed `calculate_fee`: floor division → **ceiling division** — ensures `fee >= 1 stroop` whenever `rate > 0 && amount > 0`
- Added `set_token_fee_config` (admin only) and `get_token_fee_config` (view)
- Added `resolve_fee_config` internal helper: per-token config overrides global `FeeConfig`
- Wired fee collection into `lock_funds_logic` and `release_funds`:
  - Computes `fee_amount` via `calculate_fee`
  - Transfers fee to `fee_recipient` immediately
  - Stores only `net_amount` (`gross - fee`) in the escrow record
  - Emits `FeeCollected` event (already existed in `events.rs`)
  - Rejects with `InvalidAmount` if `net_amount <= 0` to prevent total principal drain

**`test_multi_token_fees.rs`** (new file)
- 18 tests covering all specified scenarios — see test file for full list

---

### Security Notes

| Threat | Mitigation |
|---|---|
| Dust-split fee evasion | Ceiling division guarantees `fee >= 1 stroop` for any `rate > 0` |
| Fee drains entire principal | `net_amount <= 0` check returns `InvalidAmount` before any transfer |
| Unauthorized fee config change | `admin.require_auth()` on `set_token_fee_config` |
| Fee rate overflow | `MAX_FEE_RATE = 5_000` (50%) enforced; arithmetic uses `checked_mul` |

---

### Testing
```
cargo test -p bounty-escrow -- test_multi_token_fees

Closes #766 