### PR TITLE
feat(bounty-escrow): participant filter pagination + CEI/reentrancy hardening

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -292,9 +292,131 @@
         "authorization": "admin",
         "pausable": true,
         "gas_estimate": "high"
+      },
+      {
+        "name": "set_filter_mode",
+        "description": "Set active participant filter mode",
+        "parameters": [
+          {
+            "name": "mode",
+            "type": "ParticipantFilterMode",
+            "description": "Disabled, BlocklistOnly, or AllowlistOnly"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "set_whitelist_entry",
+        "description": "Add or remove a participant from allowlist",
+        "parameters": [
+          {
+            "name": "address",
+            "type": "Address",
+            "description": "Participant address"
+          },
+          {
+            "name": "whitelisted",
+            "type": "bool",
+            "description": "True to add, false to remove"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "set_blocklist_entry",
+        "description": "Add or remove a participant from blocklist",
+        "parameters": [
+          {
+            "name": "address",
+            "type": "Address",
+            "description": "Participant address"
+          },
+          {
+            "name": "blocked",
+            "type": "bool",
+            "description": "True to add, false to remove"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ],
     "view": [
+      {
+        "name": "get_filter_mode",
+        "description": "Get current participant filter mode",
+        "parameters": [],
+        "returns": {
+          "type": "ParticipantFilterMode",
+          "description": "Current participant filter mode"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "query_whitelist",
+        "description": "Get paginated allowlist participants",
+        "parameters": [
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Zero-based start index"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum number of results"
+          }
+        ],
+        "returns": {
+          "type": "Vec<Address>",
+          "description": "Allowlisted participant addresses"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "query_blocklist",
+        "description": "Get paginated blocklist participants",
+        "parameters": [
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Zero-based start index"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum number of results"
+          }
+        ],
+        "returns": {
+          "type": "Vec<Address>",
+          "description": "Blocklisted participant addresses"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
       {
         "name": "get_escrow",
         "description": "Get escrow details by bounty ID",
@@ -762,6 +884,18 @@
         "type": "temporary",
         "description": "Reentrancy protection flag",
         "data_structure": "bool"
+      },
+      {
+        "name": "WhitelistIndex",
+        "type": "instance",
+        "description": "Paginated index of allowlisted addresses",
+        "data_structure": "Vec<Address>"
+      },
+      {
+        "name": "BlocklistIndex",
+        "type": "instance",
+        "description": "Paginated index of blocklisted addresses",
+        "data_structure": "Vec<Address>"
       }
     ]
   },

--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -791,6 +791,32 @@ pub fn emit_participant_filter_mode_changed(env: &Env, event: ParticipantFilterM
     env.events().publish(topics, event);
 }
 
+/// Which participant list was mutated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ParticipantFilterListType {
+    Allowlist,
+    Blocklist,
+}
+
+/// Payload for participant list entry mutation events.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipantFilterEntryUpdated {
+    pub version: u32,
+    pub list_type: ParticipantFilterListType,
+    pub address: Address,
+    pub enabled: bool,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+/// Emit [`ParticipantFilterEntryUpdated`]
+pub fn emit_participant_filter_entry_updated(env: &Env, event: ParticipantFilterEntryUpdated) {
+    let topics = (symbol_short!("pf_entry"),);
+    env.events().publish(topics, event);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // RISK FLAG EVENTS
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -799,6 +799,10 @@ pub enum DataKey {
     RenewalHistory(u64),
     /// Per-bounty rollover chain link metadata.
     CycleLink(u64),
+    /// Ordered index of allowlisted participants for paginated queries.
+    WhitelistIndex,
+    /// Ordered index of blocklisted participants for paginated queries.
+    BlocklistIndex,
 }
 
 #[contracttype]
@@ -1631,6 +1635,7 @@ impl BountyEscrowContract {
 
         let flags = Self::get_pause_flags(&env);
         if !flags.lock_paused {
+            reentrancy_guard::release(&env);
             return Err(Error::NotPaused);
         }
 
@@ -1675,6 +1680,61 @@ impl BountyEscrowContract {
             .instance()
             .get(&DataKey::ParticipantFilterMode)
             .unwrap_or(ParticipantFilterMode::Disabled)
+    }
+
+    fn read_participant_index(env: &Env, key: DataKey) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&key)
+            .unwrap_or(Vec::<Address>::new(env))
+    }
+
+    fn write_participant_index(env: &Env, key: DataKey, values: &Vec<Address>) {
+        env.storage().instance().set(&key, values);
+    }
+
+    fn index_contains(values: &Vec<Address>, needle: &Address) -> bool {
+        for value in values.iter() {
+            if value == needle.clone() {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn index_insert_unique(values: &mut Vec<Address>, value: Address) {
+        if !Self::index_contains(values, &value) {
+            values.push_back(value);
+        }
+    }
+
+    fn index_remove(env: &Env, values: &Vec<Address>, value: &Address) -> Vec<Address> {
+        let mut filtered = Vec::<Address>::new(env);
+        for entry in values.iter() {
+            if entry != value.clone() {
+                filtered.push_back(entry);
+            }
+        }
+        filtered
+    }
+
+    fn paginate_addresses(env: &Env, values: Vec<Address>, offset: u32, limit: u32) -> Vec<Address> {
+        if limit == 0 {
+            return Vec::new(env);
+        }
+        let len = values.len();
+        if offset >= len {
+            return Vec::new(env);
+        }
+        let mut out = Vec::new(env);
+        let mut i = offset;
+        while i < len && out.len() < limit {
+            if let Some(value) = values.get(i) {
+                out.push_back(value);
+            }
+            i += 1;
+        }
+        out
     }
 
     /// Enforces participant filtering: returns Err if the address is not allowed to participate
@@ -1960,8 +2020,103 @@ impl BountyEscrowContract {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
-        anti_abuse::set_whitelist(&env, address, whitelisted);
+        anti_abuse::set_whitelist(&env, address.clone(), whitelisted);
+        let mut index = Self::read_participant_index(&env, DataKey::WhitelistIndex);
+        if whitelisted {
+            Self::index_insert_unique(&mut index, address.clone());
+        } else {
+            index = Self::index_remove(&env, &index, &address);
+        }
+        Self::write_participant_index(&env, DataKey::WhitelistIndex, &index);
+        events::emit_participant_filter_entry_updated(
+            &env,
+            events::ParticipantFilterEntryUpdated {
+                version: EVENT_VERSION_V2,
+                list_type: events::ParticipantFilterListType::Allowlist,
+                address,
+                enabled: whitelisted,
+                admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
         Ok(())
+    }
+
+    pub fn set_whitelist_entry(
+        env: Env,
+        address: Address,
+        whitelisted: bool,
+    ) -> Result<(), Error> {
+        Self::set_whitelist(env, address, whitelisted)
+    }
+
+    pub fn set_blocklist(env: Env, address: Address, blocked: bool) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        anti_abuse::set_blocklist(&env, address.clone(), blocked);
+        let mut index = Self::read_participant_index(&env, DataKey::BlocklistIndex);
+        if blocked {
+            Self::index_insert_unique(&mut index, address.clone());
+        } else {
+            index = Self::index_remove(&env, &index, &address);
+        }
+        Self::write_participant_index(&env, DataKey::BlocklistIndex, &index);
+        events::emit_participant_filter_entry_updated(
+            &env,
+            events::ParticipantFilterEntryUpdated {
+                version: EVENT_VERSION_V2,
+                list_type: events::ParticipantFilterListType::Blocklist,
+                address,
+                enabled: blocked,
+                admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn set_blocklist_entry(env: Env, address: Address, blocked: bool) -> Result<(), Error> {
+        Self::set_blocklist(env, address, blocked)
+    }
+
+    pub fn set_filter_mode(env: Env, mode: ParticipantFilterMode) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        let previous_mode = Self::get_participant_filter_mode(&env);
+        env.storage().instance().set(&DataKey::ParticipantFilterMode, &mode);
+        emit_participant_filter_mode_changed(
+            &env,
+            ParticipantFilterModeChanged {
+                previous_mode,
+                new_mode: mode,
+                admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn get_filter_mode(env: Env) -> ParticipantFilterMode {
+        Self::get_participant_filter_mode(&env)
+    }
+
+    /// Return a deterministic page of allowlisted addresses.
+    pub fn query_whitelist(env: Env, offset: u32, limit: u32) -> Vec<Address> {
+        let values = Self::read_participant_index(&env, DataKey::WhitelistIndex);
+        Self::paginate_addresses(&env, values, offset, limit)
+    }
+
+    /// Return a deterministic page of blocklisted addresses.
+    pub fn query_blocklist(env: Env, offset: u32, limit: u32) -> Vec<Address> {
+        let values = Self::read_participant_index(&env, DataKey::BlocklistIndex);
+        Self::paginate_addresses(&env, values, offset, limit)
     }
 
     fn next_capability_id(env: &Env) -> BytesN<32> {
@@ -2612,7 +2767,10 @@ impl BountyEscrowContract {
         soroban_sdk::log!(&env, "check paused ok");
 
         // 4. Participant filtering and rate limiting
-        Self::check_participant_filter(&env, depositor.clone())?;
+        if let Err(err) = Self::check_participant_filter(&env, depositor.clone()) {
+            reentrancy_guard::release(&env);
+            return Err(err);
+        }
         soroban_sdk::log!(&env, "start lock_funds");
         anti_abuse::check_rate_limit(&env, depositor.clone());
         soroban_sdk::log!(&env, "rate limit ok");
@@ -2685,20 +2843,24 @@ impl BountyEscrowContract {
         // Fee must never exceed the deposit; guard against misconfiguration.
         let net_amount = amount.checked_sub(fee_amount).unwrap_or(amount);
         if net_amount <= 0 {
+            reentrancy_guard::release(&env);
             return Err(Error::InvalidAmount);
         }
 
         // Transfer fee to recipient immediately (separate transfer so it is
         // visible as a distinct on-chain operation).
         if fee_amount > 0 {
-            Self::route_fee(
+            if let Err(err) = Self::route_fee(
                 &env,
                 &client,
                 &fee_config,
                 fee_amount,
                 lock_fee_rate,
                 events::FeeOperationType::Lock,
-            )?;
+            ) {
+                reentrancy_guard::release(&env);
+                return Err(err);
+            }
         }
         soroban_sdk::log!(&env, "fee ok");
 

--- a/contracts/bounty_escrow/contracts/escrow/src/test_participant_filter_mode.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_participant_filter_mode.rs
@@ -230,3 +230,41 @@ fn test_set_filter_mode_emits_event_and_persists() {
         ParticipantFilterMode::AllowlistOnly
     );
 }
+
+#[test]
+fn test_query_whitelist_pagination_semantics() {
+    let env = create_env();
+    let (client, depositor, other, _token) = setup(&env);
+    let third = Address::generate(&env);
+
+    client.set_whitelist_entry(&depositor, &true);
+    client.set_whitelist_entry(&other, &true);
+    client.set_whitelist_entry(&third, &true);
+
+    let page1 = client.query_whitelist(&0, &2);
+    assert_eq!(page1.len(), 2);
+
+    let page2 = client.query_whitelist(&2, &2);
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2.get(0).unwrap(), third);
+
+    let page3 = client.query_whitelist(&10, &5);
+    assert_eq!(page3.len(), 0);
+}
+
+#[test]
+fn test_query_blocklist_pagination_and_mutation() {
+    let env = create_env();
+    let (client, depositor, other, _token) = setup(&env);
+
+    client.set_blocklist_entry(&depositor, &true);
+    client.set_blocklist_entry(&other, &true);
+
+    let initial = client.query_blocklist(&0, &10);
+    assert_eq!(initial.len(), 2);
+
+    client.set_blocklist_entry(&depositor, &false);
+    let after_remove = client.query_blocklist(&0, &10);
+    assert_eq!(after_remove.len(), 1);
+    assert_eq!(after_remove.get(0).unwrap(), other);
+}


### PR DESCRIPTION
## Summary
- add participant filter pagination using upgrade-safe allowlist/blocklist indexes
- emit audit events for participant list mutations (allowlist/blocklist add/remove)
- harden CEI/reentrancy behavior by explicitly releasing guard on key early-error paths
- expose admin/view entrypoints for filter mode and paginated list queries; update manifest docs

## What changed
- `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
  - added `WhitelistIndex` and `BlocklistIndex` storage keys
  - added `set_whitelist_entry`, `set_blocklist_entry`, `set_filter_mode`, `get_filter_mode`
  - added `query_whitelist(offset, limit)` and `query_blocklist(offset, limit)`
  - wired list mutation logic to keep indexes consistent
  - added explicit guard release in `emergency_withdraw` `NotPaused` early return and lock-funds participant/fee validation error branches
- `contracts/bounty_escrow/contracts/escrow/src/events.rs`
  - added `ParticipantFilterListType`
  - added `ParticipantFilterEntryUpdated` event + emitter (`pf_entry`)
- `contracts/bounty_escrow/contracts/escrow/src/test_participant_filter_mode.rs`
  - added pagination and mutation coverage for allowlist/blocklist queries
- `contracts/bounty-escrow-manifest.json`
  - documented new participant filter entrypoints and list index storage keys

## Security notes
- pagination is bounded (`offset`, `limit`) and read-only
- participant list state is now auditable via dedicated mutation events
- reentrancy guard lifecycle is explicit on added early-return branches to reduce lock leakage risk
- storage additions are append-only and upgrade-safe

## Test plan
- attempted `cargo test --manifest-path /Users/admin/grainlify/contracts/bounty_escrow/contracts/escrow/Cargo.toml`
- attempted `cargo check --manifest-path /Users/admin/grainlify/contracts/bounty_escrow/contracts/escrow/Cargo.toml --lib`
- repository currently has pre-existing compile failures unrelated to this diff (e.g., missing `EscrowPublished` imports, `EscrowStatus::Draft`, missing `RecurringEndCondition`), which block full green execution locally

Closes #1019
Closes #1014

Made with [Cursor](https://cursor.com)