### PR TITLE
feat: add actor and reason metadata to PauseStateChanged_V2 event

### DIFF
--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -1107,11 +1107,16 @@ pub struct PauseStateChanged {
 /// ### Topics
 /// `(PAUSE_STATE_CHANGED_V2, operation_symbol)`
 ///
+/// ### Fields
+/// - `actor`: The address that triggered the pause state change (admin or authorized caller).
+/// - `reason`: Optional human-readable reason string, bounded to 256 characters.
+///
 /// ### Security notes
 /// - `previous_paused` is read from storage **before** the mutation so the
 ///   event accurately reflects the transition (old → new).
 /// - `invariant_ok` is always `true` on-chain; a `false` value would indicate
 ///   a storage corruption bug.
+/// - `reason` is bounded to [`PAUSE_REASON_MAX_LEN`] characters to prevent storage abuse.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PauseStateChangedV2 {
@@ -1119,11 +1124,18 @@ pub struct PauseStateChangedV2 {
     pub operation: Symbol,
     pub previous_paused: bool,
     pub paused: bool,
-    pub admin: Address,
+    /// The address that triggered the pause state change.
+    pub actor: Address,
+    /// Optional human-readable reason, bounded to 256 characters.
     pub reason: Option<String>,
     pub timestamp: u64,
     pub receipt_id: u64,
 }
+
+/// Maximum allowed length (in characters) for a pause reason string.
+///
+/// Enforced in [`ProgramEscrowContract::set_paused`] to prevent storage abuse.
+pub const PAUSE_REASON_MAX_LEN: u32 = 256;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3542,7 +3554,21 @@ impl ProgramEscrowContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
-    /// Update pause flags (admin only)
+    /// Update pause flags (admin only).
+    ///
+    /// ### Parameters
+    /// - `lock`: If `Some(true)`, pause lock operations; `Some(false)` unpauses.
+    /// - `release`: If `Some(true)`, pause release operations; `Some(false)` unpauses.
+    /// - `refund`: If `Some(true)`, pause refund operations; `Some(false)` unpauses.
+    /// - `reason`: Optional human-readable reason string, bounded to [`PAUSE_REASON_MAX_LEN`] (256) characters.
+    ///
+    /// ### Events
+    /// Emits [`PauseStateChanged`] and [`PauseStateChangedV2`] for each flag that changes.
+    /// The V2 event includes `actor` (the admin address) and `reason` for full audit trail.
+    ///
+    /// ### Errors
+    /// Panics if the contract is not initialized or the caller is not the admin.
+    /// Panics if `reason` exceeds 256 characters.
     pub fn set_paused(
         env: Env,
         lock: Option<bool>,
@@ -3556,6 +3582,13 @@ impl ProgramEscrowContract {
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
+
+        // Enforce 256-character bound on reason to prevent storage abuse.
+        if let Some(ref r) = reason {
+            if r.len() > PAUSE_REASON_MAX_LEN {
+                panic!("Pause reason exceeds maximum length of 256 characters");
+            }
+        }
 
         let mut flags = Self::get_pause_flags(&env);
         let timestamp = env.ledger().timestamp();
@@ -3586,7 +3619,7 @@ impl ProgramEscrowContract {
                     operation: symbol_short!("lock"),
                     previous_paused,
                     paused,
-                    admin: admin.clone(),
+                    actor: admin.clone(),
                     reason: reason.clone(),
                     timestamp,
                     receipt_id,
@@ -3616,7 +3649,7 @@ impl ProgramEscrowContract {
                     operation: symbol_short!("release"),
                     previous_paused,
                     paused,
-                    admin: admin.clone(),
+                    actor: admin.clone(),
                     reason: reason.clone(),
                     timestamp,
                     receipt_id,
@@ -3646,7 +3679,7 @@ impl ProgramEscrowContract {
                     operation: symbol_short!("refund"),
                     previous_paused,
                     paused,
-                    admin: admin.clone(),
+                    actor: admin.clone(),
                     reason: reason.clone(),
                     timestamp,
                     receipt_id,

--- a/contracts/program-escrow/src/test.rs
+++ b/contracts/program-escrow/src/test.rs
@@ -4244,7 +4244,7 @@ fn test_pause_state_changed_v2_event_on_pause() {
         "previous_paused must be false before first pause"
     );
     assert_eq!(data.paused, true);
-    assert_eq!(data.admin, admin);
+    assert_eq!(data.actor, admin);
     assert_eq!(data.timestamp, 99_999);
     assert!(data.receipt_id > 0);
 }

--- a/contracts/program-escrow/src/test_pause.rs
+++ b/contracts/program-escrow/src/test_pause.rs
@@ -683,3 +683,150 @@ fn test_rbac_emergency_withdraw_ignores_release_and_refund_pause() {
     // Should still fail because lock is not paused
     contract_client.emergency_withdraw(&target);
 }
+
+// =========================================================================
+// ISSUE #1267: actor+reason metadata in PauseStateChangedV2 event
+// =========================================================================
+
+/// V2 event includes `actor` field (the admin address that triggered the pause).
+#[test]
+fn test_pause_v2_event_includes_actor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, admin) = setup_with_admin(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 5000);
+    contract.set_paused(&Some(true), &None, &None, &None);
+
+    let events = env.events().all();
+    let v2_event = events
+        .iter()
+        .find(|e| {
+            if let Some(t0) = e.1.get(0) {
+                let sym: Symbol = t0.into_val(&env);
+                sym == Symbol::new(&env, "PauseStV2")
+            } else {
+                false
+            }
+        })
+        .expect("PauseStateChangedV2 event must be emitted");
+
+    let data = PauseStateChangedV2::try_from_val(&env, &v2_event.2).unwrap();
+    assert_eq!(data.actor, admin, "actor must be the admin address");
+}
+
+/// V2 event includes `reason` when provided.
+#[test]
+fn test_pause_v2_event_includes_reason() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, _admin) = setup_with_admin(&env);
+
+    let reason = String::from_str(&env, "Security incident detected");
+    contract.set_paused(&Some(true), &None, &None, &Some(reason.clone()));
+
+    let events = env.events().all();
+    let v2_event = events
+        .iter()
+        .find(|e| {
+            if let Some(t0) = e.1.get(0) {
+                let sym: Symbol = t0.into_val(&env);
+                sym == Symbol::new(&env, "PauseStV2")
+            } else {
+                false
+            }
+        })
+        .expect("PauseStateChangedV2 event must be emitted");
+
+    let data = PauseStateChangedV2::try_from_val(&env, &v2_event.2).unwrap();
+    assert_eq!(data.reason, Some(reason), "reason must be included in V2 event");
+}
+
+/// V2 event has `reason = None` when no reason is provided.
+#[test]
+fn test_pause_v2_event_reason_none_when_omitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, _admin) = setup_with_admin(&env);
+
+    contract.set_paused(&Some(true), &None, &None, &None);
+
+    let events = env.events().all();
+    let v2_event = events
+        .iter()
+        .find(|e| {
+            if let Some(t0) = e.1.get(0) {
+                let sym: Symbol = t0.into_val(&env);
+                sym == Symbol::new(&env, "PauseStV2")
+            } else {
+                false
+            }
+        })
+        .expect("PauseStateChangedV2 event must be emitted");
+
+    let data = PauseStateChangedV2::try_from_val(&env, &v2_event.2).unwrap();
+    assert_eq!(data.reason, None, "reason must be None when not provided");
+}
+
+/// Reason at exactly 256 characters is accepted.
+#[test]
+fn test_pause_reason_at_max_length_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, _admin) = setup_with_admin(&env);
+
+    // Build a 256-character string
+    let reason_str: std::string::String = "a".repeat(256);
+    let reason = String::from_str(&env, &reason_str);
+    // Should not panic
+    contract.set_paused(&Some(true), &None, &None, &Some(reason));
+    let flags = contract.get_pause_flags();
+    assert_eq!(flags.lock_paused, true);
+}
+
+/// Reason exceeding 256 characters is rejected.
+#[test]
+#[should_panic(expected = "Pause reason exceeds maximum length of 256 characters")]
+fn test_pause_reason_exceeds_max_length_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, _admin) = setup_with_admin(&env);
+
+    // Build a 257-character string
+    let reason_str: std::string::String = "a".repeat(257);
+    let reason = String::from_str(&env, &reason_str);
+    contract.set_paused(&Some(true), &None, &None, &Some(reason));
+}
+
+/// All three operations (lock, release, refund) emit V2 events with correct actor.
+#[test]
+fn test_pause_v2_events_emitted_for_all_operations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract, admin) = setup_with_admin(&env);
+
+    let reason = String::from_str(&env, "Maintenance");
+    contract.set_paused(&Some(true), &Some(true), &Some(true), &Some(reason.clone()));
+
+    let events = env.events().all();
+    let v2_events: std::vec::Vec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Some(t0) = e.1.get(0) {
+                let sym: Symbol = t0.into_val(&env);
+                sym == Symbol::new(&env, "PauseStV2")
+            } else {
+                false
+            }
+        })
+        .collect();
+
+    assert_eq!(v2_events.len(), 3, "Must emit one V2 event per operation");
+
+    for event in &v2_events {
+        let data = PauseStateChangedV2::try_from_val(&env, &event.2).unwrap();
+        assert_eq!(data.actor, admin, "actor must be admin in all V2 events");
+        assert_eq!(data.reason, Some(reason.clone()), "reason must be present in all V2 events");
+        assert_eq!(data.paused, true);
+    }
+}

