### PR TITLE
feat(bounty-escrow): fee routing invariants (#50)

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./contract-manifest-schema.json",
   "contract_name": "BountyEscrowContract",
-  "contract_purpose": "Manages bounty escrow with multi-token support, capability-based authorization, two-step admin rotation with timelock, refund-eligibility views, fee configuration, and comprehensive security features including reentrancy protection and rate limiting",
+  "contract_purpose": "Manages bounty escrow with multi-token support, capability-based authorization, two-step admin rotation with timelock, refund-eligibility views, fee configuration, per-bounty fee routing invariants, and comprehensive security features including reentrancy protection and rate limiting",
   "version": {
-    "current": "2.1.1",
+    "current": "2.4.0",
     "schema": "1.0.0",
     "history": [
       {
@@ -54,6 +54,23 @@
           "Added InvalidBatchSizeCap error code for batch size governance",
           "Added BatchSizeCaps and FeeRoutingSchemaVersion DataKey variants for upgrade-safe storage",
           "Fee routing invariant is now enforced on-chain: last destination absorbs rounding remainder ensuring exact accounting"
+        ]
+      },
+      {
+        "version": "2.4.0",
+        "release_date": "2026-04-23",
+        "changes": [
+          "Added per-bounty fee routing invariants (Issue #50)",
+          "New set_fee_routing entrypoint: admin sets treasury/partner split (basis points) per bounty; shares must sum to 10 000",
+          "New get_fee_routing view: returns PerBountyFeeRouting or None when no override is set",
+          "New PerBountyFeeRouting storage type with treasury_recipient, treasury_bps, partner_recipient, partner_bps",
+          "New DataKey::PerBountyFeeRouting(u64) for upgrade-safe persistent storage",
+          "route_fee_for_bounty internal helper: uses per-bounty routing when set, falls back to global route_fee",
+          "Emits FeeRoutingUpdated event on set_fee_routing for audit trail",
+          "Emits FeeRouted event on every per-bounty fee split for indexer visibility",
+          "Emits FeeRoutingInvariantChecked event proving distributed_total == fee_amount on every per-bounty routing call",
+          "Invariant enforced on-chain: panic if distributed != fee_amount (impossible in correct execution)",
+          "All lock, release, and recurring-lock paths now use route_fee_for_bounty"
         ]
       }
     ]
@@ -876,9 +893,65 @@
         "authorization": "admin",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "set_fee_routing",
+        "description": "Set a per-bounty fee routing override. Fees collected for this bounty are split between treasury_recipient and an optional partner_recipient according to the supplied basis-point shares. treasury_bps + partner_bps must equal 10 000. Emits FeeRoutingUpdated.",
+        "parameters": [
+          {
+            "name": "bounty_id",
+            "type": "u64",
+            "description": "Bounty to configure routing for. Must exist."
+          },
+          {
+            "name": "treasury_recipient",
+            "type": "Address",
+            "description": "Primary treasury address that receives its share of the fee."
+          },
+          {
+            "name": "treasury_bps",
+            "type": "i128",
+            "description": "Treasury share in basis points (0–10 000). Must equal 10 000 when no partner."
+          },
+          {
+            "name": "partner_recipient",
+            "type": "Option<Address>",
+            "description": "Optional partner/referral address.",
+            "optional": true
+          },
+          {
+            "name": "partner_bps",
+            "type": "i128",
+            "description": "Partner share in basis points (0–10 000). Must be 0 when partner_recipient is None."
+          }
+        ],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ]
   },
