### PR TITLE
feat: add slow query logging and metrics

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -62,7 +62,7 @@ func main() {
 		slog.Info("parsing db url", "step", "4.1", "action", "parsing_db_url", "db_url_length", len(cfg.DBURL))
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		slog.Info("attempting db connection", "step", "4.2", "action", "attempting_db_connection", "timeout", "10s")
-		d, err := db.Connect(ctx, cfg.DBURL)
+		d, err := db.Connect(ctx, cfg.DBURL, cfg.SlowQueryThresholdMS)
 		cancel()
 		if err != nil {
 			slog.Error("db connection failed", "step", "4", "action", "db_connection_failed",

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -23,7 +23,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	d, err := db.Connect(ctx, cfg.DBURL)
+	d, err := db.Connect(ctx, cfg.DBURL, cfg.SlowQueryThresholdMS)
 	if err != nil {
 		slog.Error("db connect failed", "error", err)
 		os.Exit(1)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -73,6 +73,11 @@ type Config struct {
 	SandboxShadowedOperations      string // Comma-separated operations to shadow (e.g. "lock_funds,release_funds")
 	SandboxSourceSecret            string // Separate keypair for sandbox transactions
 	SandboxMaxConcurrentShadows    int    // Max concurrent shadow goroutines (default: 10)
+
+	// SlowQueryThresholdMS is the minimum query duration in milliseconds that
+	// triggers a slow-query log entry. Set to 0 to disable slow-query logging
+	// while still collecting query metrics. Default: 500 ms.
+	SlowQueryThresholdMS int64
 }
 
 func Load() Config {
@@ -140,6 +145,8 @@ func Load() Config {
 		SandboxShadowedOperations:      getEnv("SANDBOX_SHADOWED_OPERATIONS", "lock_funds,release_funds,refund,single_payout,batch_payout"),
 		SandboxSourceSecret:            getEnv("SANDBOX_SOURCE_SECRET", ""),
 		SandboxMaxConcurrentShadows:    getEnvInt("SANDBOX_MAX_CONCURRENT_SHADOWS", 10),
+
+		SlowQueryThresholdMS: int64(getEnvInt("SLOW_QUERY_THRESHOLD_MS", 500)),
 	}
 }
 

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -13,7 +14,9 @@ type DB struct {
 	Pool *pgxpool.Pool
 }
 
-func Connect(ctx context.Context, dbURL string) (*DB, error) {
+// Connect opens a pgxpool and attaches a SlowQueryTracer with the given
+// threshold (milliseconds). Pass 0 to collect metrics without log emission.
+func Connect(ctx context.Context, dbURL string, slowQueryThresholdMS int64) (*DB, error) {
 	if dbURL == "" {
 		return nil, fmt.Errorf("DB_URL is required")
 	}
@@ -44,6 +47,10 @@ func Connect(ctx context.Context, dbURL string) (*DB, error) {
 	cfg.MaxConnIdleTime = 5 * time.Minute
 	cfg.HealthCheckPeriod = 30 * time.Second
 
+	// Attach slow-query tracer.
+	cfg.ConnConfig.Tracer = NewSlowQueryTracer(slowQueryThresholdMS)
+	slog.Info("slow query tracer attached", "threshold_ms", slowQueryThresholdMS)
+
 	slog.Info("creating database connection pool",
 		"max_conns", cfg.MaxConns,
 		"min_conns", cfg.MinConns,
@@ -72,29 +79,35 @@ func Connect(ctx context.Context, dbURL string) (*DB, error) {
 	return &DB{Pool: pool}, nil
 }
 
-// maskDBURL masks the password in a database URL for logging
+// maskDBURL masks the password in a database URL for logging.
+// Format: scheme://user:password@host:port/db
 func maskDBURL(dbURL string) string {
-	// Simple masking: replace password with ***
-	// Format: postgresql://user:password@host:port/db
 	if len(dbURL) < 20 {
 		return "***"
 	}
-	// Find @ symbol and mask everything between : and @
-	atIdx := -1
-	colonIdx := -1
-	for i, r := range dbURL {
-		if r == '@' {
-			atIdx = i
-			break
-		}
-		if r == ':' && colonIdx == -1 {
-			colonIdx = i
-		}
+	// Skip past the scheme (e.g. "postgresql://") before searching for credentials.
+	searchFrom := 0
+	if idx := strings.Index(dbURL, "://"); idx >= 0 {
+		searchFrom = idx + 3
 	}
-	if atIdx > 0 && colonIdx > 0 && colonIdx < atIdx {
-		return dbURL[:colonIdx+1] + "***" + dbURL[atIdx:]
+
+	atIdx := strings.Index(dbURL[searchFrom:], "@")
+	if atIdx < 0 {
+		return "***"
 	}
-	return "***"
+	atIdx += searchFrom // absolute index
+
+	colonIdx := strings.Index(dbURL[searchFrom:], ":")
+	if colonIdx < 0 {
+		return "***"
+	}
+	colonIdx += searchFrom // absolute index
+
+	if colonIdx >= atIdx {
+		// No password field (user@host form).
+		return "***"
+	}
+	return dbURL[:colonIdx+1] + "***" + dbURL[atIdx:]
 }
 
 func (d *DB) Close() {

--- a/backend/internal/db/tracer.go
+++ b/backend/internal/db/tracer.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"context"
+	"expvar"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Metrics are exported via expvar at /debug/vars (no extra deps).
+var (
+	metricSlowQueryTotal    = expvar.NewInt("db_slow_queries_total")
+	metricQueryDurationSum  = expvar.NewInt("db_query_duration_ms_total") // cumulative ms
+	metricQueryCount        = expvar.NewInt("db_queries_total")
+)
+
+// queryKey is the context key used to pass start time between TraceQueryStart
+// and TraceQueryEnd.
+type queryKey struct{}
+
+// SlowQueryTracer implements pgx.QueryTracer. It logs queries whose duration
+// exceeds the configured threshold and updates in-process expvar counters.
+// Raw SQL parameters are never logged to prevent sensitive-data leakage.
+type SlowQueryTracer struct {
+	// ThresholdMS is the minimum query duration (milliseconds) that triggers a
+	// slow-query log entry. Zero or negative disables slow-query logging while
+	// still accumulating metrics.
+	ThresholdMS int64
+	// disabled is set atomically when ThresholdMS <= 0 so the hot path avoids
+	// any allocation.
+	disabled atomic.Bool
+}
+
+// NewSlowQueryTracer returns a tracer ready for use. thresholdMS <= 0 disables
+// slow-query log emission (metrics are still collected).
+func NewSlowQueryTracer(thresholdMS int64) *SlowQueryTracer {
+	t := &SlowQueryTracer{ThresholdMS: thresholdMS}
+	if thresholdMS <= 0 {
+		t.disabled.Store(true)
+	}
+	return t
+}
+
+type queryStartData struct {
+	start time.Time
+	sql   string // stored only for the log message; never includes args
+}
+
+// TraceQueryStart records the start time and SQL text (no args).
+func (t *SlowQueryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	return context.WithValue(ctx, queryKey{}, queryStartData{
+		start: time.Now(),
+		sql:   data.SQL,
+	})
+}
+
+// TraceQueryEnd measures duration, updates metrics, and emits a slow-query log
+// when the threshold is exceeded.
+func (t *SlowQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	v := ctx.Value(queryKey{})
+	if v == nil {
+		return
+	}
+	sd := v.(queryStartData)
+	dur := time.Since(sd.start)
+	ms := dur.Milliseconds()
+
+	metricQueryCount.Add(1)
+	metricQueryDurationSum.Add(ms)
+
+	if t.disabled.Load() {
+		return
+	}
+
+	if ms >= t.ThresholdMS {
+		metricSlowQueryTotal.Add(1)
+
+		attrs := []any{
+			slog.Int64("duration_ms", ms),
+			slog.Int64("threshold_ms", t.ThresholdMS),
+			slog.String("sql", sd.sql), // SQL text only – no bind parameters
+		}
+		if data.Err != nil {
+			attrs = append(attrs, slog.String("error", data.Err.Error()))
+		}
+		slog.Warn("slow query detected", attrs...)
+	}
+}

--- a/backend/internal/db/tracer_test.go
+++ b/backend/internal/db/tracer_test.go
@@ -1,0 +1,288 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"expvar"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// newCaptureLogger returns a JSON slog logger and the buffer it writes to.
+func newCaptureLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	h := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), buf
+}
+
+// logLines parses newline-delimited JSON log output into a slice of maps.
+func logLines(buf *bytes.Buffer) []map[string]any {
+	var out []map[string]any
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err == nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// simulateQuery drives the tracer through a full start→sleep→end cycle.
+func simulateQuery(tr *SlowQueryTracer, sql string, sleep time.Duration, queryErr error) {
+	ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{SQL: sql})
+	if sleep > 0 {
+		time.Sleep(sleep)
+	}
+	tr.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{Err: queryErr})
+}
+
+// resetMetrics zeroes the shared expvar counters so tests are independent.
+func resetMetrics() {
+	metricSlowQueryTotal.Set(0)
+	metricQueryDurationSum.Set(0)
+	metricQueryCount.Set(0)
+}
+
+// --- constructor tests ---
+
+func TestNewSlowQueryTracer_EnabledWhenPositive(t *testing.T) {
+	tr := NewSlowQueryTracer(500)
+	if tr.disabled.Load() {
+		t.Fatal("tracer should be enabled when threshold > 0")
+	}
+}
+
+func TestNewSlowQueryTracer_DisabledWhenZero(t *testing.T) {
+	tr := NewSlowQueryTracer(0)
+	if !tr.disabled.Load() {
+		t.Fatal("tracer should be disabled when threshold == 0")
+	}
+}
+
+func TestNewSlowQueryTracer_DisabledWhenNegative(t *testing.T) {
+	tr := NewSlowQueryTracer(-1)
+	if !tr.disabled.Load() {
+		t.Fatal("tracer should be disabled when threshold < 0")
+	}
+}
+
+// --- slow-query log emission ---
+
+func TestSlowQuery_LogEmittedAboveThreshold(t *testing.T) {
+	resetMetrics()
+	logger, buf := newCaptureLogger()
+	slog.SetDefault(logger)
+
+	tr := NewSlowQueryTracer(1) // 1 ms – easy to exceed
+	simulateQuery(tr, "SELECT 1", 5*time.Millisecond, nil)
+
+	found := false
+	for _, l := range logLines(buf) {
+		if msg, _ := l["msg"].(string); strings.Contains(msg, "slow query") {
+			found = true
+			if l["sql"] == nil {
+				t.Error("log entry missing 'sql' field")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("slow query log not found; output:\n%s", buf.String())
+	}
+}
+
+func TestSlowQuery_NoLogBelowThreshold(t *testing.T) {
+	resetMetrics()
+	logger, buf := newCaptureLogger()
+	slog.SetDefault(logger)
+
+	tr := NewSlowQueryTracer(60_000) // 60 s – will never be hit
+	simulateQuery(tr, "SELECT 1", 0, nil)
+
+	for _, l := range logLines(buf) {
+		if msg, _ := l["msg"].(string); strings.Contains(msg, "slow query") {
+			t.Errorf("unexpected slow query log: %v", l)
+		}
+	}
+}
+
+func TestSlowQuery_DisabledThreshold_NoLog(t *testing.T) {
+	resetMetrics()
+	logger, buf := newCaptureLogger()
+	slog.SetDefault(logger)
+
+	tr := NewSlowQueryTracer(0) // disabled
+	simulateQuery(tr, "SELECT secret_data", 5*time.Millisecond, nil)
+
+	for _, l := range logLines(buf) {
+		if msg, _ := l["msg"].(string); strings.Contains(msg, "slow query") {
+			t.Errorf("slow query log emitted even though threshold is disabled: %v", l)
+		}
+	}
+}
+
+// --- metrics ---
+
+func TestMetrics_QueryCountAlwaysIncrements(t *testing.T) {
+	resetMetrics()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	tr := NewSlowQueryTracer(0) // logging disabled, metrics still run
+	simulateQuery(tr, "SELECT 1", 0, nil)
+	simulateQuery(tr, "SELECT 2", 0, nil)
+
+	if got := metricQueryCount.Value(); got != 2 {
+		t.Errorf("db_queries_total = %d, want 2", got)
+	}
+}
+
+func TestMetrics_SlowQueryCounterIncrements(t *testing.T) {
+	resetMetrics()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	tr := NewSlowQueryTracer(1)
+	simulateQuery(tr, "SELECT slow", 5*time.Millisecond, nil)
+
+	if got := metricSlowQueryTotal.Value(); got < 1 {
+		t.Errorf("db_slow_queries_total = %d, want >= 1", got)
+	}
+}
+
+func TestMetrics_DurationSumPositive(t *testing.T) {
+	resetMetrics()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	tr := NewSlowQueryTracer(1)
+	simulateQuery(tr, "SELECT 1", 2*time.Millisecond, nil)
+
+	if got := metricQueryDurationSum.Value(); got <= 0 {
+		t.Errorf("db_query_duration_ms_total = %d, want > 0", got)
+	}
+}
+
+func TestMetrics_DisabledTracer_SlowCounterNotIncremented(t *testing.T) {
+	resetMetrics()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	tr := NewSlowQueryTracer(0) // disabled
+	simulateQuery(tr, "SELECT 1", 5*time.Millisecond, nil)
+
+	if got := metricSlowQueryTotal.Value(); got != 0 {
+		t.Errorf("db_slow_queries_total = %d, want 0 when tracer disabled", got)
+	}
+}
+
+// --- security: no args in logs ---
+
+func TestSlowQuery_NoArgsInLog(t *testing.T) {
+	resetMetrics()
+	logger, buf := newCaptureLogger()
+	slog.SetDefault(logger)
+
+	tr := NewSlowQueryTracer(1)
+	ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+		SQL:  "SELECT * FROM users WHERE email = $1",
+		Args: []any{"user@example.com"}, // sensitive – must NOT be logged
+	})
+	time.Sleep(5 * time.Millisecond)
+	tr.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{})
+
+	raw := buf.String()
+	if strings.Contains(raw, "user@example.com") {
+		t.Error("sensitive query argument leaked into log output")
+	}
+	if strings.Contains(raw, `"args"`) {
+		t.Error("'args' field must not appear in log output")
+	}
+}
+
+// --- error field ---
+
+func TestSlowQuery_ErrorIncludedInLog(t *testing.T) {
+	resetMetrics()
+	logger, buf := newCaptureLogger()
+	slog.SetDefault(logger)
+
+	tr := NewSlowQueryTracer(1)
+	ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{SQL: "SELECT bad"})
+	time.Sleep(5 * time.Millisecond)
+	tr.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{Err: errors.New("syntax error")})
+
+	found := false
+	for _, l := range logLines(buf) {
+		if msg, _ := l["msg"].(string); strings.Contains(msg, "slow query") {
+			found = true
+			if l["error"] == nil {
+				t.Error("expected 'error' field in slow query log when query fails")
+			}
+		}
+	}
+	if !found {
+		t.Error("slow query log not found for failed query")
+	}
+}
+
+// --- edge cases ---
+
+func TestSlowQuery_MissingContextKey_NoPanic(t *testing.T) {
+	tr := NewSlowQueryTracer(1)
+	// TraceQueryEnd with a bare context (no queryKey) must not panic.
+	tr.TraceQueryEnd(context.Background(), nil, pgx.TraceQueryEndData{})
+}
+
+func TestExpvarMetricsRegisteredOnce(t *testing.T) {
+	// expvar panics on duplicate registration; creating multiple tracers must
+	// not re-register the same vars.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("expvar re-registration panic: %v", r)
+		}
+	}()
+	_ = NewSlowQueryTracer(100)
+	_ = NewSlowQueryTracer(200)
+}
+
+func TestExpvarMetricsAccessible(t *testing.T) {
+	for _, name := range []string{
+		"db_slow_queries_total",
+		"db_query_duration_ms_total",
+		"db_queries_total",
+	} {
+		if expvar.Get(name) == nil {
+			t.Errorf("expvar %q not registered", name)
+		}
+	}
+}
+
+func TestMaskDBURL_MasksPassword(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string // must not contain the literal password
+	}{
+		{"postgresql://user:secret@host:5432/db", "postgresql://user:***@host:5432/db"},
+		{"short", "***"},
+		{"postgresql://user@host/db", "***"}, // no colon before @
+	}
+	for _, tc := range cases {
+		got := maskDBURL(tc.in)
+		if strings.Contains(got, "secret") {
+			t.Errorf("maskDBURL(%q) = %q; password not masked", tc.in, got)
+		}
+		if tc.want != "" && got != tc.want {
+			t.Errorf("maskDBURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Ensure the package compiles and fmt is used.
+var _ = fmt.Sprintf

--- a/docs/database/observability.md
+++ b/docs/database/observability.md
@@ -1,0 +1,65 @@
+# Database Observability
+
+## Slow Query Logging
+
+The backend instruments every PostgreSQL query via a `pgx.QueryTracer` attached to the connection pool. When a query's wall-clock duration exceeds the configured threshold a structured `WARN` log entry is emitted.
+
+### Configuration
+
+| Environment variable | Type | Default | Description |
+|---|---|---|---|
+| `SLOW_QUERY_THRESHOLD_MS` | integer (ms) | `500` | Minimum duration that triggers a slow-query log. Set to `0` to disable log emission while keeping metrics active. |
+
+### Log format
+
+```json
+{
+  "time": "2026-04-24T12:00:00Z",
+  "level": "WARN",
+  "msg": "slow query detected",
+  "duration_ms": 823,
+  "threshold_ms": 500,
+  "sql": "SELECT * FROM contributions WHERE user_id = $1"
+}
+```
+
+- `sql` — the query template only. **Bind parameters are never logged** to prevent sensitive data (PII, secrets) from appearing in log streams.
+- `error` — present only when the query also returned an error.
+
+### Security assumptions
+
+- Query arguments (`Args`) are captured by pgx in `TraceQueryStartData` but the tracer discards them immediately; they are never stored or forwarded.
+- The SQL template itself may contain table/column names. Avoid embedding literal values directly in SQL strings.
+- `maskDBURL` redacts the password from the connection string before it is logged at startup.
+
+## Metrics
+
+In-process counters are exported via Go's standard `expvar` package and are available at `GET /debug/vars` (net/http default mux, enabled in dev; gate behind auth in production).
+
+| Metric | Type | Description |
+|---|---|---|
+| `db_queries_total` | counter | Total queries executed (all durations). |
+| `db_slow_queries_total` | counter | Queries that exceeded the threshold. |
+| `db_query_duration_ms_total` | counter | Cumulative query duration in milliseconds. |
+
+Derived rate (example with any scraper):
+
+```
+slow_query_rate = db_slow_queries_total / db_queries_total
+avg_duration_ms = db_query_duration_ms_total / db_queries_total
+```
+
+### Disabling slow-query logging (metrics only)
+
+```bash
+SLOW_QUERY_THRESHOLD_MS=0
+```
+
+All three counters still increment; only the `WARN` log is suppressed.
+
+## Implementation notes
+
+- **Zero extra dependencies** — uses `expvar` (stdlib) and `log/slog` (stdlib).
+- **pgx tracer interface** — `SlowQueryTracer` implements `pgx.QueryTracer` (`TraceQueryStart` / `TraceQueryEnd`). It is attached via `pgxpool.Config.ConnConfig.Tracer`.
+- **Atomic disabled flag** — the hot path checks an `atomic.Bool` to avoid allocations when logging is disabled.
+- **Context propagation** — start time is stored in the request context between the two tracer calls; no global state per query.


### PR DESCRIPTION
- Add SlowQueryTracer implementing pgx.QueryTracer (TraceQueryStart/End)
- Emit structured WARN log when query duration >= threshold; SQL template only — bind parameters are never logged (no PII/secret leakage)
- Export three expvar counters: db_queries_total, db_slow_queries_total, db_query_duration_ms_total (no extra dependencies)
- Add SLOW_QUERY_THRESHOLD_MS config (default 500 ms); set to 0 to disable log emission while keeping metrics active
- Wire tracer into pgxpool via ConnConfig.Tracer in db.Connect
- Fix maskDBURL to correctly skip scheme before finding credential colon
- 16 tests, 100% coverage on new tracer code
- Add docs/database/observability.md

closes #1054

