### PR TITLE
feat(bounty-escrow): maintenance mode hardening

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -35,6 +35,14 @@
           "Added refund approval audit events for approval set/consumption lifecycle",
           "Added upgrade-safe storage marker for refund eligibility schema versioning"
         ]
+      },
+      {
+        "version": "2.2.0",
+        "release_date": "2026-04-22",
+        "changes": [
+          "Hardened maintenance mode with explicit initialization, idempotent toggling, and audit-friendly v2 events",
+          "Added upgrade-safe storage keys for maintenance mode metadata and schema versioning"
+        ]
       }
     ]
   },
@@ -791,6 +799,30 @@
         "data_structure": "u32"
       },
       {
+        "name": "MaintenanceMode",
+        "type": "instance",
+        "description": "Maintenance mode flag (explicitly initialized)",
+        "data_structure": "bool"
+      },
+      {
+        "name": "MaintenanceModeUpdatedAt",
+        "type": "instance",
+        "description": "Timestamp when maintenance mode last changed",
+        "data_structure": "u64"
+      },
+      {
+        "name": "MaintenanceModeUpdatedBy",
+        "type": "instance",
+        "description": "Admin address that last changed maintenance mode",
+        "data_structure": "Address"
+      },
+      {
+        "name": "MaintenanceModeSchemaVersion",
+        "type": "instance",
+        "description": "Version marker for maintenance mode semantics",
+        "data_structure": "u32"
+      },
+      {
         "name": "ReentrancyGuard",
         "type": "temporary",
         "description": "Reentrancy protection flag",
@@ -809,7 +841,8 @@
       "Input validation for all parameters",
       "Overflow protection in arithmetic operations",
       "Event emission for audit trail",
-      "Deterministic refund eligibility view semantics"
+      "Deterministic refund eligibility view semantics",
+      "Deterministic maintenance mode semantics with audit events"
     ],
     "access_control": [
       {
@@ -1066,6 +1099,33 @@
           }
         ],
         "trigger": "Successful refund call with admin approval record"
+      },
+      {
+        "name": "MaintenanceModeChangedV2",
+        "description": "Maintenance mode toggled with previous state (audit-friendly)",
+        "data": [
+          {
+            "name": "previous_enabled",
+            "type": "bool",
+            "description": "Previous maintenance mode state"
+          },
+          {
+            "name": "enabled",
+            "type": "bool",
+            "description": "New maintenance mode state"
+          },
+          {
+            "name": "admin",
+            "type": "Address",
+            "description": "Admin who toggled maintenance mode"
+          },
+          {
+            "name": "timestamp",
+            "type": "u64",
+            "description": "Ledger timestamp"
+          }
+        ],
+        "trigger": "Admin toggles maintenance mode (state change only)"
       }
     ]
   },

--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -798,6 +798,22 @@ pub fn emit_maintenance_mode_changed(env: &Env, event: MaintenanceModeChanged) {
     env.events().publish(topics, event);
 }
 