+  "view_entrypoints_fee_routing": [
+    {
+      "name": "get_fee_routing",
+      "description": "Return the per-bounty fee routing override for bounty_id, or None when no override is set.",
+      "parameters": [
+        {
+          "name": "bounty_id",
+          "type": "u64",
+          "description": "Bounty identifier"
+        }
+      ],
+      "returns": {
+        "type": "Option<PerBountyFeeRouting>",
+        "description": "Per-bounty routing config, or None if using global routing."
+      },
+      "authorization": "any",
+      "pausable": false,
+      "gas_estimate": "low"
+    }
+  ],
   "configuration": {
     "parameters": [
       {
@@ -1049,6 +1122,12 @@
         "type": "instance",
         "description": "Paginated index of blocklisted addresses",
         "data_structure": "Vec<Address>"
+      },
+      {
+        "name": "PerBountyFeeRouting",
+        "type": "persistent",
+        "description": "Per-bounty fee routing override keyed by bounty_id. When present, overrides global treasury routing for that bounty.",
+        "data_structure": "PerBountyFeeRouting"
       }
     ]
   },

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -864,6 +864,9 @@ pub enum DataKey {
     FeeRoutingSchemaVersion,
     /// Runtime-configurable batch size caps for lock and release operations.
     BatchSizeCaps,
+    /// Per-bounty fee routing override: `bounty_id -> PerBountyFeeRouting`.
+    /// When present, overrides the global treasury routing for that specific bounty.
+    PerBountyFeeRouting(u64),
 }
 
 #[contracttype]
@@ -957,6 +960,32 @@ pub struct BatchSizeCaps {
     pub lock_cap: u32,
     /// Maximum allowed item count for `batch_release_funds`.
     pub release_cap: u32,
+}
+
+/// Per-bounty fee routing override.
+///
+/// When set for a specific `bounty_id`, the fee collected on lock and release
+/// for that bounty is split between a primary treasury and an optional partner
+/// instead of using the global `FeeConfig` routing.
+///
+/// # Invariant
+/// `treasury_bps + partner_bps == 10_000` (100 %) when `partner_recipient` is
+/// `Some`. When `partner_recipient` is `None`, `treasury_bps` must equal
+/// `10_000` and `partner_bps` must be `0`.
+///
+/// The fee *amount* is still computed from the global or per-token rate; this
+/// struct only controls *where* the collected fee is sent.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerBountyFeeRouting {
+    /// Primary treasury recipient for this bounty's fees.
+    pub treasury_recipient: Address,
+    /// Treasury share in basis points (0–10 000).
+    pub treasury_bps: i128,
+    /// Optional partner / referral recipient.
+    pub partner_recipient: Option<Address>,
+    /// Partner share in basis points (0–10 000). Must be 0 when `partner_recipient` is `None`.
+    pub partner_bps: i128,
 }
 
 /// Per-token fee configuration.
@@ -1711,6 +1740,220 @@ impl BountyEscrowContract {
             fee_config.treasury_destinations,
             fee_config.distribution_enabled,
         )
