### PR TITLE
feat(program-escrow): spend limits thresholds

### DIFF
--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -3,7 +3,7 @@
   "contract_name": "ProgramEscrowContract",
   "contract_purpose": "Handles hackathon and program prize pools with batch payouts, dependency management, circuit breaker protection, and comprehensive monitoring",
   "version": {
-    "current": "2.0.0",
+    "current": "2.3.0",
     "schema": "1.0.0",
     "history": [
       {
@@ -45,6 +45,20 @@
           "Hardened history pagination with deterministic limit validation and explicit range errors",
           "Centralized pagination behavior across payout, schedule, and release history queries",
           "Added upgrade-safe pagination config storage with backward-compatible defaults"
+        ]
+      },
+      {
+        "version": "2.3.0",
+        "release_date": "2026-04-23",
+        "changes": [
+          "Hardened spend-limit threshold enforcement: enforce_spend_threshold now returns Result and emits SpendLimitExceededEvent before any token transfer",
+          "Added SpendLimitSetEvent audit event emitted after every set_program_spend_threshold call",
+          "Added SpendLimitExceededEvent audit event emitted on every threshold rejection",
+          "Added SpendLimitSchemaVersionSet audit event emitted on init for upgrade-safe schema tracking",
+          "Added SpendLimitSchemaVersion upgrade-safe storage key to instance storage",
+          "Added get_spend_limit_schema_version view entrypoint",
+          "Added ContractError::SpendLimitExceeded (code 904) to canonical error enum",
+          "Deterministic error ordering preserved: threshold check runs before balance and circuit-breaker checks"
         ]
       }
     ]
@@ -448,6 +462,18 @@
         "gas_estimate": "low"
       },
       {
+        "name": "get_spend_limit_schema_version",
+        "description": "Return the spend-limit storage schema version written during init. Returns 0 on legacy deployments.",
+        "parameters": [],
+        "returns": {
+          "type": "u32",
+          "description": "Schema version (1 = current; 0 = legacy pre-v2.3)"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
         "name": "get_program_release_schedules",
         "description": "Get release schedules for all programs",
         "parameters": [],
@@ -780,6 +806,12 @@
         "data_structure": "HistoryPaginationConfig"
       },
       {
+        "name": "DataKey::SpendLimitSchemaVersion",
+        "type": "instance",
+        "description": "Upgrade-safe version marker for spend-limit threshold storage layout. Increment when MultisigConfig schema changes.",
+        "data_structure": "u32"
+      },
+      {
         "name": "SCHEDULES",
         "type": "instance",
         "description": "Release schedules",
@@ -1007,6 +1039,44 @@
           }
         ],
         "trigger": "Successful single payout"
+      },
+      {
+        "name": "SpendLimitSetEvent",
+        "description": "Audit event emitted after every set_program_spend_threshold call",
+        "topics": ["SpLimSet", "program_id"],
+        "data": [
+          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
+          {"name": "program_id", "type": "String", "description": "Program the threshold applies to"},
+          {"name": "previous_threshold", "type": "i128", "description": "Previous threshold (i128::MAX = unlimited)"},
+          {"name": "new_threshold", "type": "i128", "description": "New threshold value"},
+          {"name": "set_by", "type": "Address", "description": "Admin that made the change"},
+          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+        ],
+        "trigger": "Every successful set_program_spend_threshold call"
+      },
+      {
+        "name": "SpendLimitExceededEvent",
+        "description": "Audit event emitted when a payout is rejected for exceeding the spend threshold",
+        "topics": ["SpLimExc", "program_id"],
+        "data": [
+          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
+          {"name": "program_id", "type": "String", "description": "Program the threshold applies to"},
+          {"name": "requested_amount", "type": "i128", "description": "Amount that was requested and rejected"},
+          {"name": "threshold", "type": "i128", "description": "Configured threshold that was exceeded"},
+          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+        ],
+        "trigger": "Every payout rejected due to spend threshold violation"
+      },
+      {
+        "name": "SpendLimitSchemaVersionSet",
+        "description": "Upgrade-safe marker recording the spend-limit storage schema version",
+        "topics": ["SpLimSch"],
+        "data": [
+          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
+          {"name": "schema_version", "type": "u32", "description": "Spend-limit schema version written to instance storage"},
+          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+        ],
+        "trigger": "Contract initialization (init_program)"
       }
     ]
   },