+/// V2 payload for maintenance mode changes (deterministic + audit-friendly).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaintenanceModeChangedV2 {
+    pub version: u32,
+    pub previous_enabled: bool,
+    pub enabled: bool,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+pub fn emit_maintenance_mode_changed_v2(env: &Env, event: MaintenanceModeChangedV2) {
+    let topics = (symbol_short!("maint"), symbol_short!("v2"));
+    env.events().publish(topics, event);
+}
+
 /// Payload for the [`emit_participant_filter_mode_changed`] event.
 ///
 /// Emitted when the admin changes the participant filter mode.

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -32,12 +32,13 @@ use crate::events::{
     emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_initialized,
     emit_deprecation_state_changed, emit_deterministic_selection, emit_funds_locked,
     emit_funds_locked_anon, emit_funds_refunded, emit_funds_released,
-    emit_maintenance_mode_changed, emit_notification_preferences_updated,
+    emit_maintenance_mode_changed, emit_maintenance_mode_changed_v2,
+    emit_notification_preferences_updated,
     emit_participant_filter_mode_changed, emit_risk_flags_updated, emit_ticket_claimed,
     emit_refund_approval_consumed, emit_refund_approval_set, emit_ticket_issued, BatchFundsLocked,
     BatchFundsReleased, BountyEscrowInitialized, ClaimCancelled, ClaimCreated, ClaimExecuted,
     CriticalOperationOutcome, DeprecationStateChanged, DeterministicSelectionDerived, FundsLocked,
-    FundsLockedAnon, FundsRefunded, FundsReleased, MaintenanceModeChanged,
+    FundsLockedAnon, FundsRefunded, FundsReleased, MaintenanceModeChanged, MaintenanceModeChangedV2,
     NotificationPreferencesUpdated, ParticipantFilterModeChanged, RefundApprovalConsumed,
     RefundApprovalSet, RefundTriggerType, RiskFlagsUpdated, TicketClaimed, TicketIssued,
     EVENT_VERSION_V2,
@@ -823,6 +824,12 @@ pub enum DataKey {
     NetworkId,
 
     MaintenanceMode, // bool flag
+    /// Timestamp when maintenance mode was last toggled.
+    MaintenanceModeUpdatedAt,
+    /// Admin that last toggled maintenance mode.
+    MaintenanceModeUpdatedBy,
+    /// Schema marker for maintenance mode hardening semantics.
+    MaintenanceModeSchemaVersion,
     /// Per-operation gas budget caps configured by the admin.
     /// See [`gas_budget::GasBudgetConfig`].
     GasBudgetConfig,
@@ -960,6 +967,7 @@ pub struct ReleaseApproval {
 }
 
 const REFUND_ELIGIBILITY_SCHEMA_VERSION_V1: u32 = 1;
+const MAINTENANCE_MODE_SCHEMA_VERSION_V1: u32 = 1;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1184,6 +1192,20 @@ impl BountyEscrowContract {
             &DataKey::RefundEligibilitySchemaVersion,
             &REFUND_ELIGIBILITY_SCHEMA_VERSION_V1,
         );
+        // Upgrade-safe maintenance mode initialization (explicit key write).
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceMode, &false);
+        env.storage().instance().set(
+            &DataKey::MaintenanceModeSchemaVersion,
+            &MAINTENANCE_MODE_SCHEMA_VERSION_V1,
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceModeUpdatedAt, &env.ledger().timestamp());
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceModeUpdatedBy, &admin);
 
         events::emit_bounty_initialized(
             &env,
@@ -1977,13 +1999,40 @@ impl BountyEscrowContract {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
+        let previous_enabled = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaintenanceMode)
+            .unwrap_or(false);
+
+        // Idempotent behavior: if no state change, do not emit events.
+        if previous_enabled == enabled {
+            return Ok(());
+        }
+
         env.storage()
             .instance()
             .set(&DataKey::MaintenanceMode, &enabled);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceModeUpdatedAt, &env.ledger().timestamp());
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceModeUpdatedBy, &admin);
 
         events::emit_maintenance_mode_changed(
             &env,
             MaintenanceModeChanged {
+                enabled,
+                admin: admin.clone(),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        emit_maintenance_mode_changed_v2(
+            &env,
+            MaintenanceModeChangedV2 {
+                version: EVENT_VERSION_V2,
+                previous_enabled,
                 enabled,
                 admin: admin.clone(),
                 timestamp: env.ledger().timestamp(),

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -129,6 +129,33 @@ fn test_refund_eligibility_eligible_with_admin_approval_before_deadline() {
     assert!(view.approval_present);
 }
 
+#[test]
+fn test_maintenance_mode_blocks_lock_but_not_release_or_refund_paths() {
+    let setup = TestSetup::new();
+    let bounty_id = 202;
+    let amount = 1000;
+    let deadline = setup.env.ledger().timestamp() + 100;
+
+    setup.escrow.set_maintenance_mode(&true);
+
+    // Lock should be blocked (maintenance mode acts like lock pause).
+    let res = setup
+        .escrow
+        .try_lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    assert!(matches!(res, Err(Ok(Error::FundsPaused))));
+
+    // Existing escrow should still be able to release/refund (maintenance mode only affects lock).
+    setup
+        .escrow
+        .set_maintenance_mode(&false);
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_maintenance_mode(&true);
+
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+}
+
 // Valid transitions: Locked → Released
 #[test]
 fn test_locked_to_released() {


### PR DESCRIPTION
## Summary
This PR hardens bounty escrow maintenance mode with explicit initialization, deterministic/idempotent toggle semantics, and improved auditability via a new v2 maintenance-mode event. It also adds upgrade-safe storage metadata so maintenance semantics remain stable across upgrades.

## What Changed
- Upgrade-safe maintenance initialization:
  - `init` now explicitly writes `MaintenanceMode = false` and persists maintenance metadata keys.
- Idempotent maintenance toggling:
  - `set_maintenance_mode(enabled)` returns `Ok(())` without emitting events when the requested state matches the current state.
- Audit events:
  - Preserves existing `MaintenanceModeChanged`
  - Adds `MaintenanceModeChangedV2` including `previous_enabled` for clearer audit trails.
- Storage hardening:
  - Added instance keys:
    - `MaintenanceModeUpdatedAt`
    - `MaintenanceModeUpdatedBy`
    - `MaintenanceModeSchemaVersion`
- Tests:
  - Added a status-transition test verifying maintenance mode blocks `lock_funds` (returns `FundsPaused`) while allowing existing escrow operations (e.g., `release_funds`) to proceed.

## Files Changed
- `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
- `contracts/bounty_escrow/contracts/escrow/src/events.rs`
- `contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs`
- `contracts/bounty-escrow-manifest.json`

## Security Notes
- Explicit maintenance-mode initialization prevents ambiguous defaults after upgrades.
- Idempotent toggling prevents event spam and simplifies indexer/state reconciliation.
- V2 event includes previous state to support deterministic off-chain auditing and monitoring.
- Maintenance mode semantics remain scoped to blocking `lock` operations (existing escrows can still release/refund), minimizing user harm during maintenance windows.

## Test Plan
- Added test in `test_status_transitions.rs`:
  - maintenance mode blocks `try_lock_funds` with `FundsPaused`
  - existing escrow can still `release_funds` under maintenance mode

## Test Output
Attempted to run:
- `cargo test -p escrow test_status_transitions -- --nocapture`

Environment limitation:
- `cargo : The term 'cargo' is not recognized ...`
(Please run the command in a Rust-enabled environment and attach the passing output.)

closes #997 