### PR TITLE
test: add PartiallyRefunded balance invariant tests for bounty_escrow…

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -6,7 +6,8 @@ mod invariants;
 mod multitoken_invariants;
 mod reentrancy_guard;
 // Pre-existing broken test modules excluded from compilation until their referenced types/methods are implemented:
-// #[cfg(test)] mod test_boundary_edge_cases;
+#[cfg(test)]
+mod test_boundary_edge_cases; // Issue #1294: PartiallyRefunded accounting tests
 // #[cfg(test)] mod test_cross_contract_interface; // pre-existing breakage: references unimplemented methods
 // #[cfg(test)] mod test_deterministic_randomness;
 // #[cfg(test)] mod test_multi_region_treasury;

--- a/contracts/bounty_escrow/contracts/escrow/src/test_boundary_edge_cases.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_boundary_edge_cases.rs
@@ -1,15 +1,21 @@
 //! Boundary tests for amount policy, deadlines, fee configuration, batch/query limits, and escrow cardinality.
 //!
+//! Also covers `EscrowStatus::PartiallyRefunded` balance invariants (Issue #1294):
+//! - `total_locked - sum(refunded) == remaining_amount` holds after every partial refund.
+//! - Sequential partial refunds each decrement `remaining_amount` exactly.
+//! - Refunding exactly the full remaining amount transitions to `Refunded`, not `PartiallyRefunded`.
+//! - Zero-amount refund approval is rejected before any state change.
+//!
 //! # Related contract limits
 //! - [`crate::BountyEscrowContract::set_amount_policy`] — inclusive `[min_amount, max_amount]`; invalid
 //!   ordering (`min > max`) panics.
 //! - [`crate::MAX_FEE_RATE`] — fee basis points cap (5000 = 50%).
 //! - [`crate::MAX_BATCH_SIZE`] — batch lock/release size (see `test_batch_failure_modes`).
-//! - Deadlines: `u64::MAX` is accepted as a sentinel for “no expiry” style locking; past timestamps are allowed at lock time.
+//! - Deadlines: `u64::MAX` is accepted as a sentinel for "no expiry" style locking; past timestamps are allowed at lock time.
 
 #![cfg(test)]
 
-use crate::{BountyEscrowContract, BountyEscrowContractClient, Error, EscrowStatus};
+use crate::{BountyEscrowContract, BountyEscrowContractClient, Error, EscrowStatus, RefundMode};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{token, Address, Env};
 
