### PR TITLE
feat: add query_all_delegates permission audit function via view facade

### DIFF
--- a/contracts/escrow-view-facade/src/lib.rs
+++ b/contracts/escrow-view-facade/src/lib.rs
@@ -6,6 +6,10 @@ mod bounty_escrow {
     include!("bounty_escrow_bindings.rs");
 }
 
+mod program_escrow {
+    include!("program_escrow_bindings.rs");
+}
+
 /// Represents the status of an escrow in the underlying contract.
 /// Must match `EscrowStatus` in BountyEscrow.
 #[contracttype]
@@ -221,6 +225,27 @@ impl EscrowViewFacade {
         UserPortfolio {
             as_depositor,
             as_beneficiary,
+        }
+    }
+
+    /// Query all current delegate assignments for a program escrow.
+    ///
+    /// Returns a list of delegate audit records for the requested program. If
+    /// the target program has no active delegate or the query fails for any
+    /// reason, this function returns an empty vector to preserve the facade's
+    /// read-only auditing semantics.
+    pub fn query_all_delegates(
+        env: Env,
+        program_contract: Address,
+        program_id: String,
+    ) -> Vec<program_escrow::ProgramDelegateInfo> {
+        let client = program_escrow::Client::new(&env, &program_contract);
+        let delegates_res = client.try_query_all_delegates(&program_id);
+
+        if let Ok(Ok(delegates)) = delegates_res {
+            delegates
+        } else {
+            Vec::new(&env)
         }
     }
 }

--- a/contracts/escrow-view-facade/src/program_escrow_bindings.rs
+++ b/contracts/escrow-view-facade/src/program_escrow_bindings.rs
@@ -1,0 +1,16 @@
+// Minimal explicit bindings for ProgramEscrow
+
+use soroban_sdk::{contractclient, contracttype, Address, Env, Error, String, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramDelegateInfo {
+    pub program_id: String,
+    pub delegate: Option<Address>,
+    pub permissions: u32,
+}
+
+#[contractclient(name = "Client")]
+pub trait ProgramEscrowContract {
+    fn query_all_delegates(env: Env, program_id: String) -> Vec<ProgramDelegateInfo>;
+}

--- a/contracts/escrow-view-facade/src/test.rs
+++ b/contracts/escrow-view-facade/src/test.rs
@@ -57,6 +57,14 @@ mod dummy_escrow {
         pub escrow: Escrow,
     }
 
+    #[contracttype]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ProgramDelegateInfo {
+        pub program_id: String,
+        pub delegate: Option<Address>,
+        pub permissions: u32,
+    }
+
     #[contract]
     pub struct DummyEscrow;
 
@@ -125,6 +133,17 @@ mod dummy_escrow {
                     schema_version: 1,
                 }
              });
+            result
+        }
+
+        pub fn query_all_delegates(env: Env, program_id: String) -> Vec<ProgramDelegateInfo> {
+            let mut result = Vec::new(&env);
+            let delegate = Address::generate(&env);
+            result.push_back(ProgramDelegateInfo {
+                program_id,
+                delegate: Some(delegate),
+                permissions: 0x3,
+            });
             result
         }
     }
@@ -201,4 +220,20 @@ fn test_get_user_portfolio() {
     
     // Beneficiary lists are empty out-of-the-box until tickets are aggregated
     assert_eq!(portfolio.as_beneficiary.len(), 0);
+}
+
+#[test]
+fn test_query_all_delegates_via_facade() {
+    let env = Env::default();
+    let escrow_contract = env.register_contract(None, dummy_escrow::DummyEscrow);
+    let facade_contract = env.register_contract(None, EscrowViewFacade);
+    let facade_client = EscrowViewFacadeClient::new(&env, &facade_contract);
+    let program_id = String::from_str(&env, "program-audit");
+
+    let delegates = facade_client.query_all_delegates(&escrow_contract, &program_id);
+    assert_eq!(delegates.len(), 1);
+    let info = delegates.get(0).unwrap();
+    assert_eq!(info.program_id, program_id);
+    assert!(info.delegate.is_some());
+    assert_eq!(info.permissions, 0x3);
 }

