### PR TITLE
feat(program-escrow): history pagination with deterministic behavior, explicit errors, and upgrade-safe storage

### DIFF
--- a/contracts/program-escrow-manifest.json
+++ b/contracts/program-escrow-manifest.json
@@ -3,7 +3,7 @@
   "contract_name": "ProgramEscrowContract",
   "contract_purpose": "Handles hackathon and program prize pools with batch payouts, dependency management, circuit breaker protection, and comprehensive monitoring",
   "version": {
-    "current": "2.5.0",
+    "current": "2.6.0",
     "schema": "1.0.0",
     "history": [
       {
@@ -66,9 +66,9 @@
         "changes": [
           "Added PauseStateChangedV2 audit event with version, previous_paused, and receipt_id fields for deterministic state-transition tracking",
           "PauseStateChangedV2 is emitted alongside PauseStateChanged on every set_paused call for backward compatibility",
-          "Added PauseSchemaVersion DataKey — upgrade-safe storage marker written at init",
+          "Added PauseSchemaVersion DataKey \u2014 upgrade-safe storage marker written at init",
           "Added PAUSE_SCHEMA_VERSION_V1 constant (value: 1)",
-          "Added get_pause_schema_version() view entrypoint — returns 0 for legacy pre-v1 contracts",
+          "Added get_pause_schema_version() view entrypoint \u2014 returns 0 for legacy pre-v1 contracts",
           "Pause checks remain deterministic: release_paused blocks single_payout and batch_payout; lock_paused blocks lock_program_funds; flags are orthogonal",
           "Added 16 targeted tests in test.rs covering pause invariants, V2 event fields, schema version, and edge cases"
         ]
@@ -80,13 +80,26 @@
           "Added ProgramSpendingConfig struct (window_size, max_amount, enabled) for per-window spend limits",
           "Added ProgramSpendingState struct (window_start, amount_released) for runtime window tracking",
           "Added DataKey::SpendingConfig and DataKey::SpendingState for upgrade-safe persistent storage",
-          "Added set_program_spending_limit entrypoint — authorized_payout_key only, validates window_size > 0 and max_amount >= 0",
+          "Added set_program_spending_limit entrypoint \u2014 authorized_payout_key only, validates window_size > 0 and max_amount >= 0",
           "Added get_program_spending_limit and get_program_spending_state view entrypoints",
           "Enforcement hooked into batch_payout, single_payout, release_program_schedule_manual, and release_prog_schedule_automatic",
           "Window resets automatically when current_time - window_start >= window_size",
           "Rejection emits (limit, prg_spend) event with (program_id, token, amount, new_total, max_amount, window_size) before panicking",
-          "Disabled limits (enabled=false) are stored but not enforced — no behaviour change for existing programs",
+          "Disabled limits (enabled=false) are stored but not enforced \u2014 no behaviour change for existing programs",
           "Added 15 targeted tests covering: no-limit passthrough, disabled limit, within-limit, cumulative enforcement, window reset, view functions, validation errors, event emission, and limit updates"
+        ]
+      },
+      {
+        "version": "2.6.0",
+        "release_date": "2026-04-24",
+        "changes": [
+          "Added query_payouts_by_recipient: paginated payout history filtered by recipient",
+          "Added query_payouts_by_amount: paginated payout history filtered by amount range",
+          "Added query_payouts_by_timestamp: paginated payout history filtered by timestamp range",
+          "Added query_schedules_by_recipient: paginated release schedules filtered by recipient",
+          "Added query_schedules_by_status: paginated release schedules filtered by status",
+          "Added query_releases_by_recipient: paginated release history filtered by recipient",
+          "Pagination enforces limit 1\u2013200 via HistoryPaginationConfig with upgrade-safe storage"
         ]
       }
     ]
@@ -635,6 +648,184 @@
         "authorization": "any",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "query_payouts_by_recipient",
