### PR TITLE
feat(bounty-escrow): implement high-value release timelock queue

### DIFF
--- a/contracts/bounty-escrow-manifest.json
+++ b/contracts/bounty-escrow-manifest.json
@@ -3,7 +3,7 @@
   "contract_name": "BountyEscrowContract",
   "contract_purpose": "Manages bounty escrow with multi-token support, capability-based authorization, two-step admin rotation with timelock, refund-eligibility views, fee configuration, and comprehensive security features including reentrancy protection and rate limiting",
   "version": {
-    "current": "2.1.1",
+    "current": "2.4.0",
     "schema": "1.0.0",
     "history": [
       {
@@ -54,6 +54,21 @@
           "Added InvalidBatchSizeCap error code for batch size governance",
           "Added BatchSizeCaps and FeeRoutingSchemaVersion DataKey variants for upgrade-safe storage",
           "Fee routing invariant is now enforced on-chain: last destination absorbs rounding remainder ensuring exact accounting"
+        ]
+      },
+      {
+        "version": "2.4.0",
+        "release_date": "2026-04-24",
+        "changes": [
+          "Implemented high-value release timelock queue with clear semantics",
+          "release_funds now queues releases to DataKey::QueuedRelease(bounty_id) when amount >= configured threshold instead of transferring immediately",
+          "Added execute_queued_release: permissionless execution after timelock elapses, performs actual token transfer and marks escrow Released",
+          "Added cancel_queued_release: admin-only cancellation that removes queue entry and leaves escrow Locked",
+          "Added TimelockNotElapsed (53) and ReleaseAlreadyQueued (54) error codes",
+          "Added HighValueConfig and QueuedRelease DataKey variants for upgrade-safe storage",
+          "Added ReleaseQueueCancelled audit event emitted on cancel_queued_release",
+          "set_high_value_config now uses DataKey::HighValueConfig for upgrade-safe storage",
+          "All queue operations follow CEI ordering: state mutations before token transfers"
         ]
       }
     ]
@@ -602,6 +617,32 @@
         "authorization": "any",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "get_high_value_config",
+        "description": "Get the current high-value release timelock configuration",
+        "parameters": [],
+        "returns": {
+          "type": "Option<HighValueConfig>",
+          "description": "Threshold and duration, or None if not configured"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
+      },
+      {
+        "name": "get_queued_release",
+        "description": "Get the pending queued release for a bounty, if any",
+        "parameters": [
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" }
+        ],
+        "returns": {
+          "type": "Option<QueuedRelease>",
+          "description": "Queued release record or None"
+        },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ],
     "admin": [
@@ -876,6 +917,28 @@
         "authorization": "admin",
         "pausable": false,
         "gas_estimate": "low"
+      },
+      {
+        "name": "execute_queued_release",
+        "description": "Execute a queued high-value release after the timelock has elapsed. Permissionless — anyone may call once executable_at is reached.",
+        "parameters": [
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" }
+        ],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "any",
+        "pausable": false,
+        "gas_estimate": "medium"
+      },
+      {
+        "name": "cancel_queued_release",
+        "description": "Cancel a pending queued release (admin only). Escrow remains Locked.",
+        "parameters": [
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" }
+        ],
+        "returns": { "type": "()", "description": "Empty on success" },
+        "authorization": "admin",
+        "pausable": false,
+        "gas_estimate": "low"
       }
     ]
   },
@@ -1049,6 +1112,18 @@
         "type": "instance",
         "description": "Paginated index of blocklisted addresses",
         "data_structure": "Vec<Address>"
+      },
+      {
+        "name": "HighValueConfig",
+        "type": "instance",
+        "description": "High-value release timelock configuration (threshold and duration)",
+        "data_structure": "HighValueConfig"
+      },
+      {
+        "name": "QueuedRelease",
+        "type": "persistent",
+        "description": "Per-bounty queued release record for high-value timelock, keyed by bounty_id",
+        "data_structure": "QueuedRelease"
       }
     ]
   },
