### PR TITLE
security: complete reentrancy guard audit across all mutating functions

### DIFF
--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -6093,6 +6093,9 @@ pub fn preview_split(
         caller: Option<Address>,
         schedule_id: u64,
     ) {
+        // Acquire reentrancy guard before any state reads or external calls.
+        reentrancy_guard::acquire(&env);
+
         let mut schedules = Self::get_release_schedules(env.clone());
         let program_data = Self::get_program_info(env.clone());
 
@@ -6115,10 +6118,7 @@ pub fn preview_split(
                 // Per-window spending limit check before transfer
                 Self::enforce_spending_window(&env, &program_data.program_id, s.amount);
 
-                // Transfer funds
-                let token_client = token::Client::new(&env, &program_data.token_address);
-                token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
-
+                // Effects before interaction (CEI pattern): mark released before token transfer
                 s.released = true;
                 s.released_at = Some(now);
                 s.released_by = Some(caller.clone());
@@ -6133,9 +6133,10 @@ pub fn preview_split(
             panic!("Schedule not found");
         }
 
+        // Write updated schedule state before the external token call
         env.storage().instance().set(&SCHEDULES, &schedules);
 
-        // Write to release history
+        // Write to release history and update balance before external call
         if let Some(s) = released_schedule {
             let mut updated_program_data = program_data.clone();
             updated_program_data.remaining_balance -= s.amount;
@@ -6150,16 +6151,25 @@ pub fn preview_split(
                 .unwrap_or_else(|| Vec::new(&env));
             history.push_back(ProgramReleaseHistory {
                 schedule_id: s.schedule_id,
-                recipient: s.recipient,
+                recipient: s.recipient.clone(),
                 amount: s.amount,
                 released_at: now,
                 release_type: ReleaseType::Manual,
             });
             env.storage().instance().set(&RELEASE_HISTORY, &history);
+
+            // Interaction: token transfer after all state updates
+            let token_client = token::Client::new(&env, &program_data.token_address);
+            token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
         }
+
+        reentrancy_guard::release(&env);
     }
 
     pub fn release_prog_schedule_automatic(env: Env, schedule_id: u64) {
+        // Acquire reentrancy guard before any state reads or external calls.
+        reentrancy_guard::acquire(&env);
+
         let mut schedules = Self::get_release_schedules(env.clone());
         let program_data = Self::get_program_info(env.clone());
         let now = env.ledger().timestamp();
@@ -6179,10 +6189,7 @@ pub fn preview_split(
                 // Per-window spending limit check before transfer
                 Self::enforce_spending_window(&env, &program_data.program_id, s.amount);
 
-                // Transfer funds
-                let token_client = token::Client::new(&env, &program_data.token_address);
-                token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
-
+                // Effects before interaction (CEI pattern): mark released before token transfer
                 s.released = true;
                 s.released_at = Some(now);
                 s.released_by = Some(env.current_contract_address());
@@ -6197,9 +6204,10 @@ pub fn preview_split(
             panic!("Schedule not found");
         }
 
+        // Write updated schedule state before the external token call
         env.storage().instance().set(&SCHEDULES, &schedules);
 
-        // Write to release history
+        // Write to release history and update balance before external call
         if let Some(s) = released_schedule {
             let mut updated_program_data = program_data.clone();
             updated_program_data.remaining_balance -= s.amount;
@@ -6214,13 +6222,19 @@ pub fn preview_split(
                 .unwrap_or_else(|| Vec::new(&env));
             history.push_back(ProgramReleaseHistory {
                 schedule_id: s.schedule_id,
-                recipient: s.recipient,
+                recipient: s.recipient.clone(),
                 amount: s.amount,
                 released_at: now,
                 release_type: ReleaseType::Automatic,
             });
             env.storage().instance().set(&RELEASE_HISTORY, &history);
+
+            // Interaction: token transfer after all state updates
+            let token_client = token::Client::new(&env, &program_data.token_address);
+            token_client.transfer(&env.current_contract_address(), &s.recipient, &s.amount);
         }
+
+        reentrancy_guard::release(&env);
     }
 
     /// Reserve funds for a recipient-controlled claim.

--- a/contracts/program-escrow/src/reentrancy_guard.rs
+++ b/contracts/program-escrow/src/reentrancy_guard.rs
@@ -74,3 +74,15 @@ pub fn check_not_entered(env: &Env) {
         panic!("Reentrancy detected");
     }
 }
+
+/// Returns `true` if the guard is currently held (ENTERED).
+/// Useful in tests to assert the guard is cleared after a successful call.
+#[inline(always)]
+pub fn is_entered(env: &Env) -> bool {
+    let status: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::ReentrancyGuard)
+        .unwrap_or(NOT_ENTERED);
+    status == ENTERED
+}

--- a/contracts/program-escrow/src/reentrancy_tests.rs
+++ b/contracts/program-escrow/src/reentrancy_tests.rs
@@ -970,3 +970,203 @@ fn test_reentrancy_guard_model_documentation() {
         env.deployer().register_wasm(&token_wasm, ())
     }
 }
+
+// ============================================================================
+// Schedule Release Reentrancy Tests (manual and automatic paths)
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_release_program_schedule_manual_blocks_reentrancy() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 500_0000000i128;
+    let release_timestamp = 1000u64;
+
+    let token_client = create_token_contract(&env, &authorized_key);
+    let token_admin = token::StellarAssetClient::new(&env, &token_client.address);
+    token_admin.mint(&authorized_key, &amount);
+
+    client.init_program(
+        &program_id,
+        &authorized_key,
+        &token_client.address,
+        &authorized_key,
+        &None,
+    );
+    token_client.transfer(&authorized_key, &contract_id, &amount);
+    client.lock_program_funds(&amount);
+
+    let schedule = client.create_program_release_schedule(&amount, &release_timestamp, &recipient);
+
+    // Simulate a concurrent call already holding the guard
+    crate::reentrancy_guard::set_entered(&env);
+
+    // Should panic: guard is already held
+    client.release_program_schedule_manual(&schedule.schedule_id);
+}
+
+#[test]
+fn test_release_program_schedule_manual_normal_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 500_0000000i128;
+    let release_timestamp = 1000u64;
+
+    let token_client = create_token_contract(&env, &authorized_key);
+    let token_admin = token::StellarAssetClient::new(&env, &token_client.address);
+    token_admin.mint(&authorized_key, &amount);
+
+    client.init_program(
+        &program_id,
+        &authorized_key,
+        &token_client.address,
+        &authorized_key,
+        &None,
+    );
+    token_client.transfer(&authorized_key, &contract_id, &amount);
+    client.lock_program_funds(&amount);
+
+    let schedule = client.create_program_release_schedule(&amount, &release_timestamp, &recipient);
+
+    // Guard must be clear before and after a successful call
+    assert!(!crate::reentrancy_guard::is_entered(&env));
+    client.release_program_schedule_manual(&schedule.schedule_id);
+    assert!(!crate::reentrancy_guard::is_entered(&env));
+
+    // Recipient should have received the funds
+    assert_eq!(token_client.balance(&recipient), amount);
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_release_prog_schedule_automatic_blocks_reentrancy() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 500_0000000i128;
+    let release_timestamp = 1000u64;
+
+    let token_client = create_token_contract(&env, &authorized_key);
+    let token_admin = token::StellarAssetClient::new(&env, &token_client.address);
+    token_admin.mint(&authorized_key, &amount);
+
+    client.init_program(
+        &program_id,
+        &authorized_key,
+        &token_client.address,
+        &authorized_key,
+        &None,
+    );
+    token_client.transfer(&authorized_key, &contract_id, &amount);
+    client.lock_program_funds(&amount);
+
+    let schedule = client.create_program_release_schedule(&amount, &release_timestamp, &recipient);
+
+    // Advance time so the schedule is due
+    env.ledger().set_timestamp(release_timestamp + 1);
+
+    // Simulate a concurrent call already holding the guard
+    crate::reentrancy_guard::set_entered(&env);
+
+    // Should panic: guard is already held
+    client.release_prog_schedule_automatic(&schedule.schedule_id);
+}
+
+#[test]
+fn test_release_prog_schedule_automatic_normal_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 500_0000000i128;
+    let release_timestamp = 1000u64;
+
+    let token_client = create_token_contract(&env, &authorized_key);
+    let token_admin = token::StellarAssetClient::new(&env, &token_client.address);
+    token_admin.mint(&authorized_key, &amount);
+
+    client.init_program(
+        &program_id,
+        &authorized_key,
+        &token_client.address,
+        &authorized_key,
+        &None,
+    );
+    token_client.transfer(&authorized_key, &contract_id, &amount);
+    client.lock_program_funds(&amount);
+
+    let schedule = client.create_program_release_schedule(&amount, &release_timestamp, &recipient);
+
+    // Advance time so the schedule is due
+    env.ledger().set_timestamp(release_timestamp + 1);
+
+    // Guard must be clear before and after a successful call
+    assert!(!crate::reentrancy_guard::is_entered(&env));
+    client.release_prog_schedule_automatic(&schedule.schedule_id);
+    assert!(!crate::reentrancy_guard::is_entered(&env));
+
+    // Recipient should have received the funds
+    assert_eq!(token_client.balance(&recipient), amount);
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_cross_function_schedule_manual_to_single_payout_blocked() {
+    // Guard acquired by release_program_schedule_manual must block single_payout
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 1000_0000000i128;
+
+    let token_client = create_token_contract(&env, &authorized_key);
+    let token_admin = token::StellarAssetClient::new(&env, &token_client.address);
+    token_admin.mint(&authorized_key, &amount);
+
+    client.init_program(
+        &program_id,
+        &authorized_key,
+        &token_client.address,
+        &authorized_key,
+        &None,
+    );
+    token_client.transfer(&authorized_key, &contract_id, &amount);
+    client.lock_program_funds(&amount);
+
+    // Simulate being inside release_program_schedule_manual
+    crate::reentrancy_guard::set_entered(&env);
+
+    // single_payout must be blocked by the shared guard
+    client.single_payout(&recipient, &(amount / 2));
+}


