### PR TITLE
Block refund operations when ProgramStatus is Draft (#1248)

### DIFF
--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -220,6 +220,13 @@ pub enum ContractError {
     /// that has pending claims or scheduled releases.
     CannotArchiveWithPendingOps = 106,
     
+    /// Program is not in Active status.
+    ///
+    /// This error occurs when attempting to perform operations
+    /// that require the program to be in Active status (e.g., refunds).
+    /// Programs must be published via publish_program() before these operations.
+    ProgramNotActive = 107,
+    
     // =========================================================================
     // Fund Operation Errors (200-299)
     // =========================================================================

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -3661,6 +3661,12 @@ impl ProgramEscrowContract {
             .instance()
             .get(&PROGRAM_DATA)
             .unwrap_or_else(|| panic!("Program not initialized"));
+        
+        // Check that program is in Active status before allowing emergency withdraw
+        if program_data.status != ProgramStatus::Active {
+            panic!("{}", errors::ContractError::ProgramNotActive as u32);
+        }
+        
         let token_client = token::TokenClient::new(&env, &program_data.token_address);
 
         let contract_address = env.current_contract_address();
@@ -6258,6 +6264,18 @@ pub fn preview_split(
         if Self::check_paused(&env, symbol_short!("refund")) {
             panic!("Funds Paused");
         }
+        
+        // Check that program is in Active status before allowing refund
+        let program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
+        
+        if program_data.status != ProgramStatus::Active {
+            panic!("{}", errors::ContractError::ProgramNotActive as u32);
+        }
+        
         claim_period::cancel_claim(&env, &program_id, claim_id, &admin)
     }
 

--- a/contracts/program-escrow/src/test_lifecycle.rs
+++ b/contracts/program-escrow/src/test_lifecycle.rs
@@ -1803,3 +1803,99 @@ fn test_rotation_nonce_starts_at_zero() {
     let (client, program_id, _key, _admin) = setup_rotation_program(&env);
     assert_eq!(client.get_rotation_nonce(&program_id), 0);
 }
+
+// ---------------------------------------------------------------------------
+// STATE: Draft - Refund Operations Blocked
+// Refund operations should fail when program is in Draft status.
+// ---------------------------------------------------------------------------
+
+/// cancel_claim should fail when program is in Draft status.
+#[test]
+#[should_panic(expected = "107")]
+fn test_cancel_claim_fails_on_draft_program() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = make_client(&env);
+    let (_token_client, token_id) = fund_contract(&env, &contract_id, 50_000);
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "draft-prog");
+    
+    // Initialize program but do NOT publish - stays in Draft status
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    
+    // Attempt to cancel a claim on Draft program should fail with ProgramNotActive (107)
+    client.cancel_claim(&program_id, 1, &admin);
+}
+
+/// emergency_withdraw should fail when program is in Draft status.
+#[test]
+#[should_panic(expected = "107")]
+fn test_emergency_withdraw_fails_on_draft_program() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = make_client(&env);
+    let (_token_client, token_id) = fund_contract(&env, &contract_id, 50_000);
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "draft-prog");
+    
+    // Initialize program but do NOT publish - stays in Draft status
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    
+    // Set lock_paused to true (required for emergency_withdraw)
+    client.set_pause_flags(&Some(true), &Some(false), &Some(false), &None);
+    
+    // Attempt emergency withdraw on Draft program should fail with ProgramNotActive (107)
+    let target = Address::generate(&env);
+    client.emergency_withdraw(&target);
+}
+
+/// cancel_claim should succeed when program is in Active status.
+#[test]
+fn test_cancel_claim_succeeds_on_active_program() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = make_client(&env);
+    let (_token_client, token_id) = fund_contract(&env, &contract_id, 50_000);
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "active-prog");
+    
+    // Initialize and publish program - transitions to Active status
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.publish_program(&program_id);
+    client.lock_program_funds(&50_000);
+    
+    // Create a claim first
+    let recipient = Address::generate(&env);
+    client.create_claim(&program_id, &recipient, &10_000, &86400);
+    
+    // Cancel claim should succeed on Active program
+    client.cancel_claim(&program_id, 1, &admin);
+}
+
+/// emergency_withdraw should succeed when program is in Active status.
+#[test]
+fn test_emergency_withdraw_succeeds_on_active_program() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = make_client(&env);
+    let (token_client, token_id) = fund_contract(&env, &contract_id, 50_000);
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "active-prog");
+    
+    // Initialize and publish program - transitions to Active status
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.publish_program(&program_id);
+    client.lock_program_funds(&50_000);
+    
+    // Set lock_paused to true (required for emergency_withdraw)
+    client.set_pause_flags(&Some(true), &Some(false), &Some(false), &None);
+    
+    // Emergency withdraw should succeed on Active program
+    let target = Address::generate(&env);
+    let initial_balance = token_client.balance(&target);
+    client.emergency_withdraw(&target);
+    let final_balance = token_client.balance(&target);
+    
+    // Target should have received the funds
+    assert_eq!(final_balance - initial_balance, 50_000);
+}


### PR DESCRIPTION
Closes #1248

---

- Add ProgramNotActive error code (107) to errors.rs
- Add status check to cancel_claim function to prevent refunds on Draft programs
- Add status check to emergency_withdraw function to prevent refunds on Draft programs
- Add tests in test_lifecycle.rs to verify refund operations fail on Draft programs
- Add tests to verify refund operations succeed on Active programs