@@ -187,4 +193,402 @@ fn test_escrow_status_query_limit_zero_returns_empty() {
 
     let empty = client.get_escrow_ids_by_status(&EscrowStatus::Locked, &0u32, &0u32);
     assert_eq!(empty.len(), 0);
+}
+
+// ============================================================================
+// Issue #1294 — PartiallyRefunded balance invariant tests
+// ============================================================================
+//
+// Invariant under test:
+//   escrow.amount - sum(refund_history[*].amount) == escrow.remaining_amount
+//
+// Equivalently, after each partial refund:
+//   remaining_amount_before - refund_amount == remaining_amount_after
+//
+// All tests below use `approve_refund` + `refund` to drive the contract into
+// the PartiallyRefunded state and then assert the accounting invariant.
+
+/// Assert the core balance invariant for a single escrow:
+/// `total_locked - sum(refund_history amounts) == remaining_amount`.
+fn assert_balance_invariant(
+    client: &BountyEscrowContractClient,
+    bounty_id: u64,
+    total_locked: i128,
+) {
+    let info = client.get_escrow_info(&bounty_id);
+    let refunded_sum: i128 = info.refund_history.iter().map(|r| r.amount).sum();
+    assert_eq!(
+        total_locked - refunded_sum,
+        info.remaining_amount,
+        "balance invariant violated: total_locked({}) - refunded_sum({}) != remaining_amount({})",
+        total_locked,
+        refunded_sum,
+        info.remaining_amount,
+    );
+}
+
+/// Sequential partial refunds each decrement `remaining_amount` exactly and
+/// the balance invariant holds after every step.
+///
+/// Scenario: lock 1000, refund 300 × 3 times (leaves 100 remaining).
+#[test]
+fn test_sequential_partial_refunds_balance_invariant() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 1001u64;
+    let total = 1_000i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // Three sequential partial refunds: 300, 300, 300 (leaves 100 remaining)
+    for refund_amount in [300i128, 300i128, 300i128] {
+        let before = client.get_escrow_info(&bounty_id).remaining_amount;
+        client.approve_refund(&bounty_id, &refund_amount, &depositor, &RefundMode::Partial);
+        client.refund(&bounty_id);
+        let after = client.get_escrow_info(&bounty_id).remaining_amount;
+
+        assert_eq!(
+            before - refund_amount,
+            after,
+            "remaining_amount must decrease by exactly the refund amount"
+        );
+        assert_eq!(
+            client.get_escrow_info(&bounty_id).status,
+            EscrowStatus::PartiallyRefunded,
+            "status must be PartiallyRefunded while funds remain"
+        );
+        assert_balance_invariant(&client, bounty_id, total);
+    }
+
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 100);
+}
+
+/// Refunding exactly the full remaining amount via `RefundMode::Partial` must
+/// transition to `Refunded`, not `PartiallyRefunded`.
+///
+/// The contract rule: `if amount >= remaining_amount → Refunded`.
+#[test]
+fn test_partial_refund_of_full_amount_transitions_to_refunded() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 1002u64;
+    let total = 500i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // Approve and execute a refund for the entire locked amount using Partial mode.
+    client.approve_refund(&bounty_id, &total, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+
+    let info = client.get_escrow_info(&bounty_id);
+    assert_eq!(
+        info.status,
+        EscrowStatus::Refunded,
+        "refunding the full amount must yield Refunded, not PartiallyRefunded"
+    );
+    assert_eq!(info.remaining_amount, 0);
+    assert_balance_invariant(&client, bounty_id, total);
+}
+
+/// `approve_refund` with amount == 0 must be rejected before any state change.
+#[test]
+fn test_zero_amount_partial_refund_is_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 1003u64;
+    let total = 500i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    let result =
+        client.try_approve_refund(&bounty_id, &0i128, &depositor, &RefundMode::Partial);
+    assert!(result.is_err(), "zero-amount refund approval must be rejected");
+
+    // State must be completely unchanged
+    let info = client.get_escrow_info(&bounty_id);
+    assert_eq!(info.status, EscrowStatus::Locked);
+    assert_eq!(info.remaining_amount, total);
+    assert_eq!(info.refund_history.len(), 0);
+}
+
+/// Two sequential partial refunds from `PartiallyRefunded` state each decrement
+/// `remaining_amount` correctly and the invariant holds at every step.
+#[test]
+fn test_two_sequential_partial_refunds_invariant() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 1004u64;
+    let total = 900i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // First partial refund: 400 → remaining = 500
+    client.approve_refund(&bounty_id, &400i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 500);
+    assert_eq!(
+        client.get_escrow_info(&bounty_id).status,
+        EscrowStatus::PartiallyRefunded
+    );
+    assert_balance_invariant(&client, bounty_id, total);
+
+    // Second partial refund: 300 → remaining = 200
+    client.approve_refund(&bounty_id, &300i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 200);
+    assert_eq!(
+        client.get_escrow_info(&bounty_id).status,
+        EscrowStatus::PartiallyRefunded
+    );
+    assert_balance_invariant(&client, bounty_id, total);
+}
+
+/// After multiple partial refunds, a final refund that drains the remainder
+/// transitions to `Refunded` and the invariant still holds.
+#[test]
+fn test_partial_refunds_then_full_drain_transitions_to_refunded() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 1005u64;
+    let total = 600i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // Two partial refunds of 200 each → remaining = 200
+    client.approve_refund(&bounty_id, &200i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+    client.approve_refund(&bounty_id, &200i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 200);
+    assert_eq!(
+        client.get_escrow_info(&bounty_id).status,
+        EscrowStatus::PartiallyRefunded
+    );
+
+    // Final refund drains the rest → Refunded
+    client.approve_refund(&bounty_id, &200i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+
+    let info = client.get_escrow_info(&bounty_id);
+    assert_eq!(info.status, EscrowStatus::Refunded);
+    assert_eq!(info.remaining_amount, 0);
+    assert_balance_invariant(&client, bounty_id, total);
+}
+
+/// Partial refunds on independent escrows do not affect each other's balances.
+#[test]
+fn test_partial_refund_isolation_between_escrows() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let (id_a, id_b) = (2001u64, 2002u64);
+    let (total_a, total_b) = (800i128, 600i128);
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &id_a, &total_a, &deadline);
+    client.lock_funds(&depositor, &id_b, &total_b, &deadline);
+
+    // Partially refund escrow A only
+    client.approve_refund(&id_a, &300i128, &depositor, &RefundMode::Partial);
+    client.refund(&id_a);
+
+    // Escrow B must be completely unaffected
+    let info_b = client.get_escrow_info(&id_b);
+    assert_eq!(info_b.status, EscrowStatus::Locked);
+    assert_eq!(info_b.remaining_amount, total_b);
+    assert_eq!(info_b.refund_history.len(), 0);
+
+    // Escrow A invariant still holds
+    assert_balance_invariant(&client, id_a, total_a);
+}
+
+/// Minimum-unit partial refund (1 stroop) is accepted and the invariant holds.
+#[test]
+fn test_minimum_unit_partial_refund_invariant() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 3001u64;
+    let total = 100i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    client.approve_refund(&bounty_id, &1i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+
+    let info = client.get_escrow_info(&bounty_id);
+    assert_eq!(info.remaining_amount, 99);
+    assert_eq!(info.status, EscrowStatus::PartiallyRefunded);
+    assert_balance_invariant(&client, bounty_id, total);
+}
+
+/// `approve_refund` with amount exceeding `remaining_amount` is rejected;
+/// state is unchanged after the failed attempt.
+#[test]
+fn test_partial_refund_exceeding_remaining_is_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 4001u64;
+    let total = 200i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // First partial refund reduces remaining to 100
+    client.approve_refund(&bounty_id, &100i128, &depositor, &RefundMode::Partial);
+    client.refund(&bounty_id);
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 100);
+
+    // Attempt to approve a refund larger than remaining — must fail
+    let result =
+        client.try_approve_refund(&bounty_id, &101i128, &depositor, &RefundMode::Partial);
+    assert!(
+        result.is_err(),
+        "refund exceeding remaining_amount must be rejected"
+    );
+
+    // State must be unchanged
+    assert_eq!(client.get_escrow_info(&bounty_id).remaining_amount, 100);
+    assert_balance_invariant(&client, bounty_id, total);
+}
+
+/// `RefundMode::Full` always transitions to `Refunded` regardless of the
+/// approved amount, because the mode flag overrides the amount comparison.
+#[test]
+fn test_full_mode_refund_always_transitions_to_refunded() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 5001u64;
+    let total = 400i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    // Approve with Full mode and only 200 amount
+    client.approve_refund(&bounty_id, &200i128, &depositor, &RefundMode::Full);
+    client.refund(&bounty_id);
+
+    assert_eq!(
+        client.get_escrow_info(&bounty_id).status,
+        EscrowStatus::Refunded,
+        "RefundMode::Full must always yield Refunded regardless of amount"
+    );
+}
+
+/// `refund_history` grows by exactly 1 per partial refund call, and the
+/// balance invariant holds after each entry is appended.
+#[test]
+fn test_refund_history_grows_per_partial_refund() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let depositor = Address::generate(&e);
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&e, &contract_id);
+    let token = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    token::StellarAssetClient::new(&e, &token).mint(&depositor, &1_000_000i128);
+    client.init(&admin, &token);
+
+    let bounty_id = 6001u64;
+    let total = 900i128;
+    let deadline = e.ledger().timestamp() + 100_000;
+    client.lock_funds(&depositor, &bounty_id, &total, &deadline);
+
+    for (i, amount) in [100i128, 100i128, 100i128].iter().enumerate() {
+        client.approve_refund(&bounty_id, amount, &depositor, &RefundMode::Partial);
+        client.refund(&bounty_id);
+        assert_eq!(
+            client.get_escrow_info(&bounty_id).refund_history.len(),
+            (i + 1) as u32,
+            "refund_history must grow by exactly 1 per refund"
+        );
+        assert_balance_invariant(&client, bounty_id, total);
+    }
 }

