### PR TITLE
feat(program-escrow): spend limits thresholds

### DIFF
--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -3,7 +3,7 @@
   "contract_name": "ProgramEscrowContract",
   "contract_purpose": "Handles hackathon and program prize pools with batch payouts, dependency management, circuit breaker protection, and comprehensive monitoring",
   "version": {
-    "current": "2.4.0",
+    "current": "2.5.0",
     "schema": "1.0.0",
     "history": [
       {
@@ -72,8 +72,21 @@
           "Pause checks remain deterministic: release_paused blocks single_payout and batch_payout; lock_paused blocks lock_program_funds; flags are orthogonal",
           "Added 16 targeted tests in test.rs covering pause invariants, V2 event fields, schema version, and edge cases"
         ]
-      }
-          "Deterministic error ordering preserved: threshold check runs before balance and circuit-breaker checks"
+      },
+      {
+        "version": "2.5.0",
+        "release_date": "2026-04-24",
+        "changes": [
+          "Added ProgramSpendingConfig struct (window_size, max_amount, enabled) for per-window spend limits",
+          "Added ProgramSpendingState struct (window_start, amount_released) for runtime window tracking",
+          "Added DataKey::SpendingConfig and DataKey::SpendingState for upgrade-safe persistent storage",
+          "Added set_program_spending_limit entrypoint — authorized_payout_key only, validates window_size > 0 and max_amount >= 0",
+          "Added get_program_spending_limit and get_program_spending_state view entrypoints",
+          "Enforcement hooked into batch_payout, single_payout, release_program_schedule_manual, and release_prog_schedule_automatic",
+          "Window resets automatically when current_time - window_start >= window_size",
+          "Rejection emits (limit, prg_spend) event with (program_id, token, amount, new_total, max_amount, window_size) before panicking",
+          "Disabled limits (enabled=false) are stored but not enforced — no behaviour change for existing programs",
+          "Added 15 targeted tests covering: no-limit passthrough, disabled limit, within-limit, cumulative enforcement, window reset, view functions, validation errors, event emission, and limit updates"
         ]
       }
     ]
@@ -256,6 +269,39 @@
           "description": "Empty on success"
         },
         "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "set_program_spending_limit",
+        "description": "Set or update the per-window spending limit for a program. Only the program's authorized_payout_key may call this.",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          },
+          {
+            "name": "window_size",
+            "type": "u64",
+            "description": "Window length in seconds (must be > 0)"
+          },
+          {
+            "name": "max_amount",
+            "type": "i128",
+            "description": "Maximum total releasable in one window (must be >= 0)"
+          },
+          {
+            "name": "enabled",
+            "type": "bool",
+            "description": "If false, config is stored but not enforced"
+          }
+        ],
+        "returns": {
+          "type": "()",
+          "description": "Empty on success"
+        },
+        "authorization": "authorized_payout_key",
         "pausable": false,
         "gas_estimate": "low"
       },
@@ -483,6 +529,42 @@
         "returns": {
           "type": "u32",
           "description": "Schema version (1 = current; 0 = legacy pre-v2.3)"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_program_spending_limit",
+        "description": "Return the per-window spending limit configuration for a program, or None if not set.",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          }
+        ],
+        "returns": {
+          "type": "Option<ProgramSpendingConfig>",
+          "description": "Spending limit config (window_size, max_amount, enabled), or None"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_program_spending_state",
+        "description": "Return the current window state for a program's spending limit, or None if no payout has occurred yet.",
+        "parameters": [
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program identifier"
+          }
+        ],
+        "returns": {
+          "type": "Option<ProgramSpendingState>",
+          "description": "Window state (window_start, amount_released), or None"
         },
         "authorization": "any",
         "pausable": false,

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -599,6 +599,34 @@ const SPEND_LIMIT_SET: Symbol = symbol_short!("SpLimSet");
 const SPEND_LIMIT_EXCEEDED: Symbol = symbol_short!("SpLimExc");
 const SPEND_LIMIT_SCHEMA: Symbol = symbol_short!("SpLimSch");
 