--- a/contracts/program-escrow/src/error_recovery.rs
+++ b/contracts/program-escrow/src/error_recovery.rs
@@ -358,11 +358,13 @@ fn transition_to_half_open_timeout(env: &Env) {
         .persistent()
         .set(&CircuitBreakerKey::SuccessCount, &0u32);
 
-// Emit event indicating automatic timeout transition
-env.events().publish(
-    (symbol_short!("circuit"), symbol_short!("cb_timeout")),
-    (symbol_short!("auto_half"), env.ledger().timestamp()),
-);
+    // Emit event indicating automatic timeout transition
+    env.events().publish(
+        (symbol_short!("circuit"), symbol_short!("cb_timeout")),
+        (symbol_short!("auto_half"), env.ledger().timestamp()),
+    );
+}
+
 /// **Call this after a FAILED protected operation.**
 ///
 /// Increments the failure counter and opens the circuit if the threshold
@@ -644,7 +646,7 @@ mod circuit_log_archive_tests {
 
             for i in 0..55u32 {
                 env.ledger().set_timestamp(1_000 + i as u64);
-                record_failure(&env, program_id.clone(), symbol_short!("payout"), 5_000 + i);
+                record_failure(&env, program_id.clone(), symbol_short!("payout"), 5_000 + i, None);
             }
 
             let log = get_error_log(&env);
@@ -675,11 +677,11 @@ mod circuit_log_archive_tests {
             set_circuit_admin(&env, admin, None);
 
             env.ledger().set_timestamp(2_000);
-            record_failure(&env, program_a.clone(), symbol_short!("payout"), 7);
+            record_failure(&env, program_a.clone(), symbol_short!("payout"), 7, None);
             env.ledger().set_timestamp(2_001);
-            record_failure(&env, program_b.clone(), symbol_short!("refund"), 8);
+            record_failure(&env, program_b.clone(), symbol_short!("refund"), 8, None);
             env.ledger().set_timestamp(2_002);
-            record_failure(&env, program_a.clone(), symbol_short!("payout"), 9);
+            record_failure(&env, program_a.clone(), symbol_short!("payout"), 9, None);
 
             let archive = archive_circuit_breaker_logs(&env, program_a.clone());
             assert_eq!(archive.archived_count, 2);

--- a/contracts/program-escrow/src/error_recovery_tests.rs
+++ b/contracts/program-escrow/src/error_recovery_tests.rs
@@ -63,7 +63,7 @@ fn simulate_failures(env: &Env, contract_id: &Address, n: u32) {
     let op = symbol_short!("op");
     env.as_contract(contract_id, || {
         for _ in 0..n {
-            record_failure(env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
+            record_failure(env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
         }
     });
 }
@@ -199,8 +199,8 @@ fn test_additional_failures_after_open_do_not_change_state() {
     env.as_contract(&contract_id, || {
         let prog = String::from_str(&env, "TestProg");
         let op = symbol_short!("op");
-        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
-        record_failure(&env, prog, op, ERR_TRANSFER_FAILED);
+        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
+        record_failure(&env, prog, op, ERR_TRANSFER_FAILED, None);
         assert_eq!(get_state(&env), CircuitState::Open);
     });
 }
@@ -333,7 +333,7 @@ fn test_failure_in_half_open_reopens_circuit() {
         reset_circuit_breaker(&env, &admin);
         assert_eq!(get_state(&env), CircuitState::HalfOpen);
         let prog = String::from_str(&env, "TestProg");
-        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_state(&env), CircuitState::Open);
     });
 }
@@ -345,7 +345,7 @@ fn test_reopen_after_half_open_failure_rejects_immediately() {
     env.as_contract(&contract_id, || {
         reset_circuit_breaker(&env, &admin);
         let prog = String::from_str(&env, "TestProg");
-        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED, None);
         assert_eq!(check_and_allow(&env), Err(ERR_CIRCUIT_OPEN));
     });
 }
