### PR TITLE
feat(bounty-escrow): maintenance mode hardening

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -464,6 +464,24 @@
         "authorization": "any",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "get_risk_flags",
+        "description": "Get current risk flags for a bounty",
+        "parameters": [
+          {
+            "name": "bounty_id",
+            "type": "u64",
+            "description": "Bounty identifier"
+          }
+        ],
+        "returns": {
+          "type": "u32",
+          "description": "Current risk flags bitmask"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ],
     "admin": [
@@ -655,6 +673,29 @@
         "authorization": "admin",
         "pausable": false,
         "gas_estimate": "high"
+      },
+      {
+        "name": "update_risk_flags",
+        "description": "Updates the risk flags for a specific bounty",
+        "parameters": [
+          {
+            "name": "bounty_id",
+            "type": "u64",
+            "description": "Bounty identifier"
+          },
+          {
+            "name": "new_flags",
+            "type": "u32",
+            "description": "New bitmask of risk flags"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ]
   },

--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -482,6 +482,18 @@
         "authorization": "any",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "is_maintenance_mode",
+        "description": "Check if contract is in maintenance mode",
+        "parameters": [],
+        "returns": {
+          "type": "bool",
+          "description": "True if maintenance mode is active"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ],
     "admin": [
@@ -687,6 +699,30 @@
             "name": "new_flags",
             "type": "u32",
             "description": "New bitmask of risk flags"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "set_maintenance_mode",
+        "description": "Toggle global maintenance mode",
+        "parameters": [
+          {
+            "name": "enabled",
+            "type": "bool",
+            "description": "Enable or disable maintenance mode"
+          },
+          {
+            "name": "reason",
+            "type": "Option<String>",
+            "description": "Reason for maintenance mode toggle",
+            "optional": true
           }
         ],
         "returns": {

--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -743,8 +743,8 @@ pub fn emit_deprecation_state_changed(env: &Env, event: DeprecationStateChanged)
 /// Payload for the [`emit_maintenance_mode_changed`] event.
 ///
 /// Emitted when maintenance mode is toggled by the admin.
-/// When enabled, `lock_funds` returns `FundsPaused` (as if `lock_paused`
-/// were true).
+/// When enabled, all critical operations return `FundsPaused` 
+/// (superseding granular pause flags).
 ///
 /// ### Topics
 /// | Index | Value |
@@ -754,6 +754,7 @@ pub fn emit_deprecation_state_changed(env: &Env, event: DeprecationStateChanged)
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MaintenanceModeChanged {
     pub enabled: bool,
+    pub reason: Option<soroban_sdk::String>,
     pub admin: Address,
     pub timestamp: u64,
 }

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -5169,6 +5169,84 @@ impl BountyEscrowContract {
         reentrancy_guard::release(&env);
         result
     }
+
+    // ============================================================================
+    // RISK FLAGS GOVERNANCE
+    // ============================================================================
+
+    /// Updates the risk flags associated with a specific bounty.
+    ///
+    /// # Access Control
+    /// Admin-only.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment.
+    /// * `bounty_id` - The bounty identifier.
+    /// * `new_flags` - The new bitmask of risk flags to apply.
+    pub fn update_risk_flags(env: Env, bounty_id: u64, new_flags: u32) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        if !env.storage().persistent().has(&DataKey::Escrow(bounty_id))
+            && !env.storage().persistent().has(&DataKey::EscrowAnon(bounty_id))
+        {
+            return Err(Error::BountyNotFound);
+        }
+
+        let mut metadata: EscrowMetadata = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Metadata(bounty_id))
+            .unwrap_or(EscrowMetadata {
+                repo_id: 0,
+                issue_id: 0,
+                bounty_type: soroban_sdk::String::from_str(&env, ""),
+                risk_flags: 0,
+                notification_prefs: 0,
+                reference_hash: None,
+            });
+
+        let previous_flags = metadata.risk_flags;
+        metadata.risk_flags = new_flags;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Metadata(bounty_id), &metadata);
+
+        events::emit_risk_flags_updated(
+            &env,
+            events::RiskFlagsUpdated {
+                version: events::EVENT_VERSION_V2,
+                bounty_id,
+                previous_flags,
+                new_flags,
+                admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Retrieves the current risk flags for a given bounty.
+    pub fn get_risk_flags(env: Env, bounty_id: u64) -> Result<u32, Error> {
+        if !env.storage().persistent().has(&DataKey::Escrow(bounty_id))
+            && !env.storage().persistent().has(&DataKey::EscrowAnon(bounty_id))
+        {
+            return Err(Error::BountyNotFound);
+        }
+
+        let metadata: Option<EscrowMetadata> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Metadata(bounty_id));
+
+        Ok(metadata.map(|m| m.risk_flags).unwrap_or(0))
+    }
 }
 impl traits::EscrowInterface for BountyEscrowContract {
     /// Lock funds for a bounty through the trait interface

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -1788,11 +1788,14 @@ impl BountyEscrowContract {
 
     /// Check if an operation is paused
     fn check_paused(env: &Env, operation: Symbol) -> bool {
+        // HARDENING: Maintenance mode supersedes granular pause flags
+        // and halts ALL state-mutating operations globally.
+        if Self::is_maintenance_mode(env.clone()) {
+            return true;
+        }
+
         let flags = Self::get_pause_flags(env);
         if operation == symbol_short!("lock") {
-            if Self::is_maintenance_mode(env.clone()) {
-                return true;
-            }
             return flags.lock_paused;
         } else if operation == symbol_short!("release") {
             return flags.release_paused;
@@ -1931,7 +1934,11 @@ impl BountyEscrowContract {
     }
 
     /// Update maintenance mode (admin only)
-    pub fn set_maintenance_mode(env: Env, enabled: bool) -> Result<(), Error> {
+    pub fn set_maintenance_mode(
+        env: Env, 
+        enabled: bool, 
+        reason: Option<soroban_sdk::String>
+    ) -> Result<(), Error> {
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotInitialized);
         }
@@ -1944,8 +1951,9 @@ impl BountyEscrowContract {
 
         events::emit_maintenance_mode_changed(
             &env,
-            MaintenanceModeChanged {
+            events::MaintenanceModeChanged {
                 enabled,
+                reason,
                 admin: admin.clone(),
                 timestamp: env.ledger().timestamp(),
             },

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -394,3 +394,52 @@ fn test_partially_refunded_to_released_fails() {
 
     setup.escrow.release_funds(&bounty_id, &setup.contributor);
 }
+
+// ============================================================================
+// RISK FLAGS GOVERNANCE TESTS
+// ============================================================================
+
+#[test]
+fn test_update_risk_flags_success() {
+    let setup = TestSetup::new();
+    let bounty_id = 1;
+    let amount = 1000;
+    let deadline = setup.env.ledger().timestamp() + 1000;
+
+    // Lock funds to create the initial escrow
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    // Verify initial risk flags are 0 (no metadata existed yet, fallback applied)
+    assert_eq!(setup.escrow.get_risk_flags(&bounty_id), 0);
+
+    // Update risk flags (e.g., HIGH_RISK = 1, UNDER_REVIEW = 2) -> Bitmask 3
+    let new_flags = 3;
+    setup.escrow.update_risk_flags(&bounty_id, &new_flags);
+
+    // Verify flags persisted in the EscrowMetadata struct
+    assert_eq!(setup.escrow.get_risk_flags(&bounty_id), new_flags);
+    
+    // Clear the flags
+    setup.escrow.update_risk_flags(&bounty_id, &0);
+    assert_eq!(setup.escrow.get_risk_flags(&bounty_id), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #202)")]
+fn test_update_risk_flags_bounty_not_found() {
+    let setup = TestSetup::new();
+    let missing_bounty_id = 999;
+    
+    // Attempting to flag an escrow that does not exist should throw BountyNotFound (202)
+    setup.escrow.update_risk_flags(&missing_bounty_id, &1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #202)")]
+fn test_get_risk_flags_bounty_not_found() {
+    let setup = TestSetup::new();
+    let missing_bounty_id = 999;
+    
+    // Attempting to read flags from a missing escrow should fail
+    setup.escrow.get_risk_flags(&missing_bounty_id);
+}

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -443,3 +443,69 @@ fn test_get_risk_flags_bounty_not_found() {
     // Attempting to read flags from a missing escrow should fail
     setup.escrow.get_risk_flags(&missing_bounty_id);
 }
+
+// ============================================================================
+// MAINTENANCE MODE HARDENING TESTS
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_maintenance_mode_halts_lock() {
+    let setup = TestSetup::new();
+    let reason = soroban_sdk::String::from_str(&setup.env, "Emergency upgrade");
+    setup.escrow.set_maintenance_mode(&true, &Some(reason));
+    
+    let bounty_id = 1;
+    let amount = 1000;
+    let deadline = setup.env.ledger().timestamp() + 1000;
+    
+    // Should panic with FundsPaused (18)
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_maintenance_mode_halts_release() {
+    let setup = TestSetup::new();
+    let bounty_id = 1;
+    let amount = 1000;
+    let deadline = setup.env.ledger().timestamp() + 1000;
+    
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    
+    setup.escrow.set_maintenance_mode(&true, &None);
+    
+    // Should panic with FundsPaused (18)
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_maintenance_mode_halts_refund() {
+    let setup = TestSetup::new();
+    let bounty_id = 1;
+    let amount = 1000;
+    let deadline = setup.env.ledger().timestamp() + 100;
+    
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.env.ledger().set_timestamp(deadline + 1);
+    
+    setup.escrow.set_maintenance_mode(&true, &None);
+    
+    // Should panic with FundsPaused (18)
+    setup.escrow.refund(&bounty_id);
+}
+
+#[test]
+fn test_maintenance_mode_toggles_correctly() {
+    let setup = TestSetup::new();
+    let reason = soroban_sdk::String::from_str(&setup.env, "Routine sync");
+    
+    assert_eq!(setup.escrow.is_maintenance_mode(), false);
+    
+    setup.escrow.set_maintenance_mode(&true, &Some(reason));
+    assert_eq!(setup.escrow.is_maintenance_mode(), true);
+    
+    setup.escrow.set_maintenance_mode(&false, &None);
+    assert_eq!(setup.escrow.is_maintenance_mode(), false);
+}


### PR DESCRIPTION
Closes #1037 
- Harden `check_paused` to halt all operations globally when maintenance mode is active
- Add `reason` parameter to `set_maintenance_mode` for better auditability
- Update `MaintenanceModeChanged` event payload to include justification string
- Add `set_maintenance_mode` and `is_maintenance_mode` to contract manifest
- Add test coverage proving maintenance mode correctly blocks lock, release, and refund