### PR TITLE
Feature/program escrow 10

### DIFF
--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -37,6 +37,15 @@
           "Added explicit spend-threshold configuration and retrieval entrypoints",
           "Reused per-program persistent config storage for upgrade-safe threshold state"
         ]
+      },
+      {
+        "version": "2.2.0",
+        "release_date": "2026-04-22",
+        "changes": [
+          "Hardened history pagination with deterministic limit validation and explicit range errors",
+          "Centralized pagination behavior across payout, schedule, and release history queries",
+          "Added upgrade-safe pagination config storage with backward-compatible defaults"
+        ]
       }
     ]
   },
@@ -765,6 +774,12 @@
         "data_structure": "PauseFlags"
       },
       {
+        "name": "DataKey::HistoryPaginationConfig",
+        "type": "instance",
+        "description": "History pagination configuration",
+        "data_structure": "HistoryPaginationConfig"
+      },
+      {
         "name": "SCHEDULES",
         "type": "instance",
         "description": "Release schedules",
@@ -783,7 +798,8 @@
       "Comprehensive monitoring and analytics",
       "Input validation for all parameters",
       "Overflow protection in arithmetic operations",
-      "Deterministic spend-threshold checks for payout operations"
+      "Deterministic spend-threshold checks for payout operations",
+      "Deterministic history pagination checks with explicit validation failures"
     ],
     "access_control": [
       {

--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -28,6 +28,15 @@
           "Improved fee configuration",
           "Added granular pause controls"
         ]
+      },
+      {
+        "version": "2.1.0",
+        "release_date": "2026-04-22",
+        "changes": [
+          "Added deterministic spend-threshold enforcement for single and batch payouts",
+          "Added explicit spend-threshold configuration and retrieval entrypoints",
+          "Reused per-program persistent config storage for upgrade-safe threshold state"
+        ]
       }
     ]
   },
@@ -188,6 +197,29 @@
         "authorization": "admin",
         "pausable": true,
         "gas_estimate": "medium"
+      },
+      {
+        "name": "set_program_spend_threshold",
+        "description": "Set per-program maximum spend for a single payout operation (single amount or batch total)",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          },
+          {
+            "name": "threshold_amount",
+            "type": "i128",
+            "description": "Maximum allowed gross spend per payout operation"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       },
       {
         "name": "set_program_dependencies",
@@ -383,6 +415,24 @@
         "returns": {
           "type": "PauseFlags",
           "description": "Pause configuration"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_program_spend_threshold",
+        "description": "Get the configured per-program spend threshold",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          }
+        ],
+        "returns": {
+          "type": "i128",
+          "description": "Maximum allowed gross spend per payout operation"
         },
         "authorization": "any",
         "pausable": false,
@@ -732,7 +782,8 @@
       "Reentrancy protection",
       "Comprehensive monitoring and analytics",
       "Input validation for all parameters",