@@ -357,7 +357,7 @@ fn test_half_open_can_be_reset_again_after_reopen() {
     env.as_contract(&contract_id, || {
         reset_circuit_breaker(&env, &admin);
         let prog = String::from_str(&env, "TestProg");
-        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_state(&env), CircuitState::Open);
     });
     env.as_contract(&contract_id, || {
@@ -406,7 +406,7 @@ fn test_error_log_populated_on_failure() {
     env.as_contract(&contract_id, || {
         let prog = String::from_str(&env, "TestProg");
         let op = symbol_short!("op");
-        record_failure(&env, prog, op, ERR_TRANSFER_FAILED);
+        record_failure(&env, prog, op, ERR_TRANSFER_FAILED, None);
         let log = get_error_log(&env);
         assert_eq!(log.len(), 1);
         let entry = log.get(0).unwrap();
@@ -432,7 +432,7 @@ fn test_error_log_capped_at_max() {
         let prog = String::from_str(&env, "TestProg");
         let op = symbol_short!("op");
         for _ in 0..7 {
-            record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
+            record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
         }
         let log = get_error_log(&env);
         assert_eq!(log.len(), 3, "Log should be capped at max_error_log=3");
@@ -456,7 +456,7 @@ fn test_error_log_contains_latest_errors_when_capped() {
         let prog = String::from_str(&env, "TestProg");
         let op = symbol_short!("op");
         for _ in 0..5 {
-            record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
+            record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
         }
         let log = get_error_log(&env);
         assert_eq!(log.len(), 2);
@@ -612,7 +612,7 @@ fn test_config_change_threshold_takes_effect() {
             },
         );
         let prog = String::from_str(&env, "TestProg");
-        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog, symbol_short!("op"), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_state(&env), CircuitState::Open);
     });
 }
@@ -688,7 +688,7 @@ fn test_full_circuit_breaker_lifecycle() {
     env.as_contract(&contract_id, || {
         // Phase 5: Failure in HalfOpen
         let prog = String::from_str(&env, "TestProg");
-        record_failure(&env, prog.clone(), symbol_short!("op"), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog.clone(), symbol_short!("op"), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_state(&env), CircuitState::Open);
         assert_eq!(check_and_allow(&env), Err(ERR_CIRCUIT_OPEN));
     });
@@ -895,13 +895,13 @@ fn test_interleaved_failures_and_successes_do_not_open_if_never_hit_threshold() 
         let prog = String::from_str(&env, "TestProg");
         let op = symbol_short!("op");
 
-        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_failure_count(&env), 1);
 
         record_success(&env);
         assert_eq!(get_failure_count(&env), 0);
 
-        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED);
+        record_failure(&env, prog.clone(), op.clone(), ERR_TRANSFER_FAILED, None);
         assert_eq!(get_failure_count(&env), 1);
 
         record_success(&env);

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -694,6 +694,18 @@ pub struct ProgramData {
     pub circuit_breaker_threshold: Option<u8>,
 }
 
+/// Program delegate audit record used for bulk reporting and indexer views.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramDelegateInfo {
+    /// Program identifier
+    pub program_id: String,
+    /// Currently assigned delegate (if any)
+    pub delegate: Option<Address>,
+    /// Delegate permission bitmask
+    pub permissions: u32,
+}
+
 // ========================================================================
 // Dispute Resolution Types
 // ========================================================================
@@ -7048,6 +7060,44 @@ impl ProgramEscrowContract {
             }
         }
         results
