### PR TITLE
feat(program-escrow): spend limits thresholds

### DIFF
--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -28,6 +28,15 @@
           "Improved fee configuration",
           "Added granular pause controls"
         ]
+      },
+      {
+        "version": "2.1.0",
+        "release_date": "2026-04-22",
+        "changes": [
+          "Added deterministic spend-threshold enforcement for single and batch payouts",
+          "Added explicit spend-threshold configuration and retrieval entrypoints",
+          "Reused per-program persistent config storage for upgrade-safe threshold state"
+        ]
       }
     ]
   },
@@ -188,6 +197,29 @@
         "authorization": "admin",
         "pausable": true,
         "gas_estimate": "medium"
+      },
+      {
+        "name": "set_program_spend_threshold",
+        "description": "Set per-program maximum spend for a single payout operation (single amount or batch total)",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          },
+          {
+            "name": "threshold_amount",
+            "type": "i128",
+            "description": "Maximum allowed gross spend per payout operation"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       },
       {
         "name": "set_program_dependencies",
@@ -383,6 +415,24 @@
         "returns": {
           "type": "PauseFlags",
           "description": "Pause configuration"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_program_spend_threshold",
+        "description": "Get the configured per-program spend threshold",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          }
+        ],
+        "returns": {
+          "type": "i128",
+          "description": "Maximum allowed gross spend per payout operation"
         },
         "authorization": "any",
         "pausable": false,
@@ -732,7 +782,8 @@
       "Reentrancy protection",
       "Comprehensive monitoring and analytics",
       "Input validation for all parameters",
-      "Overflow protection in arithmetic operations"
+      "Overflow protection in arithmetic operations",
+      "Deterministic spend-threshold checks for payout operations"
     ],
     "access_control": [
       {

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -686,6 +686,10 @@ pub struct ProgramInitItem {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultisigConfig {
+    /// Maximum gross spend allowed in one payout operation.
+    /// - `single_payout`: compared against the requested `amount`
+    /// - `batch_payout`: compared against the computed batch `total_payout`
+    /// `i128::MAX` disables spend-threshold enforcement.
     pub threshold_amount: i128,
     pub signers: soroban_sdk::Vec<Address>,
     pub required_signatures: u32,
@@ -2195,6 +2199,62 @@ impl ProgramEscrowContract {
             })
     }
 
+    /// Set the per-program spend threshold.
+    ///
+    /// Security and deterministic behavior:
+    /// - Admin only.
+    /// - `threshold_amount` must be strictly positive.
+    /// - Payout validation checks this threshold before balance checks.
+    pub fn set_program_spend_threshold(env: Env, program_id: String, threshold_amount: i128) {
+        let _ = Self::require_admin(&env);
+        if threshold_amount <= 0 {
+            panic!("Invalid spend threshold");
+        }
+
+        let mut cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id.clone()))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![&env],
+                required_signatures: 0,
+            });
+        cfg.threshold_amount = threshold_amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::MultisigConfig(program_id), &cfg);
+    }
+
+    /// Read per-program spend threshold. Returns `i128::MAX` when unset.
+    pub fn get_program_spend_threshold(env: Env, program_id: String) -> i128 {
+        let cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![&env],
+                required_signatures: 0,
+            });
+        cfg.threshold_amount
+    }
+
+    fn enforce_spend_threshold(env: &Env, program_id: &String, requested_amount: i128) {
+        let cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id.clone()))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![env],
+                required_signatures: 0,
+            });
+        if requested_amount > cfg.threshold_amount {
+            panic!("Spend threshold exceeded");
+        }
+    }
+
     pub fn get_analytics(_env: Env) -> Analytics {
         Analytics {
             total_locked: 0,
@@ -2316,6 +2376,10 @@ impl ProgramEscrowContract {
         }
 
         // 6. Business logic: sufficient balance
+        // Deterministic error ordering: spend threshold check runs before
+        // balance/circuit checks, so clients observe stable failures.
+        Self::enforce_spend_threshold(&env, &program_data.program_id, total_payout);
+
         if total_payout > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
             panic!("Insufficient balance");
@@ -2482,6 +2546,10 @@ impl ProgramEscrowContract {
         }
 
         // 6. Business logic: sufficient balance
+        // Deterministic error ordering: spend threshold check runs before
+        // balance/circuit checks, so clients observe stable failures.
+        Self::enforce_spend_threshold(&env, &program_data.program_id, amount);
+
         if amount > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
             panic!("Insufficient balance");

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -1939,6 +1939,57 @@ fn test_batch_payout_atomicity_all_or_nothing() {
 }
 
 #[test]
+fn test_spend_threshold_single_payout_at_boundary_allowed() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipient = Address::generate(&env);
+    let data = client.single_payout(&recipient, &10_000);
+
+    assert_eq!(data.remaining_balance, 40_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_threshold_single_payout_above_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipient = Address::generate(&env);
+    client.single_payout(&recipient, &10_001);
+}
+
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_threshold_batch_total_above_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipients = vec![&env, Address::generate(&env), Address::generate(&env)];
+    let amounts = vec![&env, 6_000, 5_000];
+    client.batch_payout(&recipients, &amounts);
+}
+
+#[test]
+#[should_panic(expected = "Invalid spend threshold")]
+fn test_spend_threshold_must_be_positive() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 1_000);
+    let program_id = String::from_str(&env, "hack-2026");
+    client.set_program_spend_threshold(&program_id, &0);
+}
+
+#[test]
 fn test_batch_payout_sequential_batches() {
     // Test multiple sequential batch payouts to same program
     // Validates that history accumulates correctly


### PR DESCRIPTION
## Summary
This PR hardens program escrow payout controls by enforcing deterministic per-program spend thresholds for both single and batch payouts. It adds explicit threshold configuration/read APIs, reuses upgrade-safe persistent storage, and extends tests for threshold edge cases and explicit failures.

## What Changed
- Added admin threshold configuration:
  - `set_program_spend_threshold(program_id, threshold_amount)`
  - `get_program_spend_threshold(program_id)`
- Enforced threshold checks in payout paths:
  - `single_payout` checks requested amount against threshold
  - `batch_payout` checks batch total against threshold
- Enforced deterministic validation order:
  - threshold checks execute before balance/circuit checks
- Reused existing upgrade-safe storage:
  - `DataKey::MultisigConfig(program_id)` (default threshold remains `i128::MAX`)
- Updated `contracts/program-escrow-manifest.json`:
  - added 2.1.0 changelog entry
  - documented new entrypoints and deterministic threshold security behavior

## Security Notes
- Prevents overspend per payout operation via hard caps.
- Deterministic error ordering improves auditability and client handling.
- Backward-compatible default behavior for existing programs with no threshold configured.
- No sensitive details exposed in threshold error messages.

## Test Plan
- Added tests in `contracts/program-escrow/src/test.rs` for:
  - threshold boundary success (equal amount)
  - single payout above threshold rejection
  - batch total above threshold rejection
  - invalid (non-positive) threshold rejection

## Operational Notes
- Branch: `feature/program-escrow-05`
- Commit: `feat(program-escrow): spend limits thresholds`
- Follow-up option: switch panic-string threshold errors to typed `ContractError` variants for stricter client-side error parsing.

closes #1047