+    }
+
+    // ── Per-bounty fee routing ────────────────────────────────────────────────
+
+    /// Set a per-bounty fee routing override (admin only).
+    ///
+    /// When set, fees collected for `bounty_id` are split between
+    /// `treasury_recipient` and an optional `partner_recipient` according to
+    /// the supplied basis-point shares instead of using the global routing.
+    ///
+    /// # Invariants enforced
+    /// - `treasury_bps + partner_bps == 10_000` (shares must sum to 100 %).
+    /// - `partner_bps == 0` when `partner_recipient` is `None`.
+    /// - Both shares must be in `[0, 10_000]`.
+    /// - The bounty must exist in persistent storage.
+    ///
+    /// # Errors
+    /// * `NotInitialized`  – contract not yet initialised.
+    /// * `BountyNotFound`  – `bounty_id` does not exist.
+    /// * `InvalidAmount`   – share invariant violated.
+    pub fn set_fee_routing(
+        env: Env,
+        bounty_id: u64,
+        treasury_recipient: Address,
+        treasury_bps: i128,
+        partner_recipient: Option<Address>,
+        partner_bps: i128,
+    ) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        // Bounty must exist (regular or anonymous).
+        if !env.storage().persistent().has(&DataKey::Escrow(bounty_id))
+            && !env.storage().persistent().has(&DataKey::EscrowAnon(bounty_id))
+        {
+            return Err(Error::BountyNotFound);
+        }
+
+        // Validate share invariants.
+        if treasury_bps < 0 || treasury_bps > BASIS_POINTS {
+            return Err(Error::InvalidAmount);
+        }
+        if partner_bps < 0 || partner_bps > BASIS_POINTS {
+            return Err(Error::InvalidAmount);
+        }
+        match &partner_recipient {
+            None => {
+                // No partner: treasury must take 100 % and partner_bps must be 0.
+                if treasury_bps != BASIS_POINTS || partner_bps != 0 {
+                    return Err(Error::InvalidAmount);
+                }
+            }
+            Some(_) => {
+                // Partner present: shares must sum to exactly 100 %.
+                if treasury_bps.checked_add(partner_bps).unwrap_or(-1) != BASIS_POINTS {
+                    return Err(Error::InvalidAmount);
+                }
+            }
+        }
+
+        let routing = PerBountyFeeRouting {
+            treasury_recipient: treasury_recipient.clone(),
+            treasury_bps,
+            partner_recipient: partner_recipient.clone(),
+            partner_bps,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PerBountyFeeRouting(bounty_id), &routing);
+
+        events::emit_fee_routing_updated(
+            &env,
+            events::FeeRoutingUpdated {
+                version: EVENT_VERSION_V2,
+                bounty_id,
+                treasury_recipient,
+                treasury_bps,
+                partner_recipient,
+                partner_bps,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Return the per-bounty fee routing override for `bounty_id`, if one has been set.
+    ///
+    /// Returns `None` when no override exists; callers should fall back to the
+    /// global `FeeConfig` routing in that case.
+    pub fn get_fee_routing(env: Env, bounty_id: u64) -> Option<PerBountyFeeRouting> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PerBountyFeeRouting(bounty_id))
+    }
+
+    /// Internal: route a fee using per-bounty routing when available, falling back to
+    /// the global `route_fee` path.
+    ///
+    /// Emits [`events::FeeRouted`] when per-bounty routing is active so indexers can
+    /// reconstruct the exact split without inspecting storage.
+    fn route_fee_for_bounty(
+        env: &Env,
+        client: &token::Client,
+        config: &FeeConfig,
+        bounty_id: u64,
+        fee_amount: i128,
+        fee_rate: i128,
+        gross_amount: i128,
+        operation_type: events::FeeOperationType,
+    ) -> Result<(), Error> {
+        if fee_amount <= 0 {
+            return Ok(());
+        }
+
+        // Check for a per-bounty routing override.
+        let maybe_routing: Option<PerBountyFeeRouting> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PerBountyFeeRouting(bounty_id));
+
+        match maybe_routing {
+            None => {
+                // No per-bounty override — use the global route_fee path.
+                Self::route_fee(env, client, config, bounty_id, fee_amount, fee_rate, operation_type)
+            }
+            Some(routing) => {
+                // Per-bounty routing: split fee between treasury and optional partner.
+                // Invariant: treasury_share + partner_share == fee_amount (last leg absorbs remainder).
+                let treasury_share = if routing.partner_recipient.is_some() {
+                    fee_amount
+                        .checked_mul(routing.treasury_bps)
+                        .and_then(|v| v.checked_div(BASIS_POINTS))
+                        .ok_or(Error::InvalidAmount)?
+                } else {
+                    fee_amount
+                };
+
+                let partner_share = fee_amount
+                    .checked_sub(treasury_share)
+                    .ok_or(Error::InvalidAmount)?;
+
+                // Transfer treasury share.
+                if treasury_share > 0 {
+                    client.transfer(
+                        &env.current_contract_address(),
+                        &routing.treasury_recipient,
+                        &treasury_share,
+                    );
+                }
+
+                // Transfer partner share (if any).
+                if partner_share > 0 {
+                    if let Some(ref partner) = routing.partner_recipient {
+                        client.transfer(
+                            &env.current_contract_address(),
+                            partner,
+                            &partner_share,
+                        );
+                    }
+                }
+
+                // Verify invariant: distributed == fee_amount.
+                let distributed = treasury_share
+                    .checked_add(partner_share)
+                    .ok_or(Error::InvalidAmount)?;
+                let invariant_ok = distributed == fee_amount;
+
+                // Emit FeeRouted audit event.
+                events::emit_fee_routed(
+                    env,
+                    events::FeeRouted {
+                        version: EVENT_VERSION_V2,
+                        bounty_id,
+                        operation_type: operation_type.clone(),
+                        gross_amount,
+                        total_fee: fee_amount,
+                        fee_rate,
+                        treasury_recipient: routing.treasury_recipient.clone(),
+                        treasury_fee: treasury_share,
+                        partner_recipient: routing.partner_recipient.clone(),
+                        partner_fee: partner_share,
+                        timestamp: env.ledger().timestamp(),
+                    },
+                );
+
+                // Emit invariant-checked audit event.
+                events::emit_fee_routing_invariant_checked(
+                    env,
+                    events::FeeRoutingInvariantChecked {
+                        version: EVENT_VERSION_V2,
+                        bounty_id,
+                        operation_type,
+                        gross_amount,
+                        fee_amount,
+                        distributed_total: distributed,
+                        weight_total: BASIS_POINTS as u64,
+                        destination_count: if routing.partner_recipient.is_some() { 2 } else { 1 },
+                        invariant_ok,
+                        timestamp: env.ledger().timestamp(),
+                    },
+                );
+
+                if !invariant_ok {
+                    panic!("Fee routing invariant violated: distributed != fee_amount");
+                }
+
+                Ok(())
+            }
+        }
     }
 
     /// Updates the granular pause state and metadata for the contract.