+    }
+
+    /// Query program delegates for a set of registered programs (paginated).
+    ///
+    /// This returns a vector of `ProgramDelegateInfo` records for the requested
+    /// slice of entries from the internal `PROGRAM_REGISTRY`.
+    pub fn query_program_delegates(
+        env: Env,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> soroban_sdk::Vec<ProgramDelegateInfo> {
+        let registry: soroban_sdk::Vec<String> = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_REGISTRY)
+            .unwrap_or(Vec::new(&env));
+
+        let total = registry.len();
+        let offset = offset.unwrap_or(0);
+        let limit = limit.unwrap_or(total);
+
+        // Validate pagination params conservatively: return empty vec on bad params
+        if offset > total || limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let end = if offset + limit > total { total } else { offset + limit };
+        let mut result = Vec::new(&env);
+        for i in offset..end {
+            let pid = registry.get(i).unwrap();
+            let program_data = Self::get_program_data_by_id(&env, &pid);
+            result.push_back(ProgramDelegateInfo {
+                program_id: pid.clone(),
+                delegate: program_data.delegate.clone(),
+                permissions: program_data.delegate_permissions,
+            });
+        }
+        result
     }
 
     pub fn get_program_release_schedule(env: Env, schedule_id: u64) -> ProgramReleaseSchedule {

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -7100,6 +7100,46 @@ impl ProgramEscrowContract {
         result
     }
 
+    /// Query the currently assigned delegate(s) and permissions for a single program.
+    ///
+    /// This read-only helper is designed for compliance auditing and permission
+    /// reporting. It returns an empty vector when the program does not exist or
+    /// when there is no active delegate assigned to the requested program.
+    pub fn query_all_delegates(
+        env: Env,
+        program_id: String,
+    ) -> soroban_sdk::Vec<ProgramDelegateInfo> {
+        let program_key = DataKey::Program(program_id.clone());
+        let program_data_opt = if env.storage().instance().has(&program_key) {
+            Some(env.storage().instance().get(&program_key).unwrap())
+        } else if env.storage().instance().has(&PROGRAM_DATA) {
+            let program_data: ProgramData = env
+                .storage()
+                .instance()
+                .get(&PROGRAM_DATA)
+                .unwrap();
+            if program_data.program_id == program_id {
+                Some(program_data)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut result = Vec::new(&env);
+        if let Some(program_data) = program_data_opt {
+            if let Some(delegate) = program_data.delegate {
+                result.push_back(ProgramDelegateInfo {
+                    program_id,
+                    delegate: Some(delegate),
+                    permissions: program_data.delegate_permissions,
+                });
+            }
+        }
+        result
+    }
+
     pub fn get_program_release_schedule(env: Env, schedule_id: u64) -> ProgramReleaseSchedule {
         let schedules = Self::get_release_schedules(env);
         for s in schedules.iter() {

--- a/contracts/program-escrow/src/test_circuit_breaker_enforcement.rs
+++ b/contracts/program-escrow/src/test_circuit_breaker_enforcement.rs
@@ -76,6 +76,7 @@ fn open_circuit(env: &Env) {
         failure_threshold: 1,
         success_threshold: 1,
         max_error_log: 10,
+        recovery_window: 0,
     };
     error_recovery::set_config(env, cfg);
     error_recovery::record_failure(
@@ -83,6 +84,7 @@ fn open_circuit(env: &Env) {
         String::from_str(env, "test-program"),
         symbol_short!("test"),
         1001,
+        None,
     );
     assert_eq!(error_recovery::get_state(env), CircuitState::Open);
 }
@@ -94,6 +96,80 @@ fn assert_circuit_closed(env: &Env) {
         CircuitState::Closed,
         "Expected circuit to be Closed"
     );
+}
+
+/// Force the circuit breaker into Open state with a custom recovery window.
+/// This allows tests to advance ledger time and validate Open→HalfOpen behavior.
+fn open_circuit_with_recovery_window(env: &Env, recovery_window: u64) {
+    let cfg = CircuitBreakerConfig {
+        failure_threshold: 1,
+        success_threshold: 1,
+        max_error_log: 10,
+        recovery_window,
+    };
+    error_recovery::set_config(env, cfg);
+    error_recovery::record_failure(
+        env,
+        String::from_str(env, "test-program"),
+        symbol_short!("test"),
+        1001,
+        None,
+    );
+    assert_eq!(error_recovery::get_state(env), CircuitState::Open);
+}
+
+/// When the Open circuit has timed out, a probe operation should advance
+/// the breaker into HalfOpen instead of rejecting immediately.
+#[test]
+fn test_open_circuit_transitions_to_halfopen_after_timeout() {
+    let TestSetup { env, .. } = setup();
+
+    open_circuit_with_recovery_window(&env, 100);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 101);
+
+    assert_eq!(error_recovery::check_and_allow(&env), Ok(()));
+    assert_eq!(error_recovery::get_state(&env), CircuitState::HalfOpen);
+}
+
+/// A successful probe while in HalfOpen should close the circuit.
+#[test]
+fn test_halfopen_probe_success_closes_circuit() {
+    let TestSetup { env, .. } = setup();
+
+    open_circuit_with_recovery_window(&env, 100);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 101);
+    assert_eq!(error_recovery::check_and_allow(&env), Ok(()));
+    assert_eq!(error_recovery::get_state(&env), CircuitState::HalfOpen);
+
+    error_recovery::record_success(&env);
+    assert_eq!(error_recovery::get_state(&env), CircuitState::Closed);
+}
+
+/// A failed probe in HalfOpen should reopen the circuit and reset the open timer.
+#[test]
+fn test_halfopen_probe_failure_reopens_circuit_and_resets_timer() {
+    let TestSetup { env, .. } = setup();
+
+    open_circuit_with_recovery_window(&env, 100);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 101);
+    assert_eq!(error_recovery::check_and_allow(&env), Ok(()));
+    assert_eq!(error_recovery::get_state(&env), CircuitState::HalfOpen);
+
+    let status_before = error_recovery::get_status(&env);
+    let opened_at_before = status_before.opened_at;
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1);
+    error_recovery::record_failure(
+        &env,
+        String::from_str(&env, "test-program"),
+        symbol_short!("probe"),
+        1001,
+        None,
+    );
+
+    let status_after = error_recovery::get_status(&env);
+    assert_eq!(status_after.state, CircuitState::Open);
+    assert!(status_after.opened_at > opened_at_before, "OpenedAt should reset on failed probe");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/program-escrow/src/test_delegate_audit.rs
+++ b/contracts/program-escrow/src/test_delegate_audit.rs
@@ -1,0 +1,49 @@
+#![cfg(test)]
+
+use crate::{ProgramEscrowContract, ProgramEscrowContractClient, DELEGATE_PERMISSION_RELEASE, DELEGATE_PERMISSION_REFUND};
+use soroban_sdk::{Address, Env, String};
+
+#[test]
+fn test_query_program_delegates_returns_expected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize_contract(&admin);
+
+    let payout_key = Address::generate(&env);
+    let token = Address::generate(&env);
+    let prog1 = String::from_str(&env, "prog-1");
+    let prog2 = String::from_str(&env, "prog-2");
+
+    client.init_program(&prog1, &payout_key, &token, &payout_key, &None, &None);
+    client.init_program(&prog2, &payout_key, &token, &payout_key, &None, &None);
+
+    let delegate1 = Address::generate(&env);
+    let delegate2 = Address::generate(&env);
+
+    client.set_program_delegate(&prog1, &payout_key, &delegate1, &DELEGATE_PERMISSION_RELEASE);
+    client.set_program_delegate(&prog2, &payout_key, &delegate2, &DELEGATE_PERMISSION_REFUND);
+
+    let delegates = ProgramEscrowContract::query_program_delegates(env.clone(), Some(0u32), Some(10u32));
+
+    assert_eq!(delegates.len(), 2);
+
+    let mut found1 = false;
+    let mut found2 = false;
+    for d in delegates.iter() {
+        if d.program_id == prog1 {
+            assert_eq!(d.delegate.unwrap(), delegate1);
+            assert_eq!(d.permissions, DELEGATE_PERMISSION_RELEASE);
+            found1 = true;
+        } else if d.program_id == prog2 {
+            assert_eq!(d.delegate.unwrap(), delegate2);
+            assert_eq!(d.permissions, DELEGATE_PERMISSION_REFUND);
+            found2 = true;
+        }
+    }
+    assert!(found1 && found2);
+}

