### PR TITLE
feat: add multisig threshold for high-value admin operations

### DIFF
--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -671,126 +671,20 @@ pub enum ContractError {
     /// present in the allowlist.
     TokenNotInAllowlist = 1102,
 
+    // =================================================================
     // =========================================================================
-    // Role Management Errors (1200-1299)
+    // Multisig Admin Op Errors (1300-1399)
     // =========================================================================
 
-    /// Admin rotation already in progress.
-    ///
-    /// This error occurs when attempting to start a new admin rotation
-    /// while another rotation is already pending.
-    AdminRotationInProgress = 1200,
-
-    /// No admin rotation in progress.
-    ///
-    /// This error occurs when attempting to accept or cancel an admin
-    /// rotation when no rotation is pending.
-    NoAdminRotationInProgress = 1201,
-
-    /// Invalid admin rotation state.
-    ///
-    /// This error occurs when admin rotation state is inconsistent
-    /// or corrupted.
-    InvalidAdminRotationState = 1202,
-
-    /// Controller rotation already in progress.
-    ///
-    /// This error occurs when attempting to start a new controller rotation
-    /// while another rotation is already pending for the same program.
-    ControllerRotationInProgress = 1203,
-
-    /// No controller rotation in progress.
-    ///
-    /// This error occurs when attempting to accept or cancel a controller
-    /// rotation when no rotation is pending.
-    NoControllerRotationInProgress = 1204,
-
-    /// Invalid controller rotation state.
-    ///
-    /// This error occurs when controller rotation state is inconsistent
-    /// or corrupted.
-    InvalidControllerRotationState = 1205,
-
-    /// Role transition period expired.
-    ///
-    /// This error occurs when attempting to complete a role rotation
-    /// after the allowed transition period has expired.
-    RoleTransitionExpired = 1206,
-
-    /// Invalid role proposal.
-    ///
-    /// This error occurs when the proposed role is invalid
-    /// (e.g., same as current, zero address, etc.).
-    InvalidRoleProposal = 1207,
-
-    /// Role rotation not allowed.
-    ///
-    /// This error occurs when role rotation is temporarily disabled
-    /// due to contract state (e.g., emergency mode, dispute, etc.).
-    RoleRotationNotAllowed = 1208,
-}
-
-/// Explicit error enum for all batch payout failure modes.
-///
-/// Used as the `Err` variant of `batch_payout` / `batch_payout_by` so callers
-/// receive a typed, stable error code instead of an opaque panic string.
-///
-/// ## Error Code Ranges
-/// Codes 3100–3199 are reserved for batch-payout errors.
-///
-/// ## Upgrade Safety
-/// Codes are stable. New variants may be added; existing codes will not change.
-#[soroban_sdk::contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum BatchPayoutError {
-    /// Program storage has not been initialized.
-    NotInitialized = 3100,
-    /// Release operations are paused.
-    Paused = 3101,
-    /// A dispute is open; payouts are blocked.
-    DisputeOpen = 3102,
-    /// Caller is not the authorized payout key, admin, or a permitted delegate.
-    Unauthorized = 3103,
-    /// `recipients` and `amounts` vectors have different lengths.
-    LengthMismatch = 3104,
-    /// Batch contains zero entries.
-    EmptyBatch = 3105,
-    /// At least one amount is zero or negative.
-    ZeroAmount = 3106,
-    /// Summing amounts would overflow `i128`.
-    AmountOverflow = 3107,
-    /// Batch total exceeds the per-program spend threshold.
-    SpendLimitExceeded = 3108,
-    /// Batch total exceeds the program's remaining balance.
-    InsufficientBalance = 3109,
-    /// Circuit breaker is open.
-    CircuitBreakerOpen = 3110,
-    /// Batch contains duplicate recipient addresses.
-    DuplicateRecipient = 3111,
-    /// A payout fee would consume an entire individual payout.
-    FeeConsumesAmount = 3112,
-}
-
-impl BatchPayoutError {
-    /// Returns a stable, human-readable description (no sensitive data).
-    pub fn description(self) -> &'static str {
-        match self {
-            BatchPayoutError::NotInitialized => "Program not initialized",
-            BatchPayoutError::Paused => "Funds Paused",
-            BatchPayoutError::DisputeOpen => "Payout blocked: dispute open",
-            BatchPayoutError::Unauthorized => "Unauthorized",
-            BatchPayoutError::LengthMismatch => "Recipients and amounts vectors must have the same length",
-            BatchPayoutError::EmptyBatch => "Cannot process empty batch",
-            BatchPayoutError::ZeroAmount => "All amounts must be greater than zero",
-            BatchPayoutError::AmountOverflow => "Payout amount overflow",
-            BatchPayoutError::SpendLimitExceeded => "Spend threshold exceeded",
-            BatchPayoutError::InsufficientBalance => "Insufficient balance",
-            BatchPayoutError::CircuitBreakerOpen => "Circuit breaker is OPEN",
-            BatchPayoutError::DuplicateRecipient => "Duplicate recipient in batch",
-            BatchPayoutError::FeeConsumesAmount => "Payout fee consumes entire payout",
-        }
-    }
+    PendingOpExists = 1300,
+    NoPendingOp = 1301,
+    PendingOpExpired = 1302,
+    AlreadyApproved = 1303,
+    NotASigner = 1304,
+    PayloadMismatch = 1305,
+    InsufficientApprovals = 1306,
+    InvalidMultisigConfig = 1307,
+=
 }
 
 impl ContractError {
@@ -934,6 +828,16 @@ impl ContractError {
             ContractError::ReleaseTriggerFailed => "Release trigger failed",
             ContractError::NoSchedulesDue => "No schedules are due for release",
             ContractError::DeterminismViolation => "Determinism violation detected",
+            // Multisig Admin Op Errors
+            ContractError::PendingOpExists => "A pending admin operation already exists",
+            ContractError::NoPendingOp => "No pending admin operation found",
+            ContractError::PendingOpExpired => "Pending admin operation has expired",
+            ContractError::AlreadyApproved => "Signer has already approved",
+            ContractError::NotASigner => "Caller is not a configured signer",
+            ContractError::PayloadMismatch => "Payload hash does not match pending operation",
+            ContractError::InsufficientApprovals => "Insufficient approvals to execute",
+            ContractError::InvalidMultisigConfig => "Invalid multisig configuration",
+
         }
     }
     

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -862,6 +862,48 @@ pub struct IdempotencySchemaVersionSet {
 
 // Constants for idempotency key validation
 pub const IDEMPOTENCY_KEY_MAX_LENGTH: u32 = 256;
+// ── Multisig threshold ────────────────────────────────────────────────────────
+pub const ADMIN_OP_EXPIRY_LEDGERS: u32 = 17_280;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigThresholdConfig {
+    pub signers: soroban_sdk::Vec<Address>,
+    pub required_approvals: u32,
+    pub high_value_threshold: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AdminOpKind { UpdateFeeConfig, UpdateMultisigConfig, EmergencyWithdraw }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAdminOp {
+    pub kind: AdminOpKind,
+    pub value: i128,
+    pub proposed_by: Address,
+    pub proposed_at: u32,
+    pub expires_at: u32,
+    pub approvals: soroban_sdk::Vec<Address>,
+    pub payload_hash: soroban_sdk::Bytes,
+}
+
+const ADMIN_OP_PROPOSED: Symbol = symbol_short!("AdmProp");
+const ADMIN_OP_APPROVED: Symbol = symbol_short!("AdmAppr");
+const ADMIN_OP_EXECUTED: Symbol = symbol_short!("AdmExec");
+const ADMIN_OP_EXPIRED:  Symbol = symbol_short!("AdmExp");
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminOpProposedEvent { pub version: u32, pub kind: AdminOpKind, pub proposed_by: Address, pub expires_at: u32, pub required_approvals: u32 }
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminOpApprovedEvent { pub version: u32, pub kind: AdminOpKind, pub approved_by: Address, pub approvals_so_far: u32, pub required_approvals: u32 }
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminOpExecutedEvent { pub version: u32, pub kind: AdminOpKind, pub executed_by: Address }
+
 pub const IDEMPOTENCY_SCHEMA_VERSION_V1: u32 = 1;
 
 // Event symbols for dispute lifecycle
@@ -1074,7 +1116,11 @@ pub enum DataKey {
     RoleManagementSchemaVersion,
     /// Role management configuration for deterministic behavior.
     RoleManagementConfig,
+    MultisigThresholdConfig,         // MultisigThresholdConfig (global admin multisig)
+    PendingAdminOp,                  // PendingAdminOp (at most one pending op at a time)
+
 }
+
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -5846,6 +5892,93 @@ impl ProgramEscrowContract {
     /// Return the admin address.
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::Admin)
+
+    // ── Multisig threshold for high-value admin operations ───────────────────
+
+    pub fn set_multisig_threshold_config(
+        env: Env,
+        signers: soroban_sdk::Vec<Address>,
+        required_approvals: u32,
+        high_value_threshold: i128,
+    ) {
+        Self::require_admin(&env);
+        if signers.is_empty() { panic!("InvalidMultisigConfig: signers must not be empty"); }
+        if required_approvals == 0 || required_approvals > signers.len() as u32 {
+            panic!("InvalidMultisigConfig: required_approvals out of range");
+        }
+        if high_value_threshold < 0 { panic!("InvalidMultisigConfig: threshold must be non-negative"); }
+        env.storage().instance().set(
+            &DataKey::MultisigThresholdConfig,
+            &MultisigThresholdConfig { signers, required_approvals, high_value_threshold },
+        );
+    }
+
+    pub fn get_multisig_threshold_config(env: Env) -> Option<MultisigThresholdConfig> {
+        env.storage().instance().get(&DataKey::MultisigThresholdConfig)
+    }
+
+    pub fn propose_admin_op(env: Env, kind: AdminOpKind, value: i128, payload_hash: soroban_sdk::Bytes) -> PendingAdminOp {
+        let admin = Self::require_admin(&env);
+        if let Some(existing) = env.storage().instance().get::<DataKey, PendingAdminOp>(&DataKey::PendingAdminOp) {
+            if env.ledger().sequence() <= existing.expires_at { panic!("PendingOpExists"); }
+        }
+        let cfg: MultisigThresholdConfig = env.storage().instance().get(&DataKey::MultisigThresholdConfig)
+            .unwrap_or(MultisigThresholdConfig { signers: vec![&env, admin.clone()], required_approvals: 1, high_value_threshold: i128::MAX });
+        let cur = env.ledger().sequence();
+        let expires_at = cur.checked_add(ADMIN_OP_EXPIRY_LEDGERS).unwrap_or(u32::MAX);
+        let mut approvals: soroban_sdk::Vec<Address> = Vec::new(&env);
+        approvals.push_back(admin.clone());
+        let op = PendingAdminOp { kind: kind.clone(), value, proposed_by: admin.clone(), proposed_at: cur, expires_at, approvals, payload_hash };
+        env.storage().instance().set(&DataKey::PendingAdminOp, &op);
+        env.events().publish((ADMIN_OP_PROPOSED,), AdminOpProposedEvent { version: EVENT_VERSION_V2, kind, proposed_by: admin, expires_at, required_approvals: cfg.required_approvals });
+        op
+    }
+
+    pub fn approve_admin_op(env: Env, signer: Address) -> PendingAdminOp {
+        signer.require_auth();
+        let cfg: MultisigThresholdConfig = env.storage().instance().get(&DataKey::MultisigThresholdConfig)
+            .unwrap_or_else(|| panic!("NoPendingOp: multisig not configured"));
+        let mut is_signer = false;
+        for s in cfg.signers.iter() { if s == signer { is_signer = true; break; } }
+        if !is_signer { panic!("NotASigner"); }
+        let mut op: PendingAdminOp = env.storage().instance().get(&DataKey::PendingAdminOp)
+            .unwrap_or_else(|| panic!("NoPendingOp"));
+        if env.ledger().sequence() > op.expires_at { panic!("PendingOpExpired"); }
+        for e in op.approvals.iter() { if e == signer { panic!("AlreadyApproved"); } }
+        op.approvals.push_back(signer.clone());
+        env.storage().instance().set(&DataKey::PendingAdminOp, &op);
+        env.events().publish((ADMIN_OP_APPROVED,), AdminOpApprovedEvent { version: EVENT_VERSION_V2, kind: op.kind.clone(), approved_by: signer, approvals_so_far: op.approvals.len() as u32, required_approvals: cfg.required_approvals });
+        op
+    }
+
+    pub fn execute_admin_op(env: Env, payload_hash: soroban_sdk::Bytes) -> AdminOpKind {
+        let admin = Self::require_admin(&env);
+        let op: PendingAdminOp = env.storage().instance().get(&DataKey::PendingAdminOp)
+            .unwrap_or_else(|| panic!("NoPendingOp"));
+        if env.ledger().sequence() > op.expires_at {
+            env.storage().instance().remove(&DataKey::PendingAdminOp);
+            env.events().publish((ADMIN_OP_EXPIRED,), op.kind.clone());
+            panic!("PendingOpExpired");
+        }
+        if op.payload_hash != payload_hash { panic!("PayloadMismatch"); }
+        let cfg: MultisigThresholdConfig = env.storage().instance().get(&DataKey::MultisigThresholdConfig)
+            .unwrap_or(MultisigThresholdConfig { signers: vec![&env, admin.clone()], required_approvals: 1, high_value_threshold: i128::MAX });
+        if (op.approvals.len() as u32) < cfg.required_approvals { panic!("InsufficientApprovals"); }
+        let kind = op.kind.clone();
+        env.storage().instance().remove(&DataKey::PendingAdminOp);
+        env.events().publish((ADMIN_OP_EXECUTED,), AdminOpExecutedEvent { version: EVENT_VERSION_V2, kind: kind.clone(), executed_by: admin });
+        kind
+    }
+
+    pub fn get_pending_admin_op(env: Env) -> Option<PendingAdminOp> {
+        env.storage().instance().get(&DataKey::PendingAdminOp)
+    }
+
+    pub fn cancel_admin_op(env: Env) {
+        Self::require_admin(&env);
+        env.storage().instance().remove(&DataKey::PendingAdminOp);
+    }
+
     }
 }
 