@@ -1441,6 +1516,56 @@
           }
         ],
         "trigger": "Admin toggles maintenance mode (state change only)"
+      },
+      {
+        "name": "ReleaseQueued",
+        "description": "High-value release queued for timelock delay",
+        "data": [
+          { "name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2" },
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" },
+          { "name": "contributor", "type": "Address", "description": "Intended recipient" },
+          { "name": "amount", "type": "i128", "description": "Amount to be released" },
+          { "name": "executable_at", "type": "u64", "description": "Timestamp after which execute_queued_release may be called" },
+          { "name": "timestamp", "type": "u64", "description": "Ledger timestamp of queuing" }
+        ],
+        "trigger": "release_funds called when amount >= high-value threshold"
+      },
+      {
+        "name": "QueuedReleaseExecuted",
+        "description": "Queued high-value release executed after timelock elapsed",
+        "data": [
+          { "name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2" },
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" },
+          { "name": "contributor", "type": "Address", "description": "Recipient of funds" },
+          { "name": "amount", "type": "i128", "description": "Amount transferred" },
+          { "name": "timestamp", "type": "u64", "description": "Ledger timestamp of execution" }
+        ],
+        "trigger": "execute_queued_release called after executable_at"
+      },
+      {
+        "name": "ReleaseQueueCancelled",
+        "description": "Admin cancelled a pending queued release",
+        "data": [
+          { "name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2" },
+          { "name": "bounty_id", "type": "u64", "description": "Bounty identifier" },
+          { "name": "contributor", "type": "Address", "description": "Intended recipient that was cancelled" },
+          { "name": "amount", "type": "i128", "description": "Amount that was queued" },
+          { "name": "admin", "type": "Address", "description": "Admin who cancelled" },
+          { "name": "timestamp", "type": "u64", "description": "Ledger timestamp of cancellation" }
+        ],
+        "trigger": "cancel_queued_release called by admin"
+      },
+      {
+        "name": "HighValueConfigUpdated",
+        "description": "High-value release timelock configuration updated",
+        "data": [
+          { "name": "version", "type": "u32", "description": "Always EVENT_VERSION_V2" },
+          { "name": "admin", "type": "Address", "description": "Admin who updated the config" },
+          { "name": "threshold", "type": "i128", "description": "New threshold amount" },
+          { "name": "duration", "type": "u64", "description": "New timelock duration in seconds" },
+          { "name": "timestamp", "type": "u64", "description": "Ledger timestamp" }
+        ],
+        "trigger": "set_high_value_config called by admin"
       }
     ]
   },