--- a/contracts/program-escrow/src/test_rbac.rs
+++ b/contracts/program-escrow/src/test_rbac.rs
@@ -226,6 +226,28 @@ fn test_rbac_delegate_cannot_rotate() {
     client.rotate_payout_key(&program_id, &delegate, &new_key, &nonce);
 }
 
+#[test]
+fn test_query_all_delegates_reflects_set_and_revoke_sequence() {
+    let env = Env::default();
+    let (client, program_id, payout_key, _admin) = setup(&env);
+    let delegate = Address::generate(&env);
+    let permissions = DELEGATE_PERMISSION_RELEASE | DELEGATE_PERMISSION_UPDATE_META;
+
+    client.set_program_delegate(&program_id, &payout_key, &delegate, &permissions);
+
+    let delegates = ProgramEscrowContract::query_all_delegates(env.clone(), program_id.clone());
+    assert_eq!(delegates.len(), 1);
+    let info = delegates.get(0).unwrap();
+    assert_eq!(info.program_id, program_id);
+    assert_eq!(info.delegate, Some(delegate));
+    assert_eq!(info.permissions, permissions);
+
+    client.revoke_program_delegate(&program_id, &payout_key);
+
+    let delegates_after_revoke = ProgramEscrowContract::query_all_delegates(env.clone(), program_id.clone());
+    assert_eq!(delegates_after_revoke.len(), 0);
+}
+
 /// Rotation on a non-existent program must panic.
 #[test]
 #[should_panic(expected = "Program not found")]

