### PR TITLE
feat(bounty-escrow): two-step admin rotation with timelock

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -292,6 +292,15 @@
         "authorization": "admin",
         "pausable": true,
         "gas_estimate": "high"
+      },
+      {
+        "name": "accept_admin",
+        "description": "Accept a pending admin role after timelock expires",
+        "parameters": [],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "signer",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ],
     "view": [
@@ -491,6 +500,24 @@
           "type": "bool",
           "description": "True if maintenance mode is active"
         },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_pending_admin",
+        "description": "View pending admin transfer state",
+        "parameters": [],
+        "returns": { "type": "Option<AdminTransferState>", "description": "Pending state if any" },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_admin_timelock",
+        "description": "View configured admin timelock",
+        "parameters": [],
+        "returns": { "type": "u64", "description": "Duration in seconds" },
         "authorization": "any",
         "pausable": false,
         "gas_estimate": "low"
@@ -729,6 +756,37 @@
           "type": "()",
           "description": "Empty on success"
         },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "set_admin_timelock",
+        "description": "Configure the delay for admin rotation",
+        "parameters": [
+          { "name": "duration", "type": "u64", "description": "Timelock duration in seconds" }
+        ],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "propose_admin",
+        "description": "Propose a new admin address",
+        "parameters": [
+          { "name": "new_admin", "type": "Address", "description": "Address of the proposed admin" }
+        ],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "cancel_admin_transfer",
+        "description": "Cancel a pending admin transfer",
+        "parameters": [],
+        "returns": { "type": "()", "description": "Empty on success" },
         "authorization": "admin",
         "pausable": false,
         "gas_estimate": "low"