--- a/docs/program-escrow/pause-management.md
+++ b/docs/program-escrow/pause-management.md
@@ -1,0 +1,131 @@
+# Pause Management — `program-escrow`
+
+## Overview
+
+The `ProgramEscrowContract` supports granular pause controls for three operation classes:
+
+| Flag | Blocks |
+|------|--------|
+| `lock_paused` | `lock_program_funds` |
+| `release_paused` | `single_payout`, `batch_payout`, `trigger_scheduled_releases` |
+| `refund_paused` | `refund_program` |
+
+Only the contract admin can toggle pause flags via `set_paused`.
+
+---
+
+## `set_paused` Function
+
+```rust
+pub fn set_paused(
+    env: Env,
+    lock: Option<bool>,
+    release: Option<bool>,
+    refund: Option<bool>,
+    reason: Option<String>,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lock` | `Option<bool>` | `Some(true)` pauses lock operations; `Some(false)` unpauses. `None` leaves unchanged. |
+| `release` | `Option<bool>` | `Some(true)` pauses release/payout operations; `Some(false)` unpauses. `None` leaves unchanged. |
+| `refund` | `Option<bool>` | `Some(true)` pauses refund operations; `Some(false)` unpauses. `None` leaves unchanged. |
+| `reason` | `Option<String>` | Optional human-readable reason string. **Bounded to 256 characters.** |
+
+### Authorization
+
+Requires the contract admin to authorize the call.
+
+### Reason String Bound
+
+The `reason` parameter is bounded to **256 characters** (`PAUSE_REASON_MAX_LEN = 256`) to prevent storage abuse. Providing a reason longer than 256 characters will cause the transaction to panic.
+
+---
+
+## Events
+
+### `PauseStateChanged` (V1)
+
+Emitted for backward compatibility. Contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `operation` | `Symbol` | `"lock"`, `"release"`, or `"refund"` |
+| `paused` | `bool` | New pause state |
+| `admin` | `Address` | Admin address that triggered the change |
+| `reason` | `Option<String>` | Optional reason string |
+| `timestamp` | `u64` | Ledger timestamp |
+| `receipt_id` | `u64` | Monotonic receipt ID |
+
+### `PauseStateChangedV2` (V2) — Preferred
+
+Emitted alongside V1 for every `set_paused` call. Adds audit trail fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `u32` | Event schema version (`EVENT_VERSION_V2`) |
+| `operation` | `Symbol` | `"lock"`, `"release"`, or `"refund"` |
+| `previous_paused` | `bool` | Pause state **before** this call |
+| `paused` | `bool` | New pause state |
+| `actor` | `Address` | **The address that triggered the pause state change** |
+| `reason` | `Option<String>` | Optional human-readable reason, bounded to 256 chars |
+| `timestamp` | `u64` | Ledger timestamp |
+| `receipt_id` | `u64` | Monotonic receipt ID |
+
+#### Topics
+
+```
+(PAUSE_STATE_CHANGED_V2, operation_symbol)
+```
+
+#### Security Notes
+
+- `actor` is always the authenticated admin address — it cannot be spoofed.
+- `previous_paused` is read from storage **before** the mutation, accurately reflecting the old → new transition.
+- `reason` is bounded to 256 characters to prevent storage abuse.
+
+---
+
+## Audit Trail
+
+The V2 event provides a complete audit trail for incident post-mortems:
+
+- **Who** paused: `actor` field
+- **What** was paused: `operation` field
+- **Why**: `reason` field
+- **When**: `timestamp` field
+- **State transition**: `previous_paused` → `paused`
+
+Indexers should prefer `PauseStateChangedV2` over `PauseStateChanged` for new integrations.
+
+---
+
+## Example
+
+```rust
+// Pause lock operations with a reason
+contract.set_paused(
+    &Some(true),   // pause lock
+    &None,         // leave release unchanged
+    &None,         // leave refund unchanged
+    &Some(String::from_str(&env, "Security incident — investigating")),
+);
+```
+
+This emits a `PauseStateChangedV2` event with:
+- `actor` = admin address
+- `operation` = `"lock"`
+- `previous_paused` = `false`
+- `paused` = `true`
+- `reason` = `Some("Security incident — investigating")`
+
+---
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PAUSE_REASON_MAX_LEN` | `256` | Maximum characters allowed in a pause reason string |


### PR DESCRIPTION
- Rename admin -> actor in PauseStateChangedV2 struct for clarity
- Add PAUSE_REASON_MAX_LEN = 256 constant to bound reason strings
- Enforce 256-char limit on reason in set_paused to prevent storage abuse
- Update all three PauseStateChangedV2 emissions to use actor field
- Add NatSpec-style doc comments to set_paused and PauseStateChangedV2
- Add tests: actor field, reason field, reason=None, max-length accepted, exceeds-max-length rejected, all three operations emit V2 events
- Add docs/program-escrow/pause-management.md documentation

Closes #1267