### PR TITLE
feat(contracts): manifest conformance seed validator

### DIFF
--- a/contracts/scripts/README.md
+++ b/contracts/scripts/README.md
@@ -118,6 +118,25 @@ stellar keys address grainlify-deployer
 stellar keys fund grainlify-deployer --network testnet
 ```
 
+---
+
+## Manifest Validation
+
+Schema validation:
+
+- `validate-manifests.sh` (AJV CLI)
+- `validate-manifests.js` (Node, cross-platform)
+
+Lightweight manifest + deployment seed validator (no extra deps):
+
+- `validate_seed_file.py`
+
+Run:
+
+```bash
+python3 contracts/scripts/validate_seed_file.py
+```
+
 ### Setting Up Mainnet
 
 > **Warning:** Mainnet deployments use real XLM and are irreversible.

--- a/contracts/scripts/validate_seed_file.py
+++ b/contracts/scripts/validate_seed_file.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Seed + manifest validation harness (dependency-free).
+
+Why this exists:
+- The repo already provides JSON Schema validation via AJV (see validate-manifests.{sh,js}).
+- This script adds a lightweight, dependency-free sanity layer that validates:
+  1) All `contracts/*-manifest.json` files have required top-level fields and sane values.
+  2) Any deployment seed files under `contracts/**/deployments/*.json` follow a consistent shape.
+
+This script is intentionally conservative about what it *fails* on:
+- It validates structure and basic types.
+- It does NOT attempt to validate Soroban StrKey formats or cross-check Rust entrypoint names,
+  because those checks are environment- and refactor-sensitive and would create noisy failures.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+CONTRACTS_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = CONTRACTS_DIR / "contract-manifest-schema.json"
+
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_VALID_AUTH = {"admin", "signer", "any", "capability", "multisig"}
+_VALID_NETWORKS = {"testnet", "mainnet", "futurenet", "local"}
+_VALID_DEPLOYMENT_STATUS = {"deployed", "upgraded", "rolled_back", "failed"}
+
+
+def _load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise SystemExit(f"ERROR: missing file: {path}") from e
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"ERROR: invalid JSON in {path}: {e}") from e
+
+
+def _find_manifests() -> list[Path]:
+    return sorted(CONTRACTS_DIR.glob("*-manifest.json"))
+
+
+def _basic_manifest_checks(manifest: dict, path: Path) -> list[str]:
+    errors: list[str] = []
+
+    required = ["contract_name", "contract_purpose", "version", "entrypoints", "configuration", "behaviors"]
+    for key in required:
+        if key not in manifest:
+            errors.append(f"{path.name}: missing required field `{key}`")
+
+    version = manifest.get("version") or {}
+    for k in ("current", "schema"):
+        v = version.get(k)
+        if not isinstance(v, str) or not _SEMVER_RE.match(v):
+            errors.append(f"{path.name}: version.{k} must be semver (x.y.z); got {v!r}")
+
+    entrypoints = manifest.get("entrypoints") or {}
+    for k in ("public", "view"):
+        if k not in entrypoints:
+            errors.append(f"{path.name}: entrypoints.{k} missing")
+        elif not isinstance(entrypoints.get(k), list):
+            errors.append(f"{path.name}: entrypoints.{k} must be an array")
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            if "authorization" in obj:
+                yield obj["authorization"]
+            for v in obj.values():
+                yield from walk(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                yield from walk(v)
+
+    for auth in walk(manifest):
+        if auth is None:
+            continue
+        if auth not in _VALID_AUTH:
+            errors.append(f"{path.name}: invalid authorization value {auth!r}")
+
+    return errors
+
+
+def _find_deployment_seed_files() -> list[Path]:
+    # Intentionally broad: teams can keep multiple seed files per contract + network.
+    return sorted(CONTRACTS_DIR.glob("**/deployments/*.json"))
+
+
+def _deployment_seed_checks(data: dict, path: Path) -> list[str]:
+    errors: list[str] = []
+
+    deployments = data.get("deployments")
+    if not isinstance(deployments, list):
+        errors.append(f"{path}: missing/invalid `deployments` array")
+        return errors
+
+    meta = data.get("metadata")
+    if meta is None:
+        errors.append(f"{path}: missing `metadata` object")
+        meta = {}
+    if not isinstance(meta, dict):
+        errors.append(f"{path}: `metadata` must be an object")
+        meta = {}
+
+    created = meta.get("created")
+    if created is not None and (not isinstance(created, str) or not _ISO_Z_RE.match(created)):
+        errors.append(f"{path}: metadata.created must be ISO-8601 Zulu like 2026-01-01T00:00:00Z; got {created!r}")
+
+    version = meta.get("version")
+    if version is not None and not isinstance(version, str):
+        errors.append(f"{path}: metadata.version must be a string; got {type(version).__name__}")
+
+    required_fields = (
+        "contract_id",
+        "wasm_hash",
+        "contract_name",
+        "network",
+        "deployer",
+        "deployed_at",
+        "status",
+    )
+
+    for i, d in enumerate(deployments):
+        if not isinstance(d, dict):
+            errors.append(f"{path}: deployments[{i}] must be an object; got {type(d).__name__}")
+            continue
+
+        for k in required_fields:
+            if k not in d:
+                errors.append(f"{path}: deployments[{i}] missing `{k}`")
+
+        network = d.get("network")
+        if isinstance(network, str) and network not in _VALID_NETWORKS:
+            errors.append(f"{path}: deployments[{i}].network must be one of {sorted(_VALID_NETWORKS)}; got {network!r}")
+
+        status = d.get("status")
+        if isinstance(status, str) and status not in _VALID_DEPLOYMENT_STATUS:
+            errors.append(
+                f"{path}: deployments[{i}].status must be one of {sorted(_VALID_DEPLOYMENT_STATUS)}; got {status!r}"
+            )
+
+        deployed_at = d.get("deployed_at")
+        if deployed_at is not None and (not isinstance(deployed_at, str) or not _ISO_Z_RE.match(deployed_at)):
+            errors.append(
+                f"{path}: deployments[{i}].deployed_at must be ISO-8601 Zulu like 2026-01-01T00:00:00Z; got {deployed_at!r}"
+            )
+
+        # Basic type sanity (do not enforce StrKey formatting here).
+        for k in ("contract_id", "wasm_hash", "contract_name", "deployer"):
+            v = d.get(k)
+            if v is not None and not isinstance(v, str):
+                errors.append(f"{path}: deployments[{i}].{k} must be a string; got {type(v).__name__}")
+            if isinstance(v, str) and not v.strip():
+                errors.append(f"{path}: deployments[{i}].{k} must be non-empty")
+
+    return errors
+
+
+def main() -> int:
+    # Existence + JSON validity check only (AJV is the schema enforcer).
+    _load_json(SCHEMA_PATH)
+
+    manifests = _find_manifests()
+    if not manifests:
+        print("WARNING: no *-manifest.json files found.")
+        return 0
+
+    all_errors: list[str] = []
+    for path in manifests:
+        manifest = _load_json(path)
+        if not isinstance(manifest, dict):
+            all_errors.append(f"{path.name}: root must be an object; got {type(manifest).__name__}")
+            continue
+        all_errors.extend(_basic_manifest_checks(manifest, path))
+
+    seed_files = _find_deployment_seed_files()
+    for seed_path in seed_files:
+        seed = _load_json(seed_path)
+        if not isinstance(seed, dict):
+            all_errors.append(f"{seed_path}: root must be an object; got {type(seed).__name__}")
+            continue
+        all_errors.extend(_deployment_seed_checks(seed, seed_path))
+
+    if all_errors:
+        for e in all_errors:
+            print(f"ERROR: {e}")
+        return 1
+
+    print(f"OK: validated {len(manifests)} manifest(s) and {len(seed_files)} deployment seed file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Objective
- Deliver manifest conformance harness across the contracts repo with strong tests + documentation

Changes
- Add dependency-free validator: `contracts/scripts/validate_seed_file.py`
  - Validates required fields + semver + authorization values for `contracts/*-manifest.json`
  - Validates deployment seed JSON shape under `contracts/**/deployments/*.json`
- Document validator usage in `contracts/scripts/README.md`

Validation
- `python3 contracts/scripts/validate_seed_file.py`

Notes
- This validator intentionally avoids StrKey-format validation and Rust source parsing to reduce false positives in CI.

Closes #1079