--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -1767,3 +1767,30 @@ pub fn emit_fee_routing_schema_version_set(env: &Env, event: FeeRoutingSchemaVer
     let topics = (symbol_short!("fee_schm"),);
     env.events().publish(topics, event);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HIGH-VALUE TIMELOCK QUEUE CANCELLATION EVENT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Emitted when an admin cancels a pending high-value queued release.
+///
+/// ### Topics
+/// | Index | Value |
+/// |-------|-------|
+/// | 0 | `"hv_cncl"` |
+/// | 1 | `bounty_id: u64` |
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseQueueCancelled {
+    pub version: u32,
+    pub bounty_id: u64,
+    pub contributor: Address,
+    pub amount: i128,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+pub fn emit_release_queue_cancelled(env: &Env, event: ReleaseQueueCancelled) {
+    let topics = (symbol_short!("hv_cncl"), event.bounty_id);
+    env.events().publish(topics, event);
+}

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -634,6 +634,10 @@ pub enum Error {
     InvalidAdminRotationTarget = 51,
     /// Batch size cap is outside the accepted bounds (1..=MAX_BATCH_SIZE).
     InvalidBatchSizeCap = 52,
+    /// High-value release timelock has not yet elapsed; call execute_queued_release after the delay.
+    TimelockNotElapsed = 53,
+    /// A release is already queued for this bounty; cancel it before queuing another.
+    ReleaseAlreadyQueued = 54,
 }
 
 /// Bit flag: escrow or payout should be treated as elevated risk (indexers, UIs).
@@ -864,6 +868,10 @@ pub enum DataKey {
     FeeRoutingSchemaVersion,
     /// Runtime-configurable batch size caps for lock and release operations.
     BatchSizeCaps,
+    /// High-value release timelock configuration (threshold + duration).
+    HighValueConfig,
+    /// Per-bounty queued release record for high-value timelock.
+    QueuedRelease(u64),
 }
 
 #[contracttype]
@@ -3796,6 +3804,53 @@ impl BountyEscrowContract {
             return Err(Error::FundsNotLocked);
         }
 
+        // High-value timelock: if configured and amount >= threshold, queue instead of releasing.
+        if let Some(hv_cfg) = env
+            .storage()
+            .instance()
+            .get::<DataKey, HighValueConfig>(&DataKey::HighValueConfig)
+        {
+            if hv_cfg.threshold > 0 && escrow.amount >= hv_cfg.threshold {
+                // Reject if a release is already queued for this bounty.
+                if env
+                    .storage()
+                    .persistent()
+                    .has(&DataKey::QueuedRelease(bounty_id))
+                {
+                    reentrancy_guard::release(&env);
+                    return Err(Error::ReleaseAlreadyQueued);
+                }
+
+                let executable_at = env
+                    .ledger()
+                    .timestamp()
+                    .saturating_add(hv_cfg.duration);
+                let queued = QueuedRelease {
+                    contributor: contributor.clone(),
+                    amount: escrow.amount,
+                    executable_at,
+                };
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::QueuedRelease(bounty_id), &queued);
+
+                events::emit_release_queued(
+                    &env,
+                    events::ReleaseQueued {
+                        version: EVENT_VERSION_V2,
+                        bounty_id,
+                        contributor,
+                        amount: escrow.amount,
+                        executable_at,
+                        timestamp: env.ledger().timestamp(),
+                    },
+                );
+
+                reentrancy_guard::release(&env);
+                return Ok(());
+            }
+        }
+
         // Resolve effective fee config for release.
         let (
             _lock_fee_rate,
@@ -6127,7 +6182,7 @@ impl BountyEscrowContract {
         }
 
         let config = HighValueConfig { threshold, duration };
-        env.storage().instance().set(&symbol_short!("hv_cfg"), &config);
+        env.storage().instance().set(&DataKey::HighValueConfig, &config);
 
         events::emit_high_value_config_updated(
             &env,
@@ -6145,77 +6200,60 @@ impl BountyEscrowContract {
 
     /// View: Gets the current high-value release configuration.
     pub fn get_high_value_config(env: Env) -> Option<HighValueConfig> {
-        env.storage().instance().get(&symbol_short!("hv_cfg"))
+        env.storage().instance().get(&DataKey::HighValueConfig)
     }
 
     /// View: Gets a currently queued release for a specific bounty.
     pub fn get_queued_release(env: Env, bounty_id: u64) -> Option<QueuedRelease> {
         env.storage()
             .persistent()
-            .get(&(symbol_short!("hv_q"), bounty_id))
+            .get(&DataKey::QueuedRelease(bounty_id))
     }
 
-    /// Queues a high-value release for the timelock.
-    /// In a full flow, this replaces the direct token transfer in `release_funds` when amount >= threshold.
-    pub fn queue_high_value_release(
-        env: Env,
-        bounty_id: u64,
-        contributor: Address,
-        amount: i128,
-    ) -> Result<(), Error> {
-        let admin = rbac::require_admin(&env);
-        admin.require_auth(); // Authorized by admin or delegator in standard flow
-
-        let config = Self::get_high_value_config(env.clone()).unwrap_or(HighValueConfig {
-            threshold: i128::MAX, // Effectively disables if unconfigured
-            duration: 0,
-        });
-
-        if amount < config.threshold {
-            return Err(Error::InvalidAmount); 
-        }
-
-        let executable_at = env.ledger().timestamp().saturating_add(config.duration);
-        let queued = QueuedRelease {
-            contributor: contributor.clone(),
-            amount,
-            executable_at,
-        };
-
-        // Upgrade-safe tuple storage key
-        env.storage()
-            .persistent()
-            .set(&(symbol_short!("hv_q"), bounty_id), &queued);
-
-        events::emit_release_queued(
-            &env,
-            events::ReleaseQueued {
-                version: events::EVENT_VERSION_V2,
-                bounty_id,
-                contributor,
-                amount,
-                executable_at,
-                timestamp: env.ledger().timestamp(),
-            },
-        );
-
-        Ok(())
-    }
-
-    /// Executes a queued release once its timelock has expired.
+    /// Executes a queued high-value release once its timelock has elapsed.
+    ///
+    /// Anyone may call this after `executable_at`; the admin queued the release
+    /// via `release_funds` and the timelock enforces the delay.
     pub fn execute_queued_release(env: Env, bounty_id: u64) -> Result<(), Error> {
-        let queued = Self::get_queued_release(env.clone(), bounty_id).ok_or(Error::BountyNotFound)?;
+        let _guard = NonReentrant::enter(&env);
+
+        let queued: QueuedRelease = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QueuedRelease(bounty_id))
+            .ok_or(Error::BountyNotFound)?;
 
         if env.ledger().timestamp() < queued.executable_at {
-            return Err(Error::DeadlineNotPassed);
+            return Err(Error::TimelockNotElapsed);
         }
 
-        // Clean up the queue to prevent double-spending
+        // EFFECTS: remove queue entry before token transfer (CEI)
         env.storage()
             .persistent()
-            .remove(&(symbol_short!("hv_q"), bounty_id));
+            .remove(&DataKey::QueuedRelease(bounty_id));
 
-        // Note: Contract-to-token transfer logic integrates here
+        // Update escrow status to Released
+        if env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
+            let mut escrow: Escrow = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Escrow(bounty_id))
+                .unwrap();
+            escrow.status = EscrowStatus::Released;
+            escrow.remaining_amount = 0;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(bounty_id), &escrow);
+        }
+
+        // INTERACTION: token transfer after state update
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(
+            &env.current_contract_address(),
+            &queued.contributor,
+            &queued.amount,
+        );
 
         events::emit_queued_release_executed(
             &env,
@@ -6224,6 +6262,39 @@ impl BountyEscrowContract {
                 bounty_id,
                 contributor: queued.contributor,
                 amount: queued.amount,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Cancels a pending queued release (admin only).
+    ///
+    /// The escrow remains in `Locked` status so the admin can re-release
+    /// normally or queue again.
+    pub fn cancel_queued_release(env: Env, bounty_id: u64) -> Result<(), Error> {
+        let admin = rbac::require_admin(&env);
+        admin.require_auth();
+
+        let queued: QueuedRelease = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QueuedRelease(bounty_id))
+            .ok_or(Error::BountyNotFound)?;
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::QueuedRelease(bounty_id));
+
+        events::emit_release_queue_cancelled(
+            &env,
+            events::ReleaseQueueCancelled {
+                version: events::EVENT_VERSION_V2,
+                bounty_id,
+                contributor: queued.contributor,
+                amount: queued.amount,
+                admin,
                 timestamp: env.ledger().timestamp(),
             },
         );

--- a/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs
@@ -955,3 +955,227 @@ fn test_claim_window_expired_event_emitted_on_failure() {
     });
     assert!(found, "ClaimWindowExpired event not emitted");
 }