--- a/docs/program-escrow/circuit-breaker.md
+++ b/docs/program-escrow/circuit-breaker.md
@@ -8,7 +8,7 @@ The circuit breaker protects payout operations from cascading failures by tracki
 
 - `Closed` — normal operation
 - `Open` — all protected operations rejected (requires admin action)
-- `HalfOpen` — trial period; successes move to `Closed`, failures re-open
+- `HalfOpen` — trial period; successes move to `Closed`, failures re-open and restart the recovery timeout
 
 The circuit breaker lives in persistent storage under keys defined in `error_recovery::CircuitBreakerKey`.
 
@@ -35,6 +35,12 @@ Unit tests were added under `contracts/program-escrow/src/test_admin_reset.rs` v
 
 - An admin-authorized reset transitions an `Open` circuit to `Closed` and clears counters.
 - A non-authorized caller cannot reset the circuit (panics / is rejected).
+
+Additional enforcement tests now cover the full HalfOpen lifecycle:
+
+- `Open` → `HalfOpen` after `recovery_window` elapses
+- `HalfOpen` → `Closed` on a successful probe
+- `HalfOpen` → `Open` on a failed probe, with the open timer reset
 
 Note: the repository contains many existing tests; depending on the environment some test suites may not compile or run fully.
 

--- a/docs/program-escrow/rbac-compliance-report.md
+++ b/docs/program-escrow/rbac-compliance-report.md
@@ -1,0 +1,53 @@
+# RBAC Permission Audit Report for Program Escrow
+
+This document describes the new audit query for program delegate permissions in the `program-escrow` contract.
+
+## Purpose
+
+Compliance teams require a point-in-time snapshot of all currently granted delegate permissions for a program. The new view function exposes a clean, read-only report of a program's active delegate and permission bitmask.
+
+## New Interface
+
+### `ProgramEscrowContract::query_all_delegates(env, program_id) -> Vec<ProgramDelegateInfo>`
+
+- `env` — the Soroban environment
+- `program_id` — the program identifier to query
+- returns a vector of active delegate records
+
+The returned vector contains at most one `ProgramDelegateInfo`, because this contract stores a single delegate and permission bitmask per program.
+
+### `EscrowViewFacade::query_all_delegates(env, program_contract, program_id) -> Vec<ProgramDelegateInfo>`
+
+- `program_contract` — on-chain address of a `ProgramEscrow` contract
+- `program_id` — the program identifier to query
+- returns a vector of delegate audit records from the target contract
+
+## `ProgramDelegateInfo`
+
+Fields:
+
+- `program_id: String`
+- `delegate: Option<Address>`
+- `permissions: u32`
+
+A missing or revoked delegate is represented by an empty result set.
+
+## Security Notes
+
+- This is a read-only query and does not modify contract state.
+- The facade wrapper uses `try_query_all_delegates` and returns an empty list on contract call failure, preserving safe audit semantics.
+- No authorization is required for read access.
+
+## Example Usage
+
+```rust
+let delegates = ProgramEscrowContract::query_all_delegates(env.clone(), program_id.clone());
+for delegate_info in delegates.iter() {
+    // Inspect delegate_info.delegate and delegate_info.permissions
+}
+```
+
+```rust
+let facade_delegates = EscrowViewFacadeClient::new(&env, &facade_contract)
+    .query_all_delegates(&program_contract, &program_id);
+```


### PR DESCRIPTION
Closes #1275

---

Adds ProgramEscrow::query_all_delegates for audit reporting and exposes it through EscrowViewFacade::query_all_delegates. Includes RBAC regression coverage for set/revoke sequences and facade integration tests, plus documentation in docs/program-escrow/rbac-compliance-report.md.