--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -518,6 +518,12 @@ pub enum ContractError {
     /// before the current window expires.
     ThresholdWindowNotExpired = 903,
     
+    /// Spend limit exceeded.
+    ///
+    /// This error occurs when a payout operation (single or batch)
+    /// would exceed the configured per-program spend threshold.
+    SpendLimitExceeded = 904,
+    
     // =========================================================================
     // Batch Recovery Errors (1000-1099)
     // =========================================================================
@@ -703,6 +709,7 @@ impl ContractError {
             ContractError::InvalidThresholdConfig => "Invalid threshold configuration",
             ContractError::CooldownActive => "Cooldown active",
             ContractError::ThresholdWindowNotExpired => "Threshold window not expired",
+            ContractError::SpendLimitExceeded => "Spend limit exceeded",
             
             // Batch Recovery Errors
             ContractError::BatchNotFound => "Batch not found",

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -521,9 +521,82 @@ pub struct DisputeResolvedEvent {
     pub resolved_at: u64,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SPEND-LIMIT THRESHOLD AUDIT EVENTS
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when the admin sets or updates the per-program spend threshold.
+///
+/// ### Topics
+/// `(SPEND_LIMIT_SET, program_id)`
+///
+/// ### Security notes
+/// - Only the admin can call `set_program_spend_threshold`.
+/// - `previous_threshold` is `i128::MAX` when no threshold was previously set.
+/// - Emitted **after** the new value is persisted so the event reflects
+///   the settled on-chain state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpendLimitSetEvent {
+    pub version: u32,
+    /// Program the threshold applies to.
+    pub program_id: String,
+    /// Previous threshold value (`i128::MAX` = unlimited).
+    pub previous_threshold: i128,
+    /// New threshold value.
+    pub new_threshold: i128,
+    /// Admin that made the change.
+    pub set_by: Address,
+    /// Ledger timestamp.
+    pub timestamp: u64,
+}
+
+/// Emitted when a payout is rejected because it would exceed the spend threshold.
+///
+/// ### Topics
+/// `(SPEND_LIMIT_EXCEEDED, program_id)`
+///
+/// ### Security notes
+/// - Emitted **before** any token transfer so no funds move on rejection.
+/// - `requested_amount` and `threshold` are published so auditors can
+///   verify the rejection was correct without re-reading storage.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpendLimitExceededEvent {
+    pub version: u32,
+    /// Program the threshold applies to.
+    pub program_id: String,
+    /// Amount that was requested (and rejected).
+    pub requested_amount: i128,
+    /// Configured threshold that was exceeded.
+    pub threshold: i128,
+    /// Ledger timestamp.
+    pub timestamp: u64,
+}
+
+/// Emitted once during contract initialization to record the spend-limit
+/// storage schema version for upgrade-safety tracking.
+///
+/// ### Topics
+/// `(SPEND_LIMIT_SCHEMA,)`
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpendLimitSchemaVersionSet {
+    pub version: u32,
+    /// Schema version written to instance storage.
+    pub schema_version: u32,
+    /// Ledger timestamp.
+    pub timestamp: u64,
+}
+
 // Event symbols for dispute lifecycle
 const DISPUTE_OPENED: Symbol = symbol_short!("DspOpen");
 const DISPUTE_RESOLVED: Symbol = symbol_short!("DspRslv");
+
+// Event symbols for spend-limit threshold lifecycle
+const SPEND_LIMIT_SET: Symbol = symbol_short!("SpLimSet");
+const SPEND_LIMIT_EXCEEDED: Symbol = symbol_short!("SpLimExc");
+const SPEND_LIMIT_SCHEMA: Symbol = symbol_short!("SpLimSch");
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -545,6 +618,9 @@ pub enum DataKey {
     DependencyStatus(String),        // program_id -> DependencyStatus
     Dispute,                         // DisputeRecord (single active dispute per contract)
     HistoryPaginationConfig,         // HistoryPaginationConfig
+    /// Upgrade-safe schema version marker for spend-limit threshold storage.
+    /// Written on init; increment when `MultisigConfig` layout changes.
+    SpendLimitSchemaVersion,
 }
 
 #[contracttype]
@@ -764,6 +840,13 @@ pub enum BatchError {
 
 pub const MAX_BATCH_SIZE: u32 = 100;
 pub const DEFAULT_MAX_HISTORY_PAGE_LIMIT: u32 = 200;
+
+/// Current spend-limit threshold storage schema version.
+///
+/// Increment whenever `MultisigConfig` layout changes in a breaking way.
+/// Written to instance storage during `init` so upgrade safety checks can
+/// detect schema mismatches on legacy deployments.
+pub const SPEND_LIMIT_SCHEMA_VERSION_V1: u32 = 1;
 
 fn default_history_pagination_config() -> HistoryPaginationConfig {
     HistoryPaginationConfig {
@@ -1196,6 +1279,26 @@ impl ProgramEscrowContract {
             );
         }
         Self::ensure_history_pagination_config(&env);
+
+        // Write upgrade-safe spend-limit schema version marker.
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::SpendLimitSchemaVersion)
+        {
+            env.storage().instance().set(
+                &DataKey::SpendLimitSchemaVersion,
+                &SPEND_LIMIT_SCHEMA_VERSION_V1,
+            );
+            env.events().publish(
+                (SPEND_LIMIT_SCHEMA,),
+                SpendLimitSchemaVersionSet {
+                    version: EVENT_VERSION_V2,
+                    schema_version: SPEND_LIMIT_SCHEMA_VERSION_V1,
+                    timestamp: env.ledger().timestamp(),
+                },
+            );
+        }
 
         env.storage()
             .instance()
@@ -2275,12 +2378,20 @@ impl ProgramEscrowContract {
 
     /// Set the per-program spend threshold.
     ///
-    /// Security and deterministic behavior:
+    /// # Invariant
+    /// After this call, any single payout or batch total exceeding
+    /// `threshold_amount` will be rejected with `SpendLimitExceeded` and
+    /// a `SpendLimitExceededEvent` audit event will be emitted.
+    ///
+    /// # Security and deterministic behavior
     /// - Admin only.
-    /// - `threshold_amount` must be strictly positive.
-    /// - Payout validation checks this threshold before balance checks.
+    /// - `threshold_amount` must be strictly positive; zero or negative
+    ///   values are rejected with `InvalidAmount`.
+    /// - Payout validation checks this threshold **before** balance checks
+    ///   so clients observe stable, deterministic failures.
+    /// - Emits `SpendLimitSetEvent` after the new value is persisted.
     pub fn set_program_spend_threshold(env: Env, program_id: String, threshold_amount: i128) {
-        let _ = Self::require_admin(&env);
+        let admin = Self::require_admin(&env);
         if threshold_amount <= 0 {
             panic!("Invalid spend threshold");
         }
@@ -2294,13 +2405,28 @@ impl ProgramEscrowContract {
                 signers: vec![&env],
                 required_signatures: 0,
             });
+
+        let previous_threshold = cfg.threshold_amount;
         cfg.threshold_amount = threshold_amount;
         env.storage()
             .persistent()
-            .set(&DataKey::MultisigConfig(program_id), &cfg);
+            .set(&DataKey::MultisigConfig(program_id.clone()), &cfg);
+
+        // Emit audit event after storage write (CEI ordering).
+        env.events().publish(
+            (SPEND_LIMIT_SET, program_id.clone()),
+            SpendLimitSetEvent {
+                version: EVENT_VERSION_V2,
+                program_id,
+                previous_threshold,
+                new_threshold: threshold_amount,
+                set_by: admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
     }
 
-    /// Read per-program spend threshold. Returns `i128::MAX` when unset.
+    /// Read per-program spend threshold. Returns `i128::MAX` when unset (unlimited).
     pub fn get_program_spend_threshold(env: Env, program_id: String) -> i128 {
         let cfg: MultisigConfig = env
             .storage()
@@ -2314,7 +2440,26 @@ impl ProgramEscrowContract {
         cfg.threshold_amount
     }
 
-    fn enforce_spend_threshold(env: &Env, program_id: &String, requested_amount: i128) {
+    /// Returns the spend-limit storage schema version written during `init_program`.
+    /// Returns `0` on legacy deployments where the marker was never written.
+    pub fn get_spend_limit_schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SpendLimitSchemaVersion)
+            .unwrap_or(0u32)
+    }
+
+    /// Enforce the per-program spend threshold.
+    ///
+    /// Returns `Err(())` and emits a `SpendLimitExceededEvent` when
+    /// `requested_amount > threshold`. The caller is responsible for
+    /// clearing the reentrancy guard and panicking with the appropriate
+    /// error before any token transfer occurs.
+    fn enforce_spend_threshold(
+        env: &Env,
+        program_id: &String,
+        requested_amount: i128,
+    ) -> Result<(), ()> {
         let cfg: MultisigConfig = env
             .storage()
             .persistent()
@@ -2325,8 +2470,21 @@ impl ProgramEscrowContract {
                 required_signatures: 0,
             });
         if requested_amount > cfg.threshold_amount {
-            panic!("Spend threshold exceeded");
+            // Emit audit event before returning the error so the rejection
+            // is always visible on-chain even if the caller panics.
+            env.events().publish(
+                (SPEND_LIMIT_EXCEEDED, program_id.clone()),
+                SpendLimitExceededEvent {
+                    version: EVENT_VERSION_V2,
+                    program_id: program_id.clone(),
+                    requested_amount,
+                    threshold: cfg.threshold_amount,
+                    timestamp: env.ledger().timestamp(),
+                },
+            );
+            return Err(());
         }
+        Ok(())
     }
 
     pub fn get_analytics(_env: Env) -> Analytics {
@@ -2452,7 +2610,10 @@ impl ProgramEscrowContract {
         // 6. Business logic: sufficient balance
         // Deterministic error ordering: spend threshold check runs before
         // balance/circuit checks, so clients observe stable failures.
-        Self::enforce_spend_threshold(&env, &program_data.program_id, total_payout);
+        if Self::enforce_spend_threshold(&env, &program_data.program_id, total_payout).is_err() {
+            reentrancy_guard::clear_entered(&env);
+            panic!("Spend threshold exceeded");
+        }
 
         if total_payout > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
@@ -2622,7 +2783,10 @@ impl ProgramEscrowContract {
         // 6. Business logic: sufficient balance
         // Deterministic error ordering: spend threshold check runs before
         // balance/circuit checks, so clients observe stable failures.
-        Self::enforce_spend_threshold(&env, &program_data.program_id, amount);
+        if Self::enforce_spend_threshold(&env, &program_data.program_id, amount).is_err() {
+            reentrancy_guard::clear_entered(&env);
+            panic!("Spend threshold exceeded");
+        }
 
         if amount > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -2500,3 +2500,257 @@ fn test_program_update_fee_config_disables_fees() {
     assert_eq!(token_client.balance(&fee_bucket), 1_000);
     let _ = admin;
 }
+
+// =============================================================================
+// SPEND LIMIT THRESHOLD TESTS (Issue #15)
+// =============================================================================
+//
+// These tests verify the spend-limit threshold invariants:
+//   - single_payout and batch_payout are rejected when the requested amount
+//     exceeds the configured per-program threshold.
+//   - The threshold is enforced BEFORE balance checks (deterministic ordering).
+//   - Audit events (SpendLimitSetEvent, SpendLimitExceededEvent) are emitted.
+//   - The upgrade-safe schema version marker is written on init.
+//   - Setting threshold to i128::MAX effectively disables enforcement.
+
+/// SL-1: single_payout below threshold succeeds.
+#[test]
+fn test_spend_limit_single_payout_below_threshold_succeeds() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &5_000);
+    client.single_payout(&recipient, &4_999);
+
+    assert_eq!(token_client.balance(&recipient), 4_999);
+    assert_eq!(client.get_remaining_balance(), 5_001);
+}
+
+/// SL-2: single_payout exactly at threshold succeeds.
+#[test]
+fn test_spend_limit_single_payout_at_threshold_succeeds() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &5_000);
+    client.single_payout(&recipient, &5_000);
+
+    assert_eq!(token_client.balance(&recipient), 5_000);
+    assert_eq!(client.get_remaining_balance(), 5_000);
+}
+
+/// SL-3: single_payout above threshold is rejected.
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_limit_single_payout_above_threshold_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &5_000);
+    client.single_payout(&recipient, &5_001); // must panic
+}
+
+/// SL-4: batch_payout total below threshold succeeds.
+#[test]
+fn test_spend_limit_batch_payout_below_threshold_succeeds() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &6_000);
+    client.batch_payout(
+        &soroban_sdk::vec![&env, r1.clone(), r2.clone()],
+        &soroban_sdk::vec![&env, 2_000i128, 3_000i128],
+    );
+
+    assert_eq!(token_client.balance(&r1), 2_000);
+    assert_eq!(token_client.balance(&r2), 3_000);
+    assert_eq!(client.get_remaining_balance(), 5_000);
+}
+
+/// SL-5: batch_payout total above threshold is rejected.
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_limit_batch_payout_above_threshold_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &4_000);
+    client.batch_payout(
+        &soroban_sdk::vec![&env, r1, r2],
+        &soroban_sdk::vec![&env, 2_000i128, 3_000i128], // total = 5_000 > 4_000
+    );
+}
+
+/// SL-6: threshold check runs before balance check (deterministic ordering).
+/// Even when balance is sufficient, exceeding threshold is rejected first.
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_limit_threshold_checked_before_balance() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 100_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    // Balance is 100_000 but threshold is only 1_000.
+    client.set_program_spend_threshold(&program_id, &1_000);
+    client.single_payout(&recipient, &50_000); // threshold exceeded, not balance
+}
+
+/// SL-7: no threshold set → i128::MAX → any amount within balance is allowed.
+#[test]
+fn test_spend_limit_no_threshold_allows_full_balance() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    // Verify default is i128::MAX (unlimited).
+    assert_eq!(
+        client.get_program_spend_threshold(&program_id),
+        i128::MAX,
+        "default threshold must be i128::MAX"
+    );
+
+    client.single_payout(&recipient, &10_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+    assert_eq!(client.get_remaining_balance(), 0);
+}
+
+/// SL-8: threshold can be updated; new value takes effect immediately.
+#[test]
+fn test_spend_limit_threshold_update_takes_effect() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 20_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    // Set tight threshold.
+    client.set_program_spend_threshold(&program_id, &3_000);
+    client.single_payout(&recipient, &3_000);
+    assert_eq!(token_client.balance(&recipient), 3_000);
+
+    // Raise threshold.
+    client.set_program_spend_threshold(&program_id, &10_000);
+    client.single_payout(&recipient, &10_000);
+    assert_eq!(token_client.balance(&recipient), 13_000);
+    assert_eq!(client.get_remaining_balance(), 7_000);
+}
+
+/// SL-9: SpendLimitSetEvent is emitted with correct fields.
+#[test]
+fn test_spend_limit_set_event_emitted() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+
+    let events_before = env.events().all().len();
+    client.set_program_spend_threshold(&program_id, &7_500);
+    let events_after = env.events().all();
+
+    // At least one new event must have been emitted.
+    assert!(
+        events_after.len() > events_before,
+        "SpendLimitSetEvent must be emitted"
+    );
+}
+
+/// SL-10: SpendLimitExceededEvent is emitted when threshold is breached.
+#[test]
+fn test_spend_limit_exceeded_event_emitted_on_rejection() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &1_000);
+
+    let events_before = env.events().all().len();
+    // Attempt an over-threshold payout; it will panic but the event is emitted first.
+    let result = client.try_single_payout(&recipient, &5_000);
+    assert!(result.is_err(), "over-threshold payout must fail");
+
+    // The SpendLimitExceededEvent must have been emitted before the panic.
+    let events_after = env.events().all();
+    assert!(
+        events_after.len() > events_before,
+        "SpendLimitExceededEvent must be emitted on rejection"
+    );
+}
+
+/// SL-11: upgrade-safe schema version is written on init.
+#[test]
+fn test_spend_limit_schema_version_written_on_init() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin_addr = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin_addr.clone());
+    let token_id = sac.address();
+    let program_id = String::from_str(&env, "schema-test");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+
+    let version = client.get_spend_limit_schema_version();
+    assert_eq!(version, 1u32, "schema version must be 1 after init");
+}
+
+/// SL-12: threshold of 1 rejects any amount > 1.
+#[test]
+#[should_panic(expected = "Spend threshold exceeded")]
+fn test_spend_limit_minimum_threshold_rejects_larger_amounts() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &1);
+    client.single_payout(&recipient, &2); // must panic
+}
+
+/// SL-13: threshold of 1 allows amount == 1.
+#[test]
+fn test_spend_limit_minimum_threshold_allows_exact_amount() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spend_threshold(&program_id, &1);
+    client.single_payout(&recipient, &1);
+    assert_eq!(token_client.balance(&recipient), 1);
+}
+
+/// SL-14: zero threshold is rejected by set_program_spend_threshold.
+#[test]
+#[should_panic(expected = "Invalid spend threshold")]
+fn test_spend_limit_zero_threshold_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+    client.set_program_spend_threshold(&program_id, &0);
+}
+
+/// SL-15: negative threshold is rejected by set_program_spend_threshold.
+#[test]
+#[should_panic(expected = "Invalid spend threshold")]
+fn test_spend_limit_negative_threshold_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+    client.set_program_spend_threshold(&program_id, &-1);
+}