+
+// ============================================================================
+// HIGH-VALUE RELEASE TIMELOCK QUEUE TESTS
+// ============================================================================
+
+#[test]
+fn test_high_value_release_queues_instead_of_immediate_transfer() {
+    let setup = TestSetup::new();
+    let bounty_id = 400_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+
+    // release_funds should queue, not transfer immediately
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // Escrow should still be Locked (not Released yet)
+    let escrow = setup.escrow.get_escrow_info(&bounty_id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+
+    // Queue entry should exist
+    let queued = setup.escrow.get_queued_release(&bounty_id);
+    assert!(queued.is_some());
+    let q = queued.unwrap();
+    assert_eq!(q.contributor, setup.contributor);
+    assert_eq!(q.amount, amount);
+    assert_eq!(q.executable_at, setup.env.ledger().timestamp() + delay);
+}
+
+#[test]
+fn test_execute_queued_release_before_timelock_fails() {
+    let setup = TestSetup::new();
+    let bounty_id = 401_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // Try to execute before timelock elapses
+    let res = setup.escrow.try_execute_queued_release(&bounty_id);
+    assert!(matches!(res, Err(Ok(crate::Error::TimelockNotElapsed))));
+}
+
+#[test]
+fn test_execute_queued_release_after_timelock_succeeds() {
+    let setup = TestSetup::new();
+    let bounty_id = 402_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let now = setup.env.ledger().timestamp();
+    let deadline = now + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // Advance time past the timelock
+    setup.env.ledger().set_timestamp(now + delay + 1);
+
+    setup.escrow.execute_queued_release(&bounty_id);
+
+    // Queue entry should be gone
+    assert!(setup.escrow.get_queued_release(&bounty_id).is_none());
+
+    // Escrow should now be Released
+    let escrow = setup.escrow.get_escrow_info(&bounty_id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_execute_queued_release_double_execute_fails() {
+    let setup = TestSetup::new();
+    let bounty_id = 403_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let now = setup.env.ledger().timestamp();
+    let deadline = now + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+    setup.env.ledger().set_timestamp(now + delay + 1);
+    setup.escrow.execute_queued_release(&bounty_id);
+
+    // Second execute should fail — queue entry is gone
+    let res = setup.escrow.try_execute_queued_release(&bounty_id);
+    assert!(matches!(res, Err(Ok(crate::Error::BountyNotFound))));
+}
+
+#[test]
+fn test_release_already_queued_error_on_duplicate_queue() {
+    let setup = TestSetup::new();
+    let bounty_id = 404_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // Second release_funds call should fail with ReleaseAlreadyQueued
+    let res = setup.escrow.try_release_funds(&bounty_id, &setup.contributor);
+    assert!(matches!(res, Err(Ok(crate::Error::ReleaseAlreadyQueued))));
+}
+
+#[test]
+fn test_cancel_queued_release_restores_locked_state() {
+    let setup = TestSetup::new();
+    let bounty_id = 405_u64;
+    let amount = 10_000_i128;
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // Cancel the queued release
+    setup.escrow.cancel_queued_release(&bounty_id);
+
+    // Queue entry should be gone
+    assert!(setup.escrow.get_queued_release(&bounty_id).is_none());
+
+    // Escrow should still be Locked
+    let escrow = setup.escrow.get_escrow_info(&bounty_id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+}
+
+#[test]
+fn test_below_threshold_release_is_immediate() {
+    let setup = TestSetup::new();
+    let bounty_id = 406_u64;
+    let amount = 1_000_i128; // below threshold
+    let threshold = 5_000_i128;
+    let delay = 3_600_u64;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&threshold, &delay);
+
+    // release_funds should complete immediately (amount < threshold)
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    // No queue entry
+    assert!(setup.escrow.get_queued_release(&bounty_id).is_none());
+
+    // Escrow should be Released
+    let escrow = setup.escrow.get_escrow_info(&bounty_id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_high_value_config_event_emitted() {
+    let setup = TestSetup::new();
+    setup.escrow.set_high_value_config(&5_000, &3_600);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "hv_cfg").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "HighValueConfigUpdated event not emitted");
+}
+
+#[test]
+fn test_release_queued_event_emitted() {
+    let setup = TestSetup::new();
+    let bounty_id = 407_u64;
+    let amount = 10_000_i128;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&5_000, &3_600);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "hv_q").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "ReleaseQueued event not emitted");
+}
+
+#[test]
+fn test_cancel_queued_release_event_emitted() {
+    let setup = TestSetup::new();
+    let bounty_id = 408_u64;
+    let amount = 10_000_i128;
+    let deadline = setup.env.ledger().timestamp() + 100_000;
+
+    setup.escrow.lock_funds(&setup.depositor, &bounty_id, &amount, &deadline);
+    setup.escrow.set_high_value_config(&5_000, &3_600);
+    setup.escrow.release_funds(&bounty_id, &setup.contributor);
+    setup.escrow.cancel_queued_release(&bounty_id);
+
+    let events = setup.env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics.len() >= 1
+            && topics
+                .get(0)
+                .map(|t| t == soroban_sdk::Symbol::new(&setup.env, "hv_cncl").into_val(&setup.env))
+                .unwrap_or(false)
+    });
+    assert!(found, "ReleaseQueueCancelled event not emitted");
+}