--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -1376,3 +1376,64 @@ pub fn emit_recurring_lock_cancelled(env: &Env, event: RecurringLockCancelled) {
     let topics = (symbol_short!("rl_cncl"), event.recurring_id);
     env.events().publish(topics, event);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ADMIN ROTATION EVENTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTimelockConfigured {
+    pub version: u32,
+    pub admin: Address,
+    pub duration: u64,
+    pub timestamp: u64,
+}
+
+pub fn emit_admin_timelock_configured(env: &Env, event: AdminTimelockConfigured) {
+    let topics = (symbol_short!("adm_tlck"),);
+    env.events().publish(topics, event);
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposed {
+    pub version: u32,
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub available_at: u64,
+    pub timestamp: u64,
+}
+
+pub fn emit_admin_transfer_proposed(env: &Env, event: AdminTransferProposed) {
+    let topics = (symbol_short!("adm_prop"),);
+    env.events().publish(topics, event);
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferCancelled {
+    pub version: u32,
+    pub old_admin: Address,
+    pub proposed_admin: Address,
+    pub timestamp: u64,
+}
+
+pub fn emit_admin_transfer_cancelled(env: &Env, event: AdminTransferCancelled) {
+    let topics = (symbol_short!("adm_cncl"),);
+    env.events().publish(topics, event);
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAccepted {
+    pub version: u32,
+    pub old_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+pub fn emit_admin_transfer_accepted(env: &Env, event: AdminTransferAccepted) {
+    let topics = (symbol_short!("adm_acc"),);
+    env.events().publish(topics, event);
+}

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -5255,6 +5255,151 @@ impl BountyEscrowContract {
 
         Ok(metadata.map(|m| m.risk_flags).unwrap_or(0))
     }
+
+    // ============================================================================
+    // TWO-STEP ADMIN ROTATION WITH TIMELOCK
+    // ============================================================================
+
+    /// Represents a pending admin transfer.
+    #[contracttype]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct AdminTransferState {
+        pub proposed_admin: Address,
+        pub available_at: u64,
+    }
+
+    const DEFAULT_ADMIN_TIMELOCK: u64 = 86400; // 24 hours default
+
+    /// Configures the minimum delay required before an admin transfer can be accepted.
+    pub fn set_admin_timelock(env: Env, duration: u64) -> Result<(), Error> {
+        let admin = rbac::require_admin(&env);
+        admin.require_auth();
+
+        // Enforce a minimum timelock of 5 minutes to prevent instant hijack bypasses
+        if duration < 300 {
+            return Err(Error::InvalidAmount);
+        }
+
+        env.storage()
+            .instance()
+            .set(&symbol_short!("adm_tlock"), &duration);
+
+        events::emit_admin_timelock_configured(
+            &env,
+            events::AdminTimelockConfigured {
+                version: events::EVENT_VERSION_V2,
+                admin,
+                duration,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Step 1: Current admin proposes a new admin. Starts the timelock countdown.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let admin = rbac::require_admin(&env);
+        admin.require_auth();
+
+        let duration = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("adm_tlock"))
+            .unwrap_or(DEFAULT_ADMIN_TIMELOCK);
+            
+        let available_at = env.ledger().timestamp().saturating_add(duration);
+
+        let state = AdminTransferState {
+            proposed_admin: new_admin.clone(),
+            available_at,
+        };
+
+        env.storage()
+            .instance()
+            .set(&symbol_short!("adm_xfer"), &state);
+
+        events::emit_admin_transfer_proposed(
+            &env,
+            events::AdminTransferProposed {
+                version: events::EVENT_VERSION_V2,
+                old_admin: admin,
+                new_admin,
+                available_at,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Cancels an active admin transfer proposal.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), Error> {
+        let admin = rbac::require_admin(&env);
+        admin.require_auth();
+
+        if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<_, AdminTransferState>(&symbol_short!("adm_xfer"))
+        {
+            env.storage().instance().remove(&symbol_short!("adm_xfer"));
+            events::emit_admin_transfer_cancelled(
+                &env,
+                events::AdminTransferCancelled {
+                    version: events::EVENT_VERSION_V2,
+                    old_admin: admin,
+                    proposed_admin: state.proposed_admin,
+                    timestamp: env.ledger().timestamp(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    /// Step 2: Proposed admin accepts the role. Fails if the timelock has not expired.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        let state = env
+            .storage()
+            .instance()
+            .get::<_, AdminTransferState>(&symbol_short!("adm_xfer"))
+            .ok_or(Error::Unauthorized)?;
+
+        // The NEW admin must be the one to sign and accept
+        state.proposed_admin.require_auth();
+
+        if env.ledger().timestamp() < state.available_at {
+            return Err(Error::DeadlineNotPassed);
+        }
+
+        let old_admin = rbac::require_admin(&env);
+
+        // Execute the transfer and clean up state
+        env.storage().instance().set(&DataKey::Admin, &state.proposed_admin);
+        env.storage().instance().remove(&symbol_short!("adm_xfer"));
+
+        events::emit_admin_transfer_accepted(
+            &env,
+            events::AdminTransferAccepted {
+                version: events::EVENT_VERSION_V2,
+                old_admin,
+                new_admin: state.proposed_admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    /// View: Gets the current pending admin transfer details.
+    pub fn get_pending_admin(env: Env) -> Option<AdminTransferState> {
+        env.storage().instance().get(&symbol_short!("adm_xfer"))
+    }
+
+    /// View: Gets the current configured admin timelock duration.
+    pub fn get_admin_timelock(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("adm_tlock"))
+            .unwrap_or(DEFAULT_ADMIN_TIMELOCK)
+    }
 }
 impl traits::EscrowInterface for BountyEscrowContract {
     /// Lock funds for a bounty through the trait interface

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -509,3 +509,74 @@ fn test_maintenance_mode_toggles_correctly() {
     setup.escrow.set_maintenance_mode(&false, &None);
     assert_eq!(setup.escrow.is_maintenance_mode(), false);
 }
+
+// ============================================================================
+// ADMIN ROTATION TESTS
+// ============================================================================
+
+#[test]
+fn test_admin_rotation_lifecycle_success() {
+    let setup = TestSetup::new();
+    let new_admin = Address::generate(&setup.env);
+    
+    // 1. Configure Timelock to 1 hour (3600 seconds)
+    setup.escrow.set_admin_timelock(&3600);
+    assert_eq!(setup.escrow.get_admin_timelock(), 3600);
+
+    // 2. Propose Admin
+    let current_time = setup.env.ledger().timestamp();
+    setup.escrow.propose_admin(&new_admin);
+    
+    let pending = setup.escrow.get_pending_admin().unwrap();
+    assert_eq!(pending.proposed_admin, new_admin);
+    assert_eq!(pending.available_at, current_time + 3600);
+
+    // 3. Fast forward time past the timelock
+    setup.env.ledger().set_timestamp(current_time + 3601);
+
+    // 4. Accept Admin (must be signed by the new admin)
+    setup.escrow.accept_admin();
+
+    // 5. Verify the transfer state is cleaned up
+    assert!(setup.escrow.get_pending_admin().is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")] // DeadlineNotPassed
+fn test_admin_rotation_fails_before_timelock() {
+    let setup = TestSetup::new();
+    let new_admin = Address::generate(&setup.env);
+    
+    setup.escrow.propose_admin(&new_admin);
+    
+    // Try to accept immediately without advancing the ledger timestamp
+    setup.escrow.accept_admin();
+}
+
+#[test]
+fn test_admin_rotation_cancel() {
+    let setup = TestSetup::new();
+    let new_admin = Address::generate(&setup.env);
+    
+    setup.escrow.propose_admin(&new_admin);
+    assert!(setup.escrow.get_pending_admin().is_some());
+    
+    setup.escrow.cancel_admin_transfer();
+    assert!(setup.escrow.get_pending_admin().is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")] // Unauthorized
+fn test_accept_admin_unauthorized_if_none_pending() {
+    let setup = TestSetup::new();
+    // Try to accept when nothing is proposed
+    setup.escrow.accept_admin();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")] // InvalidAmount
+fn test_admin_timelock_enforces_minimum() {
+    let setup = TestSetup::new();
+    // Try to set timelock to 1 second (minimum is 300)
+    setup.escrow.set_admin_timelock(&1);
+}


### PR DESCRIPTION
closes #1033 
- Implement `propose_admin`, `accept_admin`, and `cancel_admin_transfer`
- Introduce `AdminTransferState` with mandatory timelock delay
- Add `set_admin_timelock` configuration with a 5-minute hardcoded minimum floor
- Emit explicit, verifiable events for all rotation lifecycle stages
- Add extensive unit test coverage for success, early rejection, and cancellation
- Register rotation endpoints in contract manifest