+// Event symbol for per-window spending limit rejection
+const PROG_SPEND_LIMIT: Symbol = symbol_short!("limit");
+
+/// Per-program, per-window spending limit configuration.
+///
+/// Set by the program's `authorized_payout_key`. When `enabled` is `false`
+/// the limit is stored but not enforced.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramSpendingConfig {
+    /// Window length in seconds (e.g. 86400 = 1 day).
+    pub window_size: u64,
+    /// Maximum total amount (token's smallest unit) releasable in one window.
+    pub max_amount: i128,
+    /// Whether enforcement is active.
+    pub enabled: bool,
+}
+
+/// Runtime state for the per-window spending limit.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramSpendingState {
+    /// Ledger timestamp when the current window started.
+    pub window_start: u64,
+    /// Cumulative amount released in the current window.
+    pub amount_released: i128,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
@@ -625,6 +653,10 @@ pub enum DataKey {
     /// Upgrade-safe schema version marker for pause flags storage.
     /// Written on init; increment when `PauseFlags` layout changes.
     PauseSchemaVersion,
+    /// Per-program, per-window spending limit configuration.
+    SpendingConfig(String),
+    /// Per-program, per-window spending limit runtime state.
+    SpendingState(String),
 }
 
 #[contracttype]
@@ -2592,6 +2624,131 @@ impl ProgramEscrowContract {
         Ok(())
     }
 