-      "Overflow protection in arithmetic operations"
+      "Overflow protection in arithmetic operations",
+      "Deterministic spend-threshold checks for payout operations"
     ],
     "access_control": [
       {

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -544,6 +544,7 @@ pub enum DataKey {
     ProgramDependencies(String),     // program_id -> Vec<String>
     DependencyStatus(String),        // program_id -> DependencyStatus
     Dispute,                         // DisputeRecord (single active dispute per contract)
+    HistoryPaginationConfig,         // HistoryPaginationConfig
 }
 
 #[contracttype]
@@ -591,6 +592,12 @@ pub struct RateLimitConfig {
     pub window_size: u64,
     pub max_operations: u32,
     pub cooldown_period: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HistoryPaginationConfig {
+    pub max_limit: u32,
 }
 
 #[contracttype]
@@ -756,6 +763,13 @@ pub enum BatchError {
 }
 
 pub const MAX_BATCH_SIZE: u32 = 100;
+pub const DEFAULT_MAX_HISTORY_PAGE_LIMIT: u32 = 200;
+
+fn default_history_pagination_config() -> HistoryPaginationConfig {
+    HistoryPaginationConfig {
+        max_limit: DEFAULT_MAX_HISTORY_PAGE_LIMIT,
+    }
+}
 
 fn vec_contains(values: &Vec<String>, target: &String) -> bool {
     for value in values.iter() {
@@ -879,6 +893,64 @@ pub struct ProgramEscrowContract;
 
 #[contractimpl]
 impl ProgramEscrowContract {
+    fn get_history_pagination_config(env: &Env) -> HistoryPaginationConfig {
+        env.storage()
+            .instance()
+            .get(&DataKey::HistoryPaginationConfig)
+            .unwrap_or_else(default_history_pagination_config)
+    }
+
+    fn ensure_history_pagination_config(env: &Env) {
+        if !env.storage().instance().has(&DataKey::HistoryPaginationConfig) {
+            env.storage().instance().set(
+                &DataKey::HistoryPaginationConfig,
+                &default_history_pagination_config(),
+            );
+        }
+    }
+
+    fn validate_pagination(env: &Env, limit: u32) {
+        if limit == 0 {
+            panic!("Pagination limit must be greater than zero");
+        }
+        let cfg = Self::get_history_pagination_config(env);
+        if limit > cfg.max_limit {
+            panic!("Pagination limit exceeds maximum");
+        }
+    }
+
+    fn paginate_filtered<T, F>(
+        env: &Env,
+        entries: soroban_sdk::Vec<T>,
+        offset: u32,
+        limit: u32,
+        mut predicate: F,
+    ) -> soroban_sdk::Vec<T>
+    where
+        T: Clone,
+        F: FnMut(&T) -> bool,
+    {
+        let mut results = Vec::new(env);
+        let mut count = 0u32;
+        let mut skipped = 0u32;
+
+        for i in 0..entries.len() {
+            if count >= limit {
+                break;
+            }
+            let entry = entries.get(i).unwrap();
+            if predicate(&entry) {
+                if skipped < offset {
+                    skipped += 1;
+                    continue;
+                }
+                results.push_back(entry);
+                count += 1;
+            }
+        }
+        results
+    }
+
     fn order_batch_lock_items(env: &Env, items: &Vec<LockItem>) -> soroban_sdk::Vec<LockItem> {
         let mut ordered: soroban_sdk::Vec<LockItem> = Vec::new(env);
         for item in items.iter() {
@@ -1123,6 +1195,7 @@ impl ProgramEscrowContract {
                 },
             );
         }
+        Self::ensure_history_pagination_config(&env);
 
         env.storage()
             .instance()
@@ -1587,6 +1660,7 @@ impl ProgramEscrowContract {
                 paused_at: 0,
             },
         );
+        Self::ensure_history_pagination_config(&env);
     }
 
     /// Set or rotate admin. If no admin is set, sets initial admin. If admin exists, current admin must authorize and the new address becomes admin.
@@ -3112,31 +3186,15 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<PayoutRecord> {
+        Self::validate_pagination(&env, limit);
         let program_data: ProgramData = env
             .storage()
             .instance()
             .get(&PROGRAM_DATA)
             .unwrap_or_else(|| panic!("Program not initialized"));
-        let history = program_data.payout_history;
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..history.len() {
-            if count >= limit {
-                break;
-            }
-            let record = history.get(i).unwrap();
-            if record.recipient == recipient {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(record);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, program_data.payout_history, offset, limit, |record| {
+            record.recipient == recipient
+        })
     }
 
     /// Query payout history by amount range
@@ -3147,31 +3205,18 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<PayoutRecord> {
+        Self::validate_pagination(&env, limit);
+        if min_amount > max_amount {
+            panic!("Invalid amount range");
+        }
         let program_data: ProgramData = env
             .storage()
             .instance()
             .get(&PROGRAM_DATA)
             .unwrap_or_else(|| panic!("Program not initialized"));
-        let history = program_data.payout_history;
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..history.len() {
-            if count >= limit {
-                break;
-            }
-            let record = history.get(i).unwrap();
-            if record.amount >= min_amount && record.amount <= max_amount {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(record);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, program_data.payout_history, offset, limit, |record| {
+            record.amount >= min_amount && record.amount <= max_amount
+        })
     }
 
     /// Query payout history by timestamp range
@@ -3182,31 +3227,18 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<PayoutRecord> {
+        Self::validate_pagination(&env, limit);
+        if min_timestamp > max_timestamp {
+            panic!("Invalid timestamp range");
+        }
         let program_data: ProgramData = env
             .storage()
             .instance()
             .get(&PROGRAM_DATA)
             .unwrap_or_else(|| panic!("Program not initialized"));
-        let history = program_data.payout_history;
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..history.len() {
-            if count >= limit {
-                break;
-            }
-            let record = history.get(i).unwrap();
-            if record.timestamp >= min_timestamp && record.timestamp <= max_timestamp {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(record);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, program_data.payout_history, offset, limit, |record| {
+            record.timestamp >= min_timestamp && record.timestamp <= max_timestamp
+        })
     }
 
     /// Query release schedules by recipient
@@ -3216,30 +3248,15 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<ProgramReleaseSchedule> {
+        Self::validate_pagination(&env, limit);
         let schedules: soroban_sdk::Vec<ProgramReleaseSchedule> = env
             .storage()
             .instance()
             .get(&SCHEDULES)
             .unwrap_or_else(|| Vec::new(&env));
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..schedules.len() {
-            if count >= limit {
-                break;
-            }
-            let schedule = schedules.get(i).unwrap();
-            if schedule.recipient == recipient {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(schedule);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, schedules, offset, limit, |schedule| {
+            schedule.recipient == recipient
+        })
     }
 
     /// Query release schedules by released status
@@ -3249,30 +3266,15 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<ProgramReleaseSchedule> {
+        Self::validate_pagination(&env, limit);
         let schedules: soroban_sdk::Vec<ProgramReleaseSchedule> = env
             .storage()
             .instance()
             .get(&SCHEDULES)
             .unwrap_or_else(|| Vec::new(&env));
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..schedules.len() {
-            if count >= limit {
-                break;
-            }
-            let schedule = schedules.get(i).unwrap();
-            if schedule.released == released {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(schedule);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, schedules, offset, limit, |schedule| {
+            schedule.released == released
+        })
     }
 
     /// Query release history with filtering and pagination
@@ -3282,30 +3284,15 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<ProgramReleaseHistory> {
+        Self::validate_pagination(&env, limit);
         let history: soroban_sdk::Vec<ProgramReleaseHistory> = env
             .storage()
             .instance()
             .get(&RELEASE_HISTORY)
             .unwrap_or_else(|| Vec::new(&env));
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..history.len() {
-            if count >= limit {
-                break;
-            }
-            let record = history.get(i).unwrap();
-            if record.recipient == recipient {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(record);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, history, offset, limit, |record| {
+            record.recipient == recipient
+        })
     }
 
     /// Get aggregate statistics for the program
@@ -3353,31 +3340,15 @@ impl ProgramEscrowContract {
         offset: u32,
         limit: u32,
     ) -> soroban_sdk::Vec<PayoutRecord> {
+        Self::validate_pagination(&env, limit);
         let program_data: ProgramData = env
             .storage()
             .instance()
             .get(&PROGRAM_DATA)
             .unwrap_or_else(|| panic!("Program not initialized"));
-        let history = program_data.payout_history;
-        let mut results = Vec::new(&env);
-        let mut count = 0u32;
-        let mut skipped = 0u32;
-
-        for i in 0..history.len() {
-            if count >= limit {
-                break;
-            }
-            let record = history.get(i).unwrap();
-            if record.recipient == recipient {
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-                results.push_back(record);
-                count += 1;
-            }
-        }
-        results
+        Self::paginate_filtered(&env, program_data.payout_history, offset, limit, |record| {
+            record.recipient == recipient
+        })
     }
 
     /// Get pending schedules (not yet released)

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -686,6 +686,10 @@ pub struct ProgramInitItem {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultisigConfig {
+    /// Maximum gross spend allowed in one payout operation.
+    /// - `single_payout`: compared against the requested `amount`
+    /// - `batch_payout`: compared against the computed batch `total_payout`
+    /// `i128::MAX` disables spend-threshold enforcement.
     pub threshold_amount: i128,
     pub signers: soroban_sdk::Vec<Address>,
     pub required_signatures: u32,
@@ -2195,6 +2199,62 @@ impl ProgramEscrowContract {
             })
     }
 
+    /// Set the per-program spend threshold.
+    ///
+    /// Security and deterministic behavior:
+    /// - Admin only.
+    /// - `threshold_amount` must be strictly positive.
+    /// - Payout validation checks this threshold before balance checks.
+    pub fn set_program_spend_threshold(env: Env, program_id: String, threshold_amount: i128) {
+        let _ = Self::require_admin(&env);
+        if threshold_amount <= 0 {
+            panic!("Invalid spend threshold");
+        }
+
+        let mut cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id.clone()))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![&env],
+                required_signatures: 0,
+            });
+        cfg.threshold_amount = threshold_amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::MultisigConfig(program_id), &cfg);
+    }
+
+    /// Read per-program spend threshold. Returns `i128::MAX` when unset.
+    pub fn get_program_spend_threshold(env: Env, program_id: String) -> i128 {
+        let cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![&env],
+                required_signatures: 0,
+            });
+        cfg.threshold_amount
+    }
+
+    fn enforce_spend_threshold(env: &Env, program_id: &String, requested_amount: i128) {
+        let cfg: MultisigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigConfig(program_id.clone()))
+            .unwrap_or(MultisigConfig {
+                threshold_amount: i128::MAX,
+                signers: vec![env],
+                required_signatures: 0,
+            });
+        if requested_amount > cfg.threshold_amount {
+            panic!("Spend threshold exceeded");
+        }
+    }
+
     pub fn get_analytics(_env: Env) -> Analytics {
         Analytics {
             total_locked: 0,
@@ -2316,6 +2376,10 @@ impl ProgramEscrowContract {
         }
 
         // 6. Business logic: sufficient balance
+        // Deterministic error ordering: spend threshold check runs before
+        // balance/circuit checks, so clients observe stable failures.
+        Self::enforce_spend_threshold(&env, &program_data.program_id, total_payout);
+
         if total_payout > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
             panic!("Insufficient balance");
@@ -2482,6 +2546,10 @@ impl ProgramEscrowContract {
         }
 
         // 6. Business logic: sufficient balance
+        // Deterministic error ordering: spend threshold check runs before
+        // balance/circuit checks, so clients observe stable failures.
+        Self::enforce_spend_threshold(&env, &program_data.program_id, amount);
+
         if amount > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
             panic!("Insufficient balance");

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -2185,6 +2185,43 @@ fn test_query_payouts_pagination_offset_and_limit() {
 }
 
 #[test]
+#[should_panic(expected = "Pagination limit must be greater than zero")]
+fn test_query_payouts_pagination_limit_zero_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token, _token_admin) = setup_program(&env, 100_000);
+    let r1 = Address::generate(&env);
+    client.single_payout(&r1, &10_000);
+    let _ = client.query_payouts_by_recipient(&r1, &0, &0);
+}
+
+#[test]
+#[should_panic(expected = "Pagination limit exceeds maximum")]
+fn test_query_payouts_pagination_limit_above_max_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token, _token_admin) = setup_program(&env, 100_000);
+    let r1 = Address::generate(&env);
+    client.single_payout(&r1, &10_000);
+    let _ = client.query_payouts_by_recipient(&r1, &0, &201);
+}
+
+#[test]
+#[should_panic(expected = "Invalid amount range")]
+fn test_query_payouts_by_amount_invalid_range_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token, _token_admin) = setup_program(&env, 100_000);
+    let _ = client.query_payouts_by_amount(&1000, &100, &0, &10);
+}
+
+#[test]
+#[should_panic(expected = "Invalid timestamp range")]
+fn test_query_payouts_by_timestamp_invalid_range_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token, _token_admin) = setup_program(&env, 100_000);
+    let now = env.ledger().timestamp();
+    let _ = client.query_payouts_by_timestamp(&(now + 10), &now, &0, &10);
+}
+
+#[test]
 fn test_query_schedules_by_status_pending_vs_released() {
     let env = Env::default();
     let (client, _admin, _token, _token_admin) = setup_program(&env, 200_000);

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -1939,6 +1939,57 @@ fn test_batch_payout_atomicity_all_or_nothing() {
 }
 
 #[test]
+fn test_spend_threshold_single_payout_at_boundary_allowed() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipient = Address::generate(&env);
+    let data = client.single_payout(&recipient, &10_000);
+
+    assert_eq!(data.remaining_balance, 40_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_threshold_single_payout_above_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipient = Address::generate(&env);
+    client.single_payout(&recipient, &10_001);
+}
+
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_threshold_batch_total_above_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 50_000);
+    let program_id = String::from_str(&env, "hack-2026");
+
+    client.set_program_spend_threshold(&program_id, &10_000);
+
+    let recipients = vec![&env, Address::generate(&env), Address::generate(&env)];
+    let amounts = vec![&env, 6_000, 5_000];
+    client.batch_payout(&recipients, &amounts);
+}
+
+#[test]
+#[should_panic(expected = "Invalid spend threshold")]
+fn test_spend_threshold_must_be_positive() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 1_000);
+    let program_id = String::from_str(&env, "hack-2026");
+    client.set_program_spend_threshold(&program_id, &0);
+}
+
+#[test]
 fn test_batch_payout_sequential_batches() {
     // Test multiple sequential batch payouts to same program
     // Validates that history accumulates correctly


### PR DESCRIPTION
## Summary
This PR hardens program escrow history queries by introducing deterministic pagination validation, explicit range errors, and centralized pagination behavior across payout/schedule/release-history endpoints. It also adds upgrade-safe pagination configuration storage with backward-compatible defaults.

## What Changed
- Added centralized pagination hardening in `contracts/program-escrow/src/lib.rs`:
  - `validate_pagination(...)` for deterministic page-limit validation
  - `paginate_filtered(...)` to unify filtering + paging behavior
- Added explicit validation errors:
  - `Pagination limit must be greater than zero`
  - `Pagination limit exceeds maximum`
  - `Invalid amount range`
  - `Invalid timestamp range`
- Added upgrade-safe config storage:
  - `DataKey::HistoryPaginationConfig`
  - `HistoryPaginationConfig { max_limit }`
  - default max page limit: `200` (backward-compatible when key is absent)
- Ensured config initialization in existing init paths:
  - `initialize_program(...)`
  - `initialize_contract(...)`
- Refactored query methods to deterministic shared flow:
  - `query_payouts_by_recipient`
  - `query_payouts_by_amount`
  - `query_payouts_by_timestamp`
  - `query_schedules_by_recipient`
  - `query_schedules_by_status`
  - `query_releases_by_recipient`
  - `get_payouts_by_recipient`
- Updated `contracts/program-escrow-manifest.json`:
  - added version history entry `2.2.0`
  - documented `DataKey::HistoryPaginationConfig`
  - added deterministic pagination validation to security features

## Security Notes
- Deterministic validation order prevents ambiguous error behavior across query endpoints.
- Explicit validation failures reduce misuse risk and make client handling predictable.
- Upgrade-safe storage key + default config avoids migration breakage for existing deployments.
- Centralized pagination logic reduces drift/bugs between history query functions.

## Test Plan
Added edge-case tests in `contracts/program-escrow/src/test.rs`:
- `test_query_payouts_pagination_limit_zero_rejected`
- `test_query_payouts_pagination_limit_above_max_rejected`
- `test_query_payouts_by_amount_invalid_range_rejected`
- `test_query_payouts_by_timestamp_invalid_range_rejected`

## Environment/Test Output
Attempted to run:
- `cargo test -p program-escrow --test test -- --nocapture`

Current shell environment does not have Cargo available:
- `cargo : The term 'cargo' is not recognized ...`

(Please run the same command in your Rust-enabled environment to attach full passing output.)

closes #1052