@@ -3244,13 +3487,14 @@ impl BountyEscrowContract {
         // Transfer fee to recipient immediately (separate transfer so it is
         // visible as a distinct on-chain operation).
         if fee_amount > 0 {
-            if let Err(err) = Self::route_fee(
+            if let Err(err) = Self::route_fee_for_bounty(
                 &env,
                 &client,
                 &fee_config,
                 bounty_id,
                 fee_amount,
                 lock_fee_rate,
+                amount,
                 events::FeeOperationType::Lock,
             ) {
                 reentrancy_guard::release(&env);
@@ -3841,13 +4085,14 @@ impl BountyEscrowContract {
         let client = token::Client::new(&env, &token_addr);
 
         if release_fee > 0 {
-            Self::route_fee(
+            Self::route_fee_for_bounty(
                 &env,
                 &client,
                 &fee_config,
                 bounty_id,
                 release_fee,
                 release_fee_rate,
+                escrow.amount,
                 events::FeeOperationType::Release,
             )?;
         }
@@ -7188,13 +7433,14 @@ mod escrow_status_transition_tests {
         // Route fee
         if fee_amount > 0 {
             let fee_config = Self::get_fee_config_internal(&env);
-            Self::route_fee(
+            Self::route_fee_for_bounty(
                 &env,
                 &client,
                 &fee_config,
                 sub_bounty_id,
                 fee_amount,
                 lock_fee_rate,
+                amount,
                 events::FeeOperationType::Lock,
             )?;
         }

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -955,3 +955,316 @@ fn test_claim_window_expired_event_emitted_on_failure() {
     });
     assert!(found, "ClaimWindowExpired event not emitted");
 }
+
+// ============================================================================
+// FEE ROUTING INVARIANTS TESTS (Issue #50)
+// ============================================================================
+
+/// Helper: configure a 2% lock fee and 1% release fee on the global config.
+fn setup_fee_config(setup: &TestSetup, fee_recipient: &Address) {
+    setup.escrow.update_fee_config(
+        &Some(200i128),  // 2% lock fee
+        &Some(100i128),  // 1% release fee
+        &None,
+        &None,
+        &Some(fee_recipient.clone()),
+        &Some(true),
+    );
+}
+
+// --- set_fee_routing: basic happy path ---
+
+#[test]
+fn test_set_fee_routing_treasury_only() {
+    let setup = TestSetup::new();
+    let bounty_id = 400u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    let treasury = Address::generate(&setup.env);
+    // treasury_bps = 10_000 (100%), no partner
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &10_000i128, &None, &0i128);
+
+    let routing = setup.escrow.get_fee_routing(&bounty_id).expect("routing must be set");
+    assert_eq!(routing.treasury_recipient, treasury);
+    assert_eq!(routing.treasury_bps, 10_000);
+    assert!(routing.partner_recipient.is_none());
+    assert_eq!(routing.partner_bps, 0);
+}
+
+#[test]
+fn test_set_fee_routing_with_partner() {
+    let setup = TestSetup::new();
+    let bounty_id = 401u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    let treasury = Address::generate(&setup.env);
+    let partner = Address::generate(&setup.env);
+    // 80% treasury, 20% partner
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &8_000i128, &Some(partner.clone()), &2_000i128);
+
+    let routing = setup.escrow.get_fee_routing(&bounty_id).expect("routing must be set");
+    assert_eq!(routing.treasury_bps, 8_000);
+    assert_eq!(routing.partner_recipient, Some(partner));
+    assert_eq!(routing.partner_bps, 2_000);
+}
+
+// --- set_fee_routing: invariant violations ---
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_set_fee_routing_shares_dont_sum_to_10000_rejected() {
+    let setup = TestSetup::new();
+    let bounty_id = 402u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    let treasury = Address::generate(&setup.env);
+    let partner = Address::generate(&setup.env);
+    // 70% + 20% = 90% — must be rejected (InvalidAmount = 13)
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &7_000i128, &Some(partner), &2_000i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_set_fee_routing_treasury_only_wrong_bps_rejected() {
+    let setup = TestSetup::new();
+    let bounty_id = 403u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    let treasury = Address::generate(&setup.env);
+    // No partner but treasury_bps != 10_000 — must be rejected
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &9_000i128, &None, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #202)")]
+fn test_set_fee_routing_bounty_not_found_rejected() {
+    let setup = TestSetup::new();
+    let treasury = Address::generate(&setup.env);
+    // Bounty 999 does not exist
+    setup.escrow.set_fee_routing(&999u64, &treasury, &10_000i128, &None, &0i128);
+}
+
+// --- get_fee_routing: returns None when not set ---
+
+#[test]
+fn test_get_fee_routing_returns_none_when_unset() {
+    let setup = TestSetup::new();
+    let bounty_id = 404u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    assert!(setup.escrow.get_fee_routing(&bounty_id).is_none());
+}
+
+// --- fee routing invariant: treasury-only routing ---
+
+#[test]
+fn test_fee_routing_treasury_only_receives_full_fee_on_lock() {
+    let setup = TestSetup::new();
+    let bounty_id = 405u64;
+    let gross = 100_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+
+    let treasury = Address::generate(&setup.env);
+    let fee_recipient = Address::generate(&setup.env);
+
+    // Enable 2% lock fee globally
+    setup_fee_config(&setup, &fee_recipient);
+
+    // Lock first so bounty exists, then set routing
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &gross, &deadline);
+    // fee = ceil(100_000 * 200 / 10_000) = 2_000 already went to fee_recipient (no routing yet)
+    // Now set routing for a NEW bounty
+    let bounty_id2 = 406u64;
+    setup.token_admin.mint(&setup.depositor, &gross);
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id2, &gross, &deadline);
+    setup.escrow.set_fee_routing(&bounty_id2, &treasury, &10_000i128, &None, &0i128);
+
+    // Lock a third bounty that has routing pre-set — but routing is set after lock,
+    // so we test release routing instead.
+    let token_client = soroban_sdk::token::TokenClient::new(&setup.env, &setup.token.address);
+    let treasury_balance_before = token_client.balance(&treasury);
+
+    // Release bounty_id2 — release fee (1%) should go to treasury via per-bounty routing
+    setup.escrow.release_funds(&bounty_id2, &setup.contributor);
+
+    // release fee = ceil(net_amount * 100 / 10_000)
+    // net_amount after 2% lock fee = 100_000 - 2_000 = 98_000
+    // release fee = ceil(98_000 * 100 / 10_000) = 980
+    let treasury_balance_after = token_client.balance(&treasury);
+    assert_eq!(
+        treasury_balance_after - treasury_balance_before,
+        980,
+        "treasury must receive the full release fee via per-bounty routing"
+    );
+}
+
+#[test]
+fn test_fee_routing_partner_split_invariant_holds() {
+    let setup = TestSetup::new();
+    let bounty_id = 407u64;
+    let gross = 100_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+
+    let treasury = Address::generate(&setup.env);
+    let partner = Address::generate(&setup.env);
+    let fee_recipient = Address::generate(&setup.env);
+
+    setup_fee_config(&setup, &fee_recipient);
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &gross, &deadline);
+    // Set 70/30 split for release fee
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &7_000i128, &Some(partner.clone()), &3_000i128);
+
+    let token_client = soroban_sdk::token::TokenClient::new(&setup.env, &setup.token.address);
+    let treasury_before = token_client.balance(&treasury);
+    let partner_before = token_client.balance(&partner);
+
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // net_amount = 100_000 - 2_000 = 98_000
+    // release fee = ceil(98_000 * 100 / 10_000) = 980
+    // treasury share = floor(980 * 7_000 / 10_000) = 686
+    // partner share = 980 - 686 = 294
+    let treasury_after = token_client.balance(&treasury);
+    let partner_after = token_client.balance(&partner);
+
+    let treasury_received = treasury_after - treasury_before;
+    let partner_received = partner_after - partner_before;
+
+    // Invariant: treasury + partner == total fee
+    assert_eq!(
+        treasury_received + partner_received,
+        980,
+        "fee routing invariant: treasury + partner must equal total release fee"
+    );
+    assert_eq!(treasury_received, 686, "treasury must receive 70% of fee");
+    assert_eq!(partner_received, 294, "partner must receive 30% of fee");
+}
+
+// --- audit event emission ---
+
+#[test]
+fn test_set_fee_routing_emits_fee_routing_updated_event() {
+    let setup = TestSetup::new();
+    let bounty_id = 408u64;
+    let amount = 10_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+
+    let treasury = Address::generate(&setup.env);
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &10_000i128, &None, &0i128);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "fee_rte").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "FeeRoutingUpdated event must be emitted by set_fee_routing");
+}
+
+#[test]
+fn test_fee_routing_emits_fee_routed_event_on_release() {
+    let setup = TestSetup::new();
+    let bounty_id = 409u64;
+    let gross = 50_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+
+    let treasury = Address::generate(&setup.env);
+    let fee_recipient = Address::generate(&setup.env);
+    setup_fee_config(&setup, &fee_recipient);
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &gross, &deadline);
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &10_000i128, &None, &0i128);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "fee_rt").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "FeeRouted event must be emitted when per-bounty routing is active");
+}
+
+#[test]
+fn test_fee_routing_emits_invariant_checked_event() {
+    let setup = TestSetup::new();
+    let bounty_id = 410u64;
+    let gross = 50_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+
+    let treasury = Address::generate(&setup.env);
+    let fee_recipient = Address::generate(&setup.env);
+    setup_fee_config(&setup, &fee_recipient);
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &gross, &deadline);
+    setup.escrow.set_fee_routing(&bounty_id, &treasury, &10_000i128, &None, &0i128);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "fee_inv").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "FeeRoutingInvariantChecked event must be emitted");
+}
+
+// --- upgrade-safe schema version ---
+
+#[test]
+fn test_fee_routing_schema_version_set_on_init() {
+    let setup = TestSetup::new();
+    // FeeRoutingSchemaVersion must be written during init
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "fee_schm").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "FeeRoutingSchemaVersionSet event must be emitted during init");
+}
+
+// --- fallback: no per-bounty routing uses global path ---
+
+#[test]
+fn test_no_per_bounty_routing_falls_back_to_global() {
+    let setup = TestSetup::new();
+    let bounty_id = 411u64;
+    let gross = 100_000i128;
+    let deadline = setup.env.ledger().timestamp() + 1_000;
+
+    let fee_recipient = Address::generate(&setup.env);
+    setup_fee_config(&setup, &fee_recipient);
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &gross, &deadline);
+    // No set_fee_routing call — global path should be used
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    let token_client = soroban_sdk::token::TokenClient::new(&setup.env, &setup.token.address);
+    // release fee = ceil(98_000 * 100 / 10_000) = 980 → goes to fee_recipient
+    assert_eq!(
+        token_client.balance(&fee_recipient),
+        // lock fee (2_000) + release fee (980)
+        2_980,
+        "global fee_recipient must receive both lock and release fees when no per-bounty routing"
+    );
+}