+        "description": "Paginated payout history filtered by recipient address",
+        "parameters": [
+          {
+            "name": "recipient",
+            "type": "Address",
+            "description": "Recipient address to filter by"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<PayoutRecord>",
+          "description": "Paginated payout records for the recipient"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "query_payouts_by_amount",
+        "description": "Paginated payout history filtered by amount range (inclusive)",
+        "parameters": [
+          {
+            "name": "min_amount",
+            "type": "i128",
+            "description": "Minimum payout amount (inclusive)"
+          },
+          {
+            "name": "max_amount",
+            "type": "i128",
+            "description": "Maximum payout amount (inclusive)"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<PayoutRecord>",
+          "description": "Paginated payout records within the amount range"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "query_payouts_by_timestamp",
+        "description": "Paginated payout history filtered by timestamp range (inclusive)",
+        "parameters": [
+          {
+            "name": "min_timestamp",
+            "type": "u64",
+            "description": "Start of timestamp range (inclusive)"
+          },
+          {
+            "name": "max_timestamp",
+            "type": "u64",
+            "description": "End of timestamp range (inclusive)"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<PayoutRecord>",
+          "description": "Paginated payout records within the timestamp range"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "query_schedules_by_recipient",
+        "description": "Paginated release schedules filtered by recipient address",
+        "parameters": [
+          {
+            "name": "recipient",
+            "type": "Address",
+            "description": "Recipient address to filter by"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<ProgramReleaseSchedule>",
+          "description": "Paginated release schedules for the recipient"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "query_schedules_by_status",
+        "description": "Paginated release schedules filtered by released status",
+        "parameters": [
+          {
+            "name": "released",
+            "type": "bool",
+            "description": "True for released schedules, false for pending"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<ProgramReleaseSchedule>",
+          "description": "Paginated release schedules matching the status"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "query_releases_by_recipient",
+        "description": "Paginated release history filtered by recipient address",
+        "parameters": [
+          {
+            "name": "recipient",
+            "type": "Address",
+            "description": "Recipient address to filter by"
+          },
+          {
+            "name": "offset",
+            "type": "u32",
+            "description": "Number of matching records to skip"
+          },
+          {
+            "name": "limit",
+            "type": "u32",
+            "description": "Maximum records to return (1\u2013200)"
+          }
+        ],
+        "returns": {
+          "type": "Vec<ProgramReleaseHistory>",
+          "description": "Paginated release history records for the recipient"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
       }
     ],
     "admin": [
@@ -1140,38 +1331,102 @@
       {
         "name": "SpendLimitSetEvent",
         "description": "Audit event emitted after every set_program_spend_threshold call",
-        "topics": ["SpLimSet", "program_id"],
+        "topics": [
+          "SpLimSet",
+          "program_id"
+        ],
         "data": [
-          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
-          {"name": "program_id", "type": "String", "description": "Program the threshold applies to"},
-          {"name": "previous_threshold", "type": "i128", "description": "Previous threshold (i128::MAX = unlimited)"},
-          {"name": "new_threshold", "type": "i128", "description": "New threshold value"},
-          {"name": "set_by", "type": "Address", "description": "Admin that made the change"},
-          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+          {
+            "name": "version",
+            "type": "u32",
+            "description": "Always EVENT_VERSION_V2"
+          },
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program the threshold applies to"
+          },
+          {
+            "name": "previous_threshold",
+            "type": "i128",
+            "description": "Previous threshold (i128::MAX = unlimited)"
+          },
+          {
+            "name": "new_threshold",
+            "type": "i128",
+            "description": "New threshold value"
+          },
+          {
+            "name": "set_by",
+            "type": "Address",
+            "description": "Admin that made the change"
+          },
+          {
+            "name": "timestamp",
+            "type": "u64",
+            "description": "Ledger timestamp"
+          }
         ],
         "trigger": "Every successful set_program_spend_threshold call"
       },
       {
         "name": "SpendLimitExceededEvent",
         "description": "Audit event emitted when a payout is rejected for exceeding the spend threshold",
-        "topics": ["SpLimExc", "program_id"],
+        "topics": [
+          "SpLimExc",
+          "program_id"
+        ],
         "data": [
-          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
-          {"name": "program_id", "type": "String", "description": "Program the threshold applies to"},
-          {"name": "requested_amount", "type": "i128", "description": "Amount that was requested and rejected"},
-          {"name": "threshold", "type": "i128", "description": "Configured threshold that was exceeded"},
-          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+          {
+            "name": "version",
+            "type": "u32",
+            "description": "Always EVENT_VERSION_V2"
+          },
+          {
+            "name": "program_id",
+            "type": "String",
+            "description": "Program the threshold applies to"
+          },
+          {
+            "name": "requested_amount",
+            "type": "i128",
+            "description": "Amount that was requested and rejected"
+          },
+          {
+            "name": "threshold",
+            "type": "i128",
+            "description": "Configured threshold that was exceeded"
+          },
+          {
+            "name": "timestamp",
+            "type": "u64",
+            "description": "Ledger timestamp"
+          }
         ],
         "trigger": "Every payout rejected due to spend threshold violation"
       },
       {
         "name": "SpendLimitSchemaVersionSet",
         "description": "Upgrade-safe marker recording the spend-limit storage schema version",
-        "topics": ["SpLimSch"],
+        "topics": [
+          "SpLimSch"
+        ],
         "data": [
-          {"name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2"},
-          {"name": "schema_version", "type": "u32", "description": "Spend-limit schema version written to instance storage"},
-          {"name": "timestamp", "type": "u64", "description": "Ledger timestamp"}
+          {
+            "name": "version",
+            "type": "u32",
+            "description": "Always EVENT_VERSION_V2"
+          },
+          {
+            "name": "schema_version",
+            "type": "u32",
+            "description": "Spend-limit schema version written to instance storage"
+          },
+          {
+            "name": "timestamp",
+            "type": "u64",
+            "description": "Ledger timestamp"
+          }
         ],
         "trigger": "Contract initialization (init_program)"
       }
@@ -1290,7 +1545,7 @@
       ]
     },
     "test_scenarios": [
-      "Complete program lifecycle (init → fund → payout)",
+      "Complete program lifecycle (init \u2192 fund \u2192 payout)",
       "Batch operations with mixed success/failure",
       "Circuit breaker activation and reset",
       "Dependency management with cycle detection",

--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -164,7 +164,17 @@ pub enum ContractError {
     /// This error occurs when the caller has exceeded
     /// the allowed rate for operations.
     RateLimitExceeded = 18,
-    
+
+    /// Pagination limit is zero.
+    ///
+    /// This error occurs when a pagination query is called with `limit = 0`.
+    InvalidPaginationLimit = 19,
+
+    /// Pagination limit exceeds the configured maximum.
+    ///
+    /// This error occurs when `limit > HistoryPaginationConfig::max_limit`.
+    PaginationLimitExceedsMax = 20,
+
     // =========================================================================
     // Program Management Errors (100-199)
     // =========================================================================
@@ -638,6 +648,8 @@ impl ContractError {
             ContractError::EntryNotFound => "Entry not found",
             ContractError::InvalidConfig => "Invalid configuration",
             ContractError::RateLimitExceeded => "Rate limit exceeded",
+            ContractError::InvalidPaginationLimit => "Pagination limit must be greater than zero",
+            ContractError::PaginationLimitExceedsMax => "Pagination limit exceeds maximum",
             
             // Program Management Errors
             ContractError::ProgramInitFailed => "Program initialization failed",


### PR DESCRIPTION
Closes #20

## Summary

Implements history pagination for the Program Escrow contract as described in issue #20.

## Changes

### `contracts/program-escrow/src/lib.rs`
- `HistoryPaginationConfig` struct with `max_limit` field
- `DataKey::HistoryPaginationConfig` — upgrade-safe storage key (defaults on first read, no migration needed)
- `DEFAULT_MAX_HISTORY_PAGE_LIMIT = 200`
- `validate_pagination()` — explicit errors: rejects `limit = 0` and `limit > max_limit`
- `paginate_filtered()` — generic offset/limit pagination with predicate, deterministic ordering
- 6 public query entrypoints: `query_payouts_by_recipient`, `query_payouts_by_amount`, `query_payouts_by_timestamp`, `query_schedules_by_recipient`, `query_schedules_by_status`, `query_releases_by_recipient`

### `contracts/program-escrow/src/errors.rs`
- `InvalidPaginationLimit = 19` — raised when `limit = 0`
- `PaginationLimitExceedsMax = 20` — raised when `limit > max_limit`

### `contracts/program-escrow-manifest.json`
- All 6 query functions documented as view entrypoints
- Version bumped to `2.6.0` with changelog entry

### `contracts/program-escrow/src/test.rs`
- Filter correctness: recipient, amount range, timestamp range
- Offset + limit pagination across pages
- Boundary inclusion (inclusive ranges)
- `limit = 0` rejected, `limit > 200` rejected
- Invalid amount/timestamp ranges rejected

## Security Notes
- Pagination config stored in instance storage with safe default — no state migration risk on upgrade
- `limit = 0` explicitly rejected to prevent unbounded iteration disguised as a no-op
- Max limit (200) configurable via `HistoryPaginationConfig` without contract upgrade