### PR DESCRIPTION
## Summary

Closes #23

Implements the high-value release timelock queue for the bounty escrow contract with clear semantics, audit events, and upgrade-safe storage.

---

## Changes

### `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
- **New error codes**: `TimelockNotElapsed = 53`, `ReleaseAlreadyQueued = 54`
- **New `DataKey` variants**: `HighValueConfig` (instance) and `QueuedRelease(u64)` (persistent) — replaces ad-hoc `symbol_short` keys for upgrade safety
- **`release_funds_logic` integration**: when `amount >= threshold`, queues to `DataKey::QueuedRelease` instead of transferring immediately; returns `ReleaseAlreadyQueued` if a queue entry already exists
- **`execute_queued_release`** (fixed): validates timelock elapsed, follows CEI ordering (remove queue entry → update escrow status → token transfer), permissionless after `executable_at`
- **`cancel_queued_release`** (new): admin-only, removes queue entry, leaves escrow `Locked`, emits `ReleaseQueueCancelled`
- **`set_high_value_config`**: migrated to `DataKey::HighValueConfig` for upgrade-safe storage

### `contracts/bounty_escrow/contracts/escrow/src/events.rs`
- Added `ReleaseQueueCancelled` event struct and `emit_release_queue_cancelled` (topic: `hv_cncl`, `bounty_id`)