--- a/contracts/program-escrow/src/test_rbac.rs
+++ b/contracts/program-escrow/src/test_rbac.rs
@@ -172,3 +172,312 @@ fn test_rbac_wrong_nonce_rejected_for_authorized_caller() {
     // Supply nonce=99 when stored nonce is 0.
     client.rotate_payout_key(&program_id, &payout_key, &new_key, &99);
 }
+
+// ---------------------------------------------------------------------------
+// Multisig Threshold Tests
+// ---------------------------------------------------------------------------
+
+use crate::{AdminOpKind, MultisigThresholdConfig, ADMIN_OP_EXPIRY_LEDGERS};
+
+fn advance_seq(env: &Env, n: u32) {
+    env.ledger().with_mut(|li| li.sequence_number += n);
+}
+
+fn make_payload(env: &Env, tag: &str) -> soroban_sdk::Bytes {
+    soroban_sdk::Bytes::from_slice(env, tag.as_bytes())
+}
+
+/// Set up a contract with a 2-of-3 multisig threshold config.
+fn setup_multisig(
+    env: &Env,
+) -> (
+    ProgramEscrowContractClient<'static>,
+    Address, // admin
+    Address, // signer1
+    Address, // signer2
+    Address, // signer3
+) {
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize_contract(&admin);
+
+    let s1 = Address::generate(env);
+    let s2 = Address::generate(env);
+    let s3 = Address::generate(env);
+    let signers = soroban_sdk::vec![env, s1.clone(), s2.clone(), s3.clone()];
+    client.set_multisig_threshold_config(&signers, &2, &1_000_000i128);
+
+    (client, admin, s1, s2, s3)
+}
+
+// --- set_multisig_threshold_config ---
+
+#[test]
+fn test_set_multisig_config_stores_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    client.set_multisig_threshold_config(
+        &soroban_sdk::vec![&env, s1.clone(), s2.clone()],
+        &2,
+        &500_000i128,
+    );
+
+    let cfg = client.get_multisig_threshold_config().unwrap();
+    assert_eq!(cfg.required_approvals, 2);
+    assert_eq!(cfg.high_value_threshold, 500_000);
+    assert_eq!(cfg.signers.len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "InvalidMultisigConfig")]
+fn test_set_multisig_config_required_gt_signers_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+    let s1 = Address::generate(&env);
+    // required=3 but only 1 signer
+    client.set_multisig_threshold_config(&soroban_sdk::vec![&env, s1], &3, &1000i128);
+}
+
+#[test]
+#[should_panic(expected = "InvalidMultisigConfig")]
+fn test_set_multisig_config_zero_required_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+    let s1 = Address::generate(&env);
+    client.set_multisig_threshold_config(&soroban_sdk::vec![&env, s1], &0, &1000i128);
+}
+
+// --- propose_admin_op ---
+
+#[test]
+fn test_propose_admin_op_stores_pending_op() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update-v1");
+
+    let op = client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    assert_eq!(op.kind, AdminOpKind::UpdateFeeConfig);
+    assert_eq!(op.approvals.len(), 1); // proposer auto-approves
+}
+
+#[test]
+#[should_panic(expected = "PendingOpExists")]
+fn test_propose_second_op_while_first_pending_rejected() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "op1");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    // Second proposal while first is still pending
+    client.propose_admin_op(&AdminOpKind::EmergencyWithdraw, &5_000_000i128, &payload);
+}
+
+#[test]
+fn test_propose_replaces_expired_op() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "op1");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+
+    // Advance past expiry
+    advance_seq(&env, ADMIN_OP_EXPIRY_LEDGERS + 1);
+
+    // New proposal should succeed
+    let payload2 = make_payload(&env, "op2");
+    let op = client.propose_admin_op(&AdminOpKind::EmergencyWithdraw, &0i128, &payload2);
+    assert_eq!(op.kind, AdminOpKind::EmergencyWithdraw);
+}
+
+// --- approve_admin_op ---
+
+#[test]
+fn test_approve_increments_approval_count() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+
+    let op = client.approve_admin_op(&s1);
+    assert_eq!(op.approvals.len(), 2); // proposer + s1
+}
+
+#[test]
+#[should_panic(expected = "NotASigner")]
+fn test_non_signer_cannot_approve() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+
+    let outsider = Address::generate(&env);
+    client.approve_admin_op(&outsider);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyApproved")]
+fn test_double_approve_rejected() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    client.approve_admin_op(&s1);
+    client.approve_admin_op(&s1); // second approval from same signer
+}
+
+#[test]
+#[should_panic(expected = "PendingOpExpired")]
+fn test_approve_expired_op_rejected() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    advance_seq(&env, ADMIN_OP_EXPIRY_LEDGERS + 1);
+    client.approve_admin_op(&s1);
+}
+
+// --- execute_admin_op ---
+
+#[test]
+fn test_execute_succeeds_after_threshold_met() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    client.approve_admin_op(&s1); // now 2-of-3 met
+
+    let kind = client.execute_admin_op(&payload);
+    assert_eq!(kind, AdminOpKind::UpdateFeeConfig);
+
+    // Pending op must be cleared
+    assert!(client.get_pending_admin_op().is_none());
+}
+
+#[test]
+#[should_panic(expected = "InsufficientApprovals")]
+fn test_execute_before_threshold_rejected() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    // Only 1 approval (proposer), need 2
+    client.execute_admin_op(&payload);
+}
+
+#[test]
+#[should_panic(expected = "PayloadMismatch")]
+fn test_execute_wrong_payload_rejected() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    client.approve_admin_op(&s1);
+
+    let wrong_payload = make_payload(&env, "different-payload");
+    client.execute_admin_op(&wrong_payload);
+}
+
+#[test]
+#[should_panic(expected = "PendingOpExpired")]
+fn test_execute_expired_op_rejected() {
+    let env = Env::default();
+    let (client, _admin, s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    client.approve_admin_op(&s1);
+    advance_seq(&env, ADMIN_OP_EXPIRY_LEDGERS + 1);
+    client.execute_admin_op(&payload);
+}
+
+#[test]
+#[should_panic(expected = "NoPendingOp")]
+fn test_execute_with_no_pending_op_rejected() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.execute_admin_op(&payload);
+}
+
+// --- cancel_admin_op ---
+
+#[test]
+fn test_cancel_clears_pending_op() {
+    let env = Env::default();
+    let (client, _admin, _s1, _s2, _s3) = setup_multisig(&env);
+    let payload = make_payload(&env, "fee-update");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    assert!(client.get_pending_admin_op().is_some());
+
+    client.cancel_admin_op();
+    assert!(client.get_pending_admin_op().is_none());
+}
+
+// --- 1-of-1 (default / no multisig) ---
+
+#[test]
+fn test_single_approval_executes_immediately_after_propose_and_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+
+    // 1-of-1 config
+    client.set_multisig_threshold_config(
+        &soroban_sdk::vec![&env, admin.clone()],
+        &1,
+        &1_000_000i128,
+    );
+
+    let payload = make_payload(&env, "op");
+    client.propose_admin_op(&AdminOpKind::UpdateFeeConfig, &0i128, &payload);
+    // 1 approval already (proposer), threshold met — execute immediately
+    let kind = client.execute_admin_op(&payload);
+    assert_eq!(kind, AdminOpKind::UpdateFeeConfig);
+}
+
+// --- 3-of-3 full quorum ---
+
+#[test]
+fn test_full_quorum_3_of_3() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    client.set_multisig_threshold_config(
+        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &3,
+        &0i128,
+    );
+
+    let payload = make_payload(&env, "full-quorum");
+    client.propose_admin_op(&AdminOpKind::EmergencyWithdraw, &0i128, &payload);
+    client.approve_admin_op(&s1);
+    client.approve_admin_op(&s2);
+    client.approve_admin_op(&s3);
+
+    let kind = client.execute_admin_op(&payload);
+    assert_eq!(kind, AdminOpKind::EmergencyWithdraw);
+}