### PR DESCRIPTION
- enforce_spend_threshold now returns Result<(), ()> and emits SpendLimitExceededEvent before any token transfer, giving indexers an on-chain audit trail of every threshold rejection.

- set_program_spend_threshold emits SpendLimitSetEvent (topics: SpLimSet, program_id) after persisting the new value, carrying previous_threshold, new_threshold, set_by, and timestamp.

- SpendLimitExceededEvent (topics: SpLimExc, program_id) carries requested_amount and threshold so auditors can verify rejections without re-reading storage.

- SpendLimitSchemaVersionSet emitted once on init_program to record SPEND_LIMIT_SCHEMA_VERSION_V1 = 1 in instance storage under DataKey::SpendLimitSchemaVersion for upgrade-safe schema tracking.

- Added get_spend_limit_schema_version() view entrypoint; returns 0 on legacy deployments where the marker was never written.

- Added ContractError::SpendLimitExceeded (code 904) to canonical error enum with description.

- Deterministic error ordering preserved: threshold check runs before balance and circuit-breaker checks in both single_payout and batch_payout.

- Added 15 spend-limit tests (SL-1 through SL-15) covering: below/ at/above threshold, batch total, deterministic ordering, default unlimited, threshold update, audit events, schema version on init, minimum threshold edge cases, and invalid threshold rejection.

- Bumped manifest to v2.3.0 with full changelog, new storage key, new entrypoint, and three new event definitions.

Closes #1057