### PR DESCRIPTION
## Summary

Two token-transferring functions in `contracts/program-escrow/src/lib.rs` were missing reentrancy guard coverage, leaving them open to reentrant calls. Both also violated the CEI (Checks-Effects-Interactions) pattern — the token transfer happened before on-chain state was updated.

## Functions fixed

| Function | Issue |
|---|---|
| `release_program_schedule_manual_internal` | No guard + token transfer before state update |
| `release_prog_schedule_automatic` | No guard + token transfer before state update |

## Changes

**`reentrancy_guard.rs`**
- Added `is_entered(env)` helper — returns `true` when the guard is held. Used by existing and new tests to assert the guard is cleared after successful calls.

**`lib.rs`**
- Added `reentrancy_guard::acquire(&env)` at the top of both functions
- Moved token transfers to after all state updates (schedule marked released, balance decremented, history written) — proper CEI pattern
- Added `reentrancy_guard::release(&env)` at the end of both functions

**`reentrancy_tests.rs`**
- `test_release_program_schedule_manual_blocks_reentrancy` — guard held → panics with "Reentrancy detected"
- `test_release_program_schedule_manual_normal_execution` — happy path, guard cleared after call
- `test_release_prog_schedule_automatic_blocks_reentrancy` — guard held → panics
- `test_release_prog_schedule_automatic_normal_execution` — happy path, guard cleared after call
- `test_cross_function_schedule_manual_to_single_payout_blocked` — guard held by schedule path blocks `single_payout`

## Security notes

- All five token-transferring functions now acquire the shared guard before any external call
- Soroban automatic state rollback on panic means the guard cannot get permanently stuck
- CEI pattern is now consistently applied across all release paths


close #1286