+    // ========================================================================
+    // Per-Window Spending Limits (Issue #25)
+    // ========================================================================
+
+    /// Set or update the per-window spending limit for a program.
+    ///
+    /// Only the program's `authorized_payout_key` may call this.
+    ///
+    /// # Arguments
+    /// * `program_id`   - Program to configure.
+    /// * `window_size`  - Window length in seconds (must be > 0).
+    /// * `max_amount`   - Max total releasable in one window (must be >= 0).
+    /// * `enabled`      - `false` stores the config without enforcing it.
+    pub fn set_program_spending_limit(
+        env: Env,
+        program_id: String,
+        window_size: u64,
+        max_amount: i128,
+        enabled: bool,
+    ) {
+        let program_data = Self::get_program_data_by_id(&env, &program_id);
+        program_data.authorized_payout_key.require_auth();
+
+        if window_size == 0 {
+            panic!("window_size must be greater than zero");
+        }
+        if max_amount < 0 {
+            panic!("max_amount must be non-negative");
+        }
+
+        let cfg = ProgramSpendingConfig {
+            window_size,
+            max_amount,
+            enabled,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::SpendingConfig(program_id), &cfg);
+    }
+
+    /// Return the spending limit configuration for a program, if set.
+    pub fn get_program_spending_limit(env: Env, program_id: String) -> Option<ProgramSpendingConfig> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SpendingConfig(program_id))
+    }
+
+    /// Return the current window state for a program's spending limit, if any.
+    pub fn get_program_spending_state(env: Env, program_id: String) -> Option<ProgramSpendingState> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SpendingState(program_id))
+    }
+
+    /// Enforce the per-window spending limit and update the window state.
+    ///
+    /// Called before any token transfer. Emits `(limit, prog_spend)` and panics
+    /// with "Program spending limit exceeded for current window" when the limit
+    /// would be exceeded.
+    ///
+    /// If no config is set or `enabled` is `false`, this is a no-op.
+    fn enforce_spending_window(env: &Env, program_id: &String, amount: i128) {
+        let cfg: ProgramSpendingConfig = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::SpendingConfig(program_id.clone()))
+        {
+            Some(c) => c,
+            None => return,
+        };
+
+        if !cfg.enabled {
+            return;
+        }
+
+        let now = env.ledger().timestamp();
+        let mut state: ProgramSpendingState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SpendingState(program_id.clone()))
+            .unwrap_or(ProgramSpendingState {
+                window_start: now,
+                amount_released: 0,
+            });
+
+        // Reset window if expired
+        if now.saturating_sub(state.window_start) >= cfg.window_size {
+            state.window_start = now;
+            state.amount_released = 0;
+        }
+
+        let new_total = state
+            .amount_released
+            .checked_add(amount)
+            .unwrap_or_else(|| panic!("Spending window overflow"));
+
+        if new_total > cfg.max_amount {
+            let program_data: ProgramData = env
+                .storage()
+                .instance()
+                .get(&PROGRAM_DATA)
+                .unwrap_or_else(|| panic!("Program not initialized"));
+
+            // Emit rejection event before panicking (CEI: event before state change)
+            env.events().publish(
+                (PROG_SPEND_LIMIT, symbol_short!("prg_spend")),
+                (
+                    program_id.clone(),
+                    program_data.token_address,
+                    amount,
+                    new_total,
+                    cfg.max_amount,
+                    cfg.window_size,
+                ),
+            );
+            panic!("Program spending limit exceeded for current window");
+        }
+
+        // Commit updated state
+        state.amount_released = new_total;
+        env.storage()
+            .persistent()
+            .set(&DataKey::SpendingState(program_id.clone()), &state);
+    }
+
     pub fn get_analytics(_env: Env) -> Analytics {
         Analytics {
             total_locked: 0,
@@ -2719,6 +2876,9 @@ impl ProgramEscrowContract {
             reentrancy_guard::clear_entered(&env);
             panic!("Spend threshold exceeded");
         }
+
+        // Per-window spending limit check (after per-payout threshold, before balance)
+        Self::enforce_spending_window(&env, &program_data.program_id, total_payout);
 
         if total_payout > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
@@ -2892,6 +3052,9 @@ impl ProgramEscrowContract {
             reentrancy_guard::clear_entered(&env);
             panic!("Spend threshold exceeded");
         }
+
+        // Per-window spending limit check (after per-payout threshold, before balance)
+        Self::enforce_spending_window(&env, &program_data.program_id, amount);
 
         if amount > program_data.remaining_balance {
             reentrancy_guard::clear_entered(&env);
@@ -3748,6 +3911,9 @@ impl ProgramEscrowContract {
                     panic!("Already released");
                 }
 
+                // Per-window spending limit check before transfer
+                Self::enforce_spending_window(&env, &program_data.program_id, s.amount);
+
                 // Transfer funds
                 let token_client = token::Client::new(&env, &program_data.token_address);
                 token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
@@ -3808,6 +3974,9 @@ impl ProgramEscrowContract {
                 if now < s.release_timestamp {
                     panic!("Not yet due");
                 }
+
+                // Per-window spending limit check before transfer
+                Self::enforce_spending_window(&env, &program_data.program_id, s.amount);
 
                 // Transfer funds
                 let token_client = token::Client::new(&env, &program_data.token_address);

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -34,7 +34,7 @@ fn setup_program(
         &None,
         &None,
     );
-    client.publish_program();
+    client.publish_program(&program_id);
 
     if initial_amount > 0 {
         token_admin_client.mint(&client.address, &initial_amount);
@@ -2753,6 +2753,238 @@ fn test_spend_limit_negative_threshold_rejected() {
     let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
     let program_id = client.get_program_info().program_id;
     client.set_program_spend_threshold(&program_id, &-1);
+}
+
+// ============================================================================
+// PER-WINDOW SPENDING LIMITS — Issue #25
+// ============================================================================
+// Tests for time-windowed spend limits: set/get config, enforcement in
+// single_payout, batch_payout, schedule releases, window reset, and events.
+
+/// SW-1: No limit set → payouts proceed without restriction.
+#[test]
+fn test_spending_window_no_limit_allows_payout() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let recipient = Address::generate(&env);
+
+    client.single_payout(&recipient, &10_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+/// SW-2: Limit disabled (enabled=false) → payouts proceed even if amount > max_amount.
+#[test]
+fn test_spending_window_disabled_limit_allows_payout() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &100i128, &false);
+    client.single_payout(&recipient, &10_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+/// SW-3: single_payout within window limit succeeds.
+#[test]
+fn test_spending_window_single_payout_within_limit_succeeds() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &5_000i128, &true);
+    client.single_payout(&recipient, &5_000);
+    assert_eq!(token_client.balance(&recipient), 5_000);
+}
+
+/// SW-4: single_payout exceeding window limit is rejected.
+#[test]
+#[should_panic(expected = "Program spending limit exceeded for current window")]
+fn test_spending_window_single_payout_exceeds_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &3_000i128, &true);
+    client.single_payout(&recipient, &3_001);
+}
+
+/// SW-5: Cumulative payouts within window are tracked; second payout that
+///        would push total over limit is rejected.
+#[test]
+#[should_panic(expected = "Program spending limit exceeded for current window")]
+fn test_spending_window_cumulative_limit_enforced() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    // Window limit = 5_000; first payout = 3_000 (ok), second = 3_000 (total 6_000 > 5_000)
+    client.set_program_spending_limit(&program_id, &86400u64, &5_000i128, &true);
+    client.single_payout(&r1, &3_000);
+    client.single_payout(&r2, &3_000); // must panic
+}
+
+/// SW-6: batch_payout total within window limit succeeds.
+#[test]
+fn test_spending_window_batch_payout_within_limit_succeeds() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &6_000i128, &true);
+    client.batch_payout(
+        &soroban_sdk::vec![&env, r1.clone(), r2.clone()],
+        &soroban_sdk::vec![&env, 2_000i128, 3_000i128],
+    );
+    assert_eq!(token_client.balance(&r1), 2_000);
+    assert_eq!(token_client.balance(&r2), 3_000);
+}
+
+/// SW-7: batch_payout total exceeding window limit is rejected.
+#[test]
+#[should_panic(expected = "Program spending limit exceeded for current window")]
+fn test_spending_window_batch_payout_exceeds_limit_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &4_000i128, &true);
+    client.batch_payout(
+        &soroban_sdk::vec![&env, r1, r2],
+        &soroban_sdk::vec![&env, 2_000i128, 3_000i128], // total 5_000 > 4_000
+    );
+}
+
+/// SW-8: Window resets after window_size seconds; new window allows full limit again.
+#[test]
+fn test_spending_window_resets_after_window_expires() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 20_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    // Short window of 100 seconds, limit 5_000
+    client.set_program_spending_limit(&program_id, &100u64, &5_000i128, &true);
+
+    // Exhaust the window
+    client.single_payout(&r1, &5_000);
+    assert_eq!(token_client.balance(&r1), 5_000);
+
+    // Advance time past the window
+    env.ledger().with_mut(|l| l.timestamp += 101);
+
+    // New window: same limit available again
+    client.single_payout(&r2, &5_000);
+    assert_eq!(token_client.balance(&r2), 5_000);
+}
+
+/// SW-9: get_program_spending_limit returns None when not set.
+#[test]
+fn test_spending_window_get_limit_none_when_not_set() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+
+    let limit = client.get_program_spending_limit(&program_id);
+    assert!(limit.is_none(), "limit must be None when not configured");
+}
+
+/// SW-10: get_program_spending_state returns None before any payout.
+#[test]
+fn test_spending_window_get_state_none_before_payout() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+
+    client.set_program_spending_limit(&program_id, &86400u64, &5_000i128, &true);
+    let state = client.get_program_spending_state(&program_id);
+    assert!(state.is_none(), "state must be None before any payout");
+}
+
+/// SW-11: get_program_spending_state reflects cumulative amount after payouts.
+#[test]
+fn test_spending_window_state_tracks_cumulative_amount() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &10_000i128, &true);
+    client.single_payout(&r1, &2_000);
+    client.single_payout(&r2, &3_000);
+
+    let state = client.get_program_spending_state(&program_id).unwrap();
+    assert_eq!(state.amount_released, 5_000);
+}
+
+/// SW-12: zero window_size is rejected.
+#[test]
+#[should_panic(expected = "window_size must be greater than zero")]
+fn test_spending_window_zero_window_size_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+    client.set_program_spending_limit(&program_id, &0u64, &5_000i128, &true);
+}
+
+/// SW-13: negative max_amount is rejected.
+#[test]
+#[should_panic(expected = "max_amount must be non-negative")]
+fn test_spending_window_negative_max_amount_rejected() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 0);
+    let program_id = client.get_program_info().program_id;
+    client.set_program_spending_limit(&program_id, &86400u64, &-1i128, &true);
+}
+
+/// SW-14: Rejection emits the (limit, prog_spend) event.
+#[test]
+fn test_spending_window_rejection_emits_event() {
+    let env = Env::default();
+    let (client, _admin, _token_client, _token_admin) = setup_program(&env, 10_000);
+    let program_id = client.get_program_info().program_id;
+    let recipient = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &1_000i128, &true);
+
+    let events_before = env.events().all().len();
+    let result = client.try_single_payout(&recipient, &5_000);
+    assert!(result.is_err(), "over-limit payout must fail");
+
+    let events_after = env.events().all();
+    assert!(
+        events_after.len() > events_before,
+        "rejection event must be emitted"
+    );
+}
+
+/// SW-15: Limit can be updated; new value takes effect immediately.
+#[test]
+fn test_spending_window_limit_update_takes_effect() {
+    let env = Env::default();
+    let (client, _admin, token_client, _token_admin) = setup_program(&env, 20_000);
+    let program_id = client.get_program_info().program_id;
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.set_program_spending_limit(&program_id, &86400u64, &3_000i128, &true);
+    client.single_payout(&r1, &3_000);
+    assert_eq!(token_client.balance(&r1), 3_000);
+
+    // Raise limit
+    client.set_program_spending_limit(&program_id, &86400u64, &20_000i128, &true);
+    client.single_payout(&r2, &10_000);
+    assert_eq!(token_client.balance(&r2), 10_000);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements per-window spending limits for the Program Escrow contract.

Closes #25

---

## Changes

### `contracts/program-escrow/src/lib.rs`
- Added `ProgramSpendingConfig` struct — `{ window_size: u64, max_amount: i128, enabled: bool }`
- Added `ProgramSpendingState` struct — `{ window_start: u64, amount_released: i128 }`
- Added `DataKey::SpendingConfig(String)` and `DataKey::SpendingState(String)` — upgrade-safe persistent storage
- Added `set_program_spending_limit(program_id, window_size, max_amount, enabled)` — authorized payout key only
- Added `get_program_spending_limit()` and `get_program_spending_state()` view functions
- Added `enforce_spending_window()` internal helper with window-reset logic and CEI-ordered event emission
- Hooked enforcement into `batch_payout`, `single_payout`, `release_program_schedule_manual`, and `release_prog_schedule_automatic`

### `contracts/program-escrow/src/test.rs`
- 15 tests (SW-1 → SW-15): no-limit passthrough, disabled limit, within/over limit, cumulative tracking, window reset, view functions, validation errors, event emission, live updates

### `contracts/program-escrow-manifest.json`
- Bumped to v2.5.0
- Added `set_program_spending_limit`, `get_program_spending_limit`, `get_program_spending_state` entrypoints

---

## Behaviour

- **Scope**: per program, per token
- **Window**: fixed-size in seconds; resets automatically when `now - window_start >= window_size`
- **Enforcement**: cumulative released amount in the window is tracked; exceeding `max_amount` panics with `"Program spending limit exceeded for current window"`
- **Optional**: no config or `enabled = false` → zero behaviour change for existing programs
- **Event**: `(limit, prg_spend)` emitted with `(program_id, token, amount, new_total, max_amount, window_size)` **before** the panic (CEI ordering)

## Deterministic error ordering
Per-payout threshold → window limit → balance check

## Security notes
- Event emitted before panic so rejections are always visible on-chain
- `checked_add` on cumulative sum — panics on overflow rather than wrapping
- Disabled limits stored but never enforced — safe for existing deployments