### PR DESCRIPTION
---

**feat(bounty-escrow): fee routing invariants (#50)**

**Summary**

closes #1042

Implements per-bounty fee routing with enforced on-chain invariants, full audit event coverage, and upgrade-safe storage — closing issue #50.

**Changes**

`lib.rs`
- `PerBountyFeeRouting` struct: `treasury_recipient`, `treasury_bps`, `partner_recipient` (Option), `partner_bps`
- `DataKey::PerBountyFeeRouting(u64)` — persistent, upgrade-safe alongside existing `FeeRoutingSchemaVersion` marker
- `set_fee_routing` (admin-only): enforces `treasury_bps + partner_bps == 10_000`; emits `FeeRoutingUpdated`
- `get_fee_routing` (view): returns `Option<PerBountyFeeRouting>`
- `route_fee_for_bounty` internal helper: uses per-bounty routing when present, falls back to global `route_fee`; emits `FeeRouted` + `FeeRoutingInvariantChecked`; panics (reverts) if `distributed != fee_amount`
- Wired `lock_funds_logic`, `release_funds_logic`, and recurring-lock path to use `route_fee_for_bounty`

`test_status_transitions.rs` — 13 new tests:
- Treasury-only and treasury+partner happy paths
- Share invariant violations (don't sum to 10_000, wrong treasury_bps without partner)
- `BountyNotFound` guard on `set_fee_routing`
- `get_fee_routing` returns `None` when unset
- Release fee correctly routed to treasury via per-bounty routing
- 70/30 partner split: `treasury_received + partner_received == total_fee` (invariant)
- `FeeRoutingUpdated`, `FeeRouted`, `FeeRoutingInvariantChecked` event emission verified
- `FeeRoutingSchemaVersionSet` emitted during `init`
- Fallback to global routing when no per-bounty override is set

`bounty-escrow-manifest.json`
- Version bumped `2.1.1 → 2.4.0`
- `set_fee_routing` admin entrypoint documented
- `get_fee_routing` view entrypoint documented
- `PerBountyFeeRouting` storage key documented

**Security invariants**
- `treasury_bps + partner_bps == 10_000` enforced on-chain (`InvalidAmount` on violation)
- `distributed_total == fee_amount` enforced on-chain (panic = atomic revert)
- `FeeRoutingInvariantChecked.invariant_ok` is always `true` on-chain; any `false` is caught and reverted
- Admin-only write; permissionless read
- Bounty must exist before routing can be set (`BountyNotFound` guard)
- CEI ordering preserved throughout