### `contracts/bounty_escrow/contracts/escrow/src/test_status_transitions.rs`
9 new tests covering:
- Queue-on-release when `amount >= threshold`
- `TimelockNotElapsed` before delay elapses
- Successful execute after timelock (escrow → Released, token transferred)
- Double-execute prevention (`BountyNotFound`)
- `ReleaseAlreadyQueued` on duplicate queue attempt
- `cancel_queued_release` restores `Locked` state
- Below-threshold release remains immediate
- `HighValueConfigUpdated`, `ReleaseQueued`, `ReleaseQueueCancelled` event emissions

### `contracts/bounty-escrow-manifest.json`
- Version bumped to `2.4.0`
- Added `execute_queued_release`, `cancel_queued_release` entrypoints
- Added `get_high_value_config`, `get_queued_release` view entrypoints
- Added `HighValueConfig`, `QueuedRelease` storage key entries
- Added `ReleaseQueued`, `QueuedReleaseExecuted`, `ReleaseQueueCancelled`, `HighValueConfigUpdated` event entries

---

## Security Notes
- **CEI ordering**: queue entry removed before token transfer — prevents double-spend
- **`execute_queued_release` is permissionless** after `executable_at` — reduces admin single point of failure
- **`cancel_queued_release` is admin-only** — prevents griefing
- **`ReleaseAlreadyQueued`** prevents overwriting an existing queue entry
- No identities or off-chain data stored on-chain