--- a/docs/bounty-escrow/partial-refund-accounting.md
+++ b/docs/bounty-escrow/partial-refund-accounting.md
@@ -1,0 +1,128 @@
+# Partial Refund Accounting — `bounty_escrow` EscrowData
+
+> Issue #1294 — Balance invariant verification for `EscrowStatus::PartiallyRefunded`
+
+## Overview
+
+The `bounty_escrow` contract supports partial refunds: an admin can approve returning a
+portion of locked funds to the depositor before the full escrow is settled. After each
+partial refund the escrow transitions to `EscrowStatus::PartiallyRefunded` and the
+remaining claimable balance is decremented exactly.
+
+This document describes the accounting invariant, the state machine, and the test
+coverage added in Issue #1294.
+
+---
+
+## Core Invariant
+
+At every point in the escrow lifecycle the following must hold:
+
+```
+escrow.amount - sum(refund_history[*].amount) == escrow.remaining_amount
+```
+
+Where:
+
+| Field | Description |
+|---|---|
+| `escrow.amount` | Total amount originally locked (immutable after `lock_funds`) |
+| `refund_history` | Append-only log of every refund executed on this escrow |
+| `escrow.remaining_amount` | Funds still available for release or further refund |
+
+---
+
+## State Machine
+
+```
+Locked ──(partial refund, amount < remaining)──► PartiallyRefunded
+Locked ──(full refund or RefundMode::Full)──────► Refunded
+PartiallyRefunded ──(partial refund, amount < remaining)──► PartiallyRefunded
+PartiallyRefunded ──(refund drains remainder)───────────────► Refunded
+```
+
+Key rules enforced by the contract:
+
+1. `approve_refund(amount)` requires `amount > 0 && amount <= remaining_amount`.
+2. `refund()` sets status to `Refunded` when `mode == Full` **or** `amount >= remaining_amount`.
+3. `refund()` sets status to `PartiallyRefunded` otherwise.
+4. `remaining_amount` is decremented by exactly `refund_amount` (integer subtraction, no rounding).
+5. Each `refund()` call appends exactly one entry to `refund_history`.
+
+---
+
+## Security Assumptions
+
+- **No underflow**: `remaining_amount` is checked against `refund_amount` before subtraction;
+  `checked_sub` is used to catch any arithmetic overflow at the Rust level.
+- **No double-spend**: The reentrancy guard prevents concurrent execution of any protected
+  function. State is updated (CEI pattern) before the external token transfer.
+- **Approval consumed**: The `RefundApproval` storage entry is deleted after a successful
+  `refund()` call, preventing replay of the same approval.
+- **Status guard**: `approve_refund` and `refund` both reject escrows that are not in
+  `Locked` or `PartiallyRefunded` state, preventing refunds on already-settled escrows.
+- **Isolation**: Each escrow's `remaining_amount` and `refund_history` are stored under a
+  per-`bounty_id` key; partial refunds on one escrow cannot affect another.
+
+---
+
+## Test Coverage (Issue #1294)
+
+All tests live in
+`contracts/bounty_escrow/contracts/escrow/src/test_boundary_edge_cases.rs`.
+
+| Test | What it verifies |
+|---|---|
+| `test_sequential_partial_refunds_balance_invariant` | Invariant holds after each of 3 sequential partial refunds |
+| `test_partial_refund_of_full_amount_transitions_to_refunded` | `Partial` mode with `amount == remaining` → `Refunded` |
+| `test_zero_amount_partial_refund_is_rejected` | `approve_refund(0)` is rejected; state unchanged |
+| `test_two_sequential_partial_refunds_invariant` | Two refunds from `PartiallyRefunded` state; invariant holds |
+| `test_partial_refunds_then_full_drain_transitions_to_refunded` | Multiple partials then final drain → `Refunded` |
+| `test_partial_refund_isolation_between_escrows` | Refunding escrow A does not affect escrow B |
+| `test_minimum_unit_partial_refund_invariant` | 1-stroop refund accepted; invariant holds |
+| `test_partial_refund_exceeding_remaining_is_rejected` | `approve_refund(remaining + 1)` rejected; state unchanged |
+| `test_full_mode_refund_always_transitions_to_refunded` | `RefundMode::Full` always yields `Refunded` |
+| `test_refund_history_grows_per_partial_refund` | `refund_history.len()` increments by 1 per call |
+
+### Running the tests
+
+```bash
+cargo test -p escrow -- test_boundary_edge_cases
+```
+
+---
+
+## Example: Sequential Partial Refunds
+
+```rust
+// Lock 1000 units
+client.lock_funds(&depositor, &bounty_id, &1000, &deadline);
+// remaining_amount = 1000, status = Locked
+
+// First partial refund: 300
+client.approve_refund(&bounty_id, &300, &depositor, &RefundMode::Partial);
+client.refund(&bounty_id);
+// remaining_amount = 700, status = PartiallyRefunded
+// refund_history = [{ amount: 300, ... }]
+
+// Second partial refund: 300
+client.approve_refund(&bounty_id, &300, &depositor, &RefundMode::Partial);
+client.refund(&bounty_id);
+// remaining_amount = 400, status = PartiallyRefunded
+// refund_history = [{ amount: 300 }, { amount: 300 }]
+
+// Final refund drains remainder: 400
+client.approve_refund(&bounty_id, &400, &depositor, &RefundMode::Partial);
+client.refund(&bounty_id);
+// remaining_amount = 0, status = Refunded
+// refund_history = [{ amount: 300 }, { amount: 300 }, { amount: 400 }]
+// Invariant: 1000 - (300 + 300 + 400) == 0 ✓
+```
+
+---
+
+## Related Files
+
+- `contracts/bounty_escrow/contracts/escrow/src/lib.rs` — `approve_refund`, `refund`, `EscrowStatus`, `RefundMode`
+- `contracts/bounty_escrow/contracts/escrow/src/test_boundary_edge_cases.rs` — tests
+- `contracts/bounty_escrow/contracts/escrow/INVARIANTS_ESCROW.md` — broader invariant catalog


### PR DESCRIPTION
/…
/
/ EscrowData

- Enable test_boundary_edge_cases module in lib.rs (was commented out)
- Add RefundMode to imports in test_boundary_edge_cases.rs
- Add assert_balance_invariant helper: total_locked - sum(refund_history) == remaining_amount
- Add 8 new tests covering Issue #1294:
  - sequential partial refunds hold invariant after each step
  - partial refund of full amount transitions to Refunded not PartiallyRefunded
  - zero-amount approve_refund is rejected with no state change
  - two sequential partial refunds from PartiallyRefunded state
  - multiple partials then full drain transitions to Refunded
  - isolation between independent escrows
  - minimum-unit (1 stroop) partial refund
  - approve_refund exceeding remaining_amount is rejected
  - RefundMode::Full always yields Refunded
  - refund_history grows by exactly 1 per refund call
- Add docs/bounty-escrow/partial-refund-accounting.md

Closes #1294