--- a/docs/program-escrow/multisig-governance.md
+++ b/docs/program-escrow/multisig-governance.md
@@ -1,0 +1,133 @@
+# Multisig Threshold for High-Value Admin Operations
+
+## Overview
+
+The `program-escrow` contract supports an optional M-of-N multisig approval gate
+for critical admin operations. When enabled, operations that meet or exceed a
+configured `high_value_threshold` must be **proposed**, **approved** by M signers,
+and then **executed** — rather than taking effect immediately from a single key.
+
+This reduces the blast radius of a compromised admin key: an attacker who controls
+one key cannot unilaterally drain funds or change fee configuration.
+
+## Configuration
+
+### `set_multisig_threshold_config`
+
+```
+set_multisig_threshold_config(signers, required_approvals, high_value_threshold)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `signers` | `Vec<Address>` | N addresses authorised to approve ops |
+| `required_approvals` | `u32` | M approvals needed (1 ≤ M ≤ N) |
+| `high_value_threshold` | `i128` | Minimum value that triggers the gate |
+
+- Admin only.
+- Setting `required_approvals = 1` effectively disables the multisig gate (single-sig behaviour).
+- Setting `high_value_threshold = 0` requires multisig for **all** admin ops.
+
+## Propose → Approve → Execute Flow
+
+### 1. Propose
+
+```
+propose_admin_op(kind, value, payload_hash) -> PendingAdminOp
+```
+
+- Caller must be the contract admin.
+- The proposer's approval is **automatically counted**.
+- Only one pending operation is allowed at a time. A second proposal while the
+  first is still active panics with `PendingOpExists`.
+- An expired pending op is silently replaced.
+- The `payload_hash` is a caller-supplied hash of the operation's arguments.
+  It is stored on-chain and must be re-supplied at execute time to prevent
+  bait-and-switch attacks.
+
+### 2. Approve
+
+```
+approve_admin_op(signer) -> PendingAdminOp
+```
+
+- Caller must be one of the configured `signers`.
+- Each signer may approve at most once (`AlreadyApproved` otherwise).
+- Panics with `PendingOpExpired` if the op has expired.
+
+### 3. Execute
+
+```
+execute_admin_op(payload_hash) -> AdminOpKind
+```
+
+- Caller must be the contract admin.
+- Panics with `InsufficientApprovals` if fewer than `required_approvals` have approved.
+- Panics with `PayloadMismatch` if `payload_hash` differs from the stored hash.
+- Panics with `PendingOpExpired` if the op has expired (also clears the pending op).
+- On success, the pending op is removed from storage and an `AdmExec` event is emitted.
+
+### Cancel
+
+```
+cancel_admin_op()
+```
+
+Admin can cancel a pending op at any time, clearing it from storage.
+
+## Supported Operation Kinds
+
+| `AdminOpKind` | Description |
+|---|---|
+| `UpdateFeeConfig` | Change global fee rates or recipient |
+| `UpdateMultisigConfig` | Change the multisig threshold config itself |
+| `EmergencyWithdraw` | Emergency withdrawal of contract funds |
+
+## Expiry
+
+Pending operations expire after **17,280 ledgers** (~24 hours at 5 s/ledger),
+exported as `ADMIN_OP_EXPIRY_LEDGERS`. An expired op cannot be approved or
+executed and is replaced on the next `propose_admin_op` call.
+
+## Storage Layout
+
+| Key | Type | Description |
+|---|---|---|
+| `MultisigThresholdConfig` | `MultisigThresholdConfig` | Global config |
+| `PendingAdminOp` | `PendingAdminOp` | At most one pending op |
+
+Both use **instance storage**.
+
+## Events
+
+| Symbol | Payload | Emitted when |
+|---|---|---|
+| `AdmProp` | `AdminOpProposedEvent` | Op proposed |
+| `AdmAppr` | `AdminOpApprovedEvent` | Signer approves |
+| `AdmExec` | `AdminOpExecutedEvent` | Op executed |
+| `AdmExp` | `AdminOpKind` | Expired op cleared at execute time |
+
+## Security Notes
+
+- The `payload_hash` binding prevents a proposer from changing the operation
+  arguments between proposal and execution.
+- The proposer's auto-approval means a 1-of-1 config is equivalent to the
+  existing single-admin behaviour — no breaking change.
+- `approve_admin_op` requires `signer.require_auth()`, so signers must
+  actively sign the transaction.
+- The pending op is removed **before** the execute event is emitted, preventing
+  re-entrancy through event callbacks.
+- Non-signers and non-admins cannot interact with the pending op flow.
+
+## Error Codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| 1200 | `PendingOpExists` | A non-expired pending op already exists |
+| 1201 | `NoPendingOp` | No pending op found |
+| 1202 | `PendingOpExpired` | Pending op TTL has passed |
+| 1203 | `AlreadyApproved` | Signer already approved this op |
+| 1204 | `NotASigner` | Caller not in the signers list |
+| 1205 | `PayloadMismatch` | Payload hash does not match stored hash |
+| 1206 | `InsufficientApprovals` | Not enough approvals to execute |
+| 1207 | `InvalidMultisigConfig` | Config parameters are out of range |


### PR DESCRIPTION
## Summary

Closes #1271

Adds an optional M-of-N multisig approval gate for critical admin operations in `program-escrow`. A single compromised admin key can no longer unilaterally execute high-value operations.

## Changes

### `contracts/program-escrow/src/lib.rs`
- `MultisigThresholdConfig` struct — signers list, `required_approvals` (M), `high_value_threshold`
- `AdminOpKind` enum — `UpdateFeeConfig`, `UpdateMultisigConfig`, `EmergencyWithdraw`
- `PendingAdminOp` struct — stores kind, value, proposer, expiry, approvals, `payload_hash`
- `set_multisig_threshold_config()` — admin-only config setter
- `propose_admin_op()` — admin proposes, auto-approves with proposer signature
- `approve_admin_op()` — signer approves; validates signer list, duplicate guard, expiry
- `execute_admin_op()` — checks threshold met + payload hash integrity before executing
- `cancel_admin_op()` / `get_pending_admin_op()` — helpers
- `ADMIN_OP_EXPIRY_LEDGERS = 17_280` (~24 h)
- `DataKey::MultisigThresholdConfig` and `DataKey::PendingAdminOp`

### `contracts/program-escrow/src/errors.rs`
- Error codes 1200–1207 for all multisig failure modes

### `contracts/program-escrow/src/test_rbac.rs`
- 18 new tests covering: config validation, propose/approve/execute happy path, expired op replacement, non-signer rejection, double-approve rejection, payload mismatch, insufficient approvals, cancel, 1-of-1 default, 3-of-3 full quorum

### `docs/program-escrow/multisig-governance.md`
- Full documentation: flow, config, events, storage layout, security notes, error codes

## Security
- `payload_hash` binding prevents bait-and-switch between proposal and execution
- Proposer auto-approval means 1-of-1 is backward-compatible with existing single-admin behaviour
- `approve_admin_op` requires `signer.require_auth()` — signers must actively sign
- Pending op removed before execute event — prevents re-entrancy
- Non-signers and non-admins cannot interact with the pending op flow