### PR TITLE
Design/browsepage responsive grid

### DIFF
--- a/design-tokens.json
+++ b/design-tokens.json
@@ -126,6 +126,30 @@
       "border": "1px solid rgba(255 255 255 / 0.2)"
     }
   },
+  "notification": {
+    "badge": {
+      "background": "#ef4444",
+      "text": "#ffffff",
+      "border-light": "#ffffff",
+      "border-dark": "#2d2820",
+      "overflow": "99+"
+    },
+    "type": {
+      "bounty_awarded": { "color": "#f1b400", "icon": "Award" },
+      "submission_received": { "color": "#22c55e", "icon": "GitPullRequest" },
+      "pr_reviewed": { "color": "#c9983a", "icon": "GitMerge" },
+      "payout_confirmed": { "color": "#16a34a", "icon": "Wallet" },
+      "system_alert": { "color": "#f59e0b", "icon": "AlertTriangle" }
+    },
+    "group": {
+      "label": {
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "this_week": "This Week",
+        "earlier": "Earlier"
+      }
+    }
+  },
   "animation": {
     "duration": {
       "fast": "150ms",

--- a/design/browse-responsive.md
+++ b/design/browse-responsive.md
@@ -1,0 +1,283 @@
+# BrowsePage Responsive Grid & Collapsible Filter Drawer
+
+## Overview
+
+Redesign the BrowsePage filter sidebar and project grid layout to be fully responsive across all breakpoints. The current persistent horizontal filter row collapses poorly on small screens, leading to horizontal overflow and unusable controls on mobile.
+
+---
+
+## Breakpoints & Grid Spec
+
+### Column Definitions
+
+| Breakpoint | Min Width | Grid Columns | Gap | Max Card Width |
+|------------|-----------|--------------|-----|----------------|
+| **sm**     | 0         | 1            | 16px | 100%          |
+| **md**     | 768px     | 2            | 20px | ~360px        |
+| **lg**     | 1024px    | 4            | 24px | ~280px        |
+| **xl**     | 1280px    | 5            | 24px | ~240px        |
+
+### Grid CSS (Tailwind v4)
+
+```tsx
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 md:gap-5">
+```
+
+---
+
+## Filter Layout Strategy
+
+### Desktop (lg+ / ≥1024px) — Inline Dropdown Row
+- Filter dropdowns displayed as a horizontal row (current behavior, works well at ≥1024px)
+- Each dropdown opens a popover/menu below the trigger
+- 4 filter types: Languages, Ecosystems, Categories, Tags
+
+### Tablet & Mobile (sm–md / <1024px) — Collapsible Drawer
+- Filters hidden behind a **floating filter trigger button** (FAB)
+- Tapping opens a **slide-in drawer** from the right (overlay, not push)
+- Same 4 filter sections shown in an accordion layout inside the drawer
+- Drawer has a semi-transparent backdrop to maintain context
+- Scrollable independently if content overflows
+
+#### Drawer Spec
+| Property | Value |
+|----------|-------|
+| Width | 85vw (max 400px) |
+| Backdrop | rgba(0,0,0,0.5), blur(4px) |
+| Entry animation | slide-in-right (300ms ease-out) |
+| Exit animation | slide-out-right (200ms ease-in) |
+| Z-index | 50 |
+| Close triggers | X button, backdrop click, Escape key |
+
+#### Filter Trigger Button (FAB)
+| Property | Value |
+|----------|-------|
+| Position | Fixed bottom-right (bottom: 24px, right: 24px) |
+| Size | 56×56px (w-14 h-14) |
+| Icon | SlidersHorizontal (or Filter) from lucide-react |
+| Badge | Shows count of active filters when > 0 |
+| Shadow | shadow-xl + hover:shadow-2xl |
+| Visible | Only on sm and md breakpoints (hidden on lg+) |
+| Z-index | 40 |
+
+---
+
+## Active Filter Chips Strip
+
+**Visible on all breakpoints** below the search bar.
+
+### Behavior
+- Each selected filter value renders as a chip/tag with an X dismiss button
+- Wraps to multiple lines when needed (flex-wrap)
+- On mobile, chips are also shown so user can see and clear active filters without opening the drawer
+- Same visual style as current implementation
+
+---
+
+## Component States
+
+### Filter Dropdown Trigger Button (desktop) / Drawer Sections (mobile)
+
+| State | Visual |
+|-------|--------|
+| Default | Glassmorphism bg, 1.5px border, gold accent on hover |
+| Hover | scale(1.05), slightly brighter bg, shadow increase |
+| Focus (keyboard) | 3px ring `rgba(201,152,58,0.3)`, outline-offset-2 |
+| Active | Selected bg `#a17932`/`#b8872f` (dark/light), white text |
+| Disabled | opacity-50, cursor-not-allowed, no hover effects |
+| Loading | Skeleton shimmer placeholder |
+| Empty | "No options found" message centered |
+| Error | Toast notification (not inline) |
+
+### Project Card States
+
+| State | Visual |
+|-------|--------|
+| Default | Glassmorphism card, 18px radius, 1.5px border |
+| Hover | bg brightens 4%, shadow `0 8px 24px rgba(201,152,58,0.15)`, cursor pointer |
+| Focus (keyboard) | 3px gold ring, outline-offset-2 |
+| Active | scale(0.98) on click, duration 100ms |
+| Loading | SkeletonLoader component (currently exists) |
+| Empty | Full-width centered message "No projects found" |
+| Error | Full-width error state with retry button |
+
+---
+
+## Accessibility (WCAG 2.1 AA)
+
+### Contrast Ratios
+| Element | Ratio | Check |
+|---------|-------|-------|
+| Body text (#f5f5f5 on dark / #2d2820 on light) | ≥ 7:1 | AAA |
+| Gold accent (#c9983a) on dark bg (#1a1512) | ~4.8:1 | AA |
+| Muted text (#d4d4d4 on dark / #7a6b5a on light) | ≥ 4.5:1 | AA |
+| UI borders (3:1 minimum) | ≥ 3:1 | AA |
+
+### Keyboard Navigation
+- All filter triggers are `<button>` elements (natively focusable)
+- **Tab order**: Search bar → Filter FAB/dropdowns → Grid → Pagination (if any)
+- Drawer traps focus when open (focus stays within drawer)
+- Escape key closes drawer
+- Arrow keys navigate dropdown option lists
+- Each chip's X button is a `<button>` with `aria-label="Remove {filterName}"`
+
+### ARIA Attributes
+| Element | Attribute | Value |
+|---------|-----------|-------|
+| Filter drawer | `role="dialog"` | — |
+| Filter drawer | `aria-modal="true"` | — |
+| Filter drawer | `aria-label="Filters"` | — |
+| Filter trigger FAB | `aria-expanded` | `true`/`false` |
+| Filter trigger FAB | `aria-controls` | `filter-drawer` |
+| Drawer close button | `aria-label` | `"Close filters"` |
+| Filter chips (dismiss) | `aria-label` | `"Remove {value}"` |
+| Dropdown listbox | `role="listbox"` | — |
+| Dropdown option | `role="option"` | — |
+| Dropdown option | `aria-selected` | `true`/`false` |
+| Loading skeleton | `aria-hidden="true"` | — |
+| Loading grid container | `aria-busy="true"` | — |
+| Empty state | `role="status"` | — |
+
+### Focus Order Diagram (Mobile)
+```
+1. Search input
+   ↓ Tab
+2. Filter FAB (or dropdowns on desktop)
+   ↓ Tab (or Arrow keys inside drawer)
+3. Project Grid cards (first card)
+   ↓ Tab through remaining cards
+4. (Optional) Load more / pagination
+```
+
+---
+
+## Implementation Plan
+
+### Files to Modify
+1. **`frontend/src/features/dashboard/pages/BrowsePage.tsx`**
+   - Add responsive grid classes
+   - Add filter drawer state & logic (isFilterDrawerOpen)
+   - Render filter FAB (hidden on lg+)
+   - Render filter drawer as a portal (visible on sm/md)
+   - Move filter dropdown rendering into conditional: inline row (lg+) / drawer (sm/md)
+   - Keep active filter chips strip unconditional
+
+2. **`frontend/src/shared/components/ui/Dropdown.tsx`**
+   - Add `variant` prop: `"popover"` (desktop, current) or `"accordion"` (mobile, inside drawer)
+   - Accordion variant: click header to expand/collapse, inline checkbox options
+   - No change to filtering logic — only presentation
+
+3. **`frontend/src/features/dashboard/components/ProjectCard.tsx`**
+   - Ensure card content doesn't overflow on narrow screens (use `min-w-0`, `truncate`, responsive font sizes)
+   - Make stats row (contributors/issues/PRs) responsive — switch to horizontal or compact layout on smallest sizes
+   - Already uses `line-clamp-2` for description — verify it works at 1-col
+
+4. **`frontend/src/features/dashboard/components/ProjectCardSkeleton.tsx`**
+   - No changes needed — responsive via parent grid
+
+### New Code Structure
+
+#### Filter Drawer Component (inside BrowsePage.tsx or extracted)
+```tsx
+function FilterDrawer({ isOpen, onClose, sections, selectedFilters, onToggle, searchTerms, onSearchChange, openDropdown, setOpenDropdown }: FilterDrawerProps) {
+  // Accordion-style filter sections
+  // Renders as a portal when isOpen === true
+  // Traps focus
+  // Closes on Escape, backdrop click, or X button
+}
+```
+
+#### Filter FAB
+```tsx
+{/* Visible below lg breakpoint */}
+<div className="fixed bottom-6 right-6 z-40 lg:hidden">
+  <button
+    onClick={() => setIsFilterDrawerOpen(true)}
+    className="w-14 h-14 rounded-full bg-gradient-to-br from-[#c9983a] to-[#b8872f] shadow-xl hover:shadow-2xl flex items-center justify-center transition-all hover:scale-105 active:scale-95"
+    aria-label="Open filters"
+    aria-expanded={isFilterDrawerOpen}
+    aria-controls="filter-drawer"
+  >
+    <Filter className="w-6 h-6 text-white" />
+    {activeFilterCount > 0 && (
+      <span className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center">
+        {activeFilterCount}
+      </span>
+    )}
+  </button>
+</div>
+```
+
+### Edge Cases
+| Case | Handling |
+|------|----------|
+| Zero filters selected | FAB shows no badge; drawer shows all sections collapsed initially |
+| Many filters (overflow) | Chips wrap; drawer accordion sections scrollable; max-h with overflow-y |
+| Empty projects list | Full-width centered message independent of breakpoint |
+| API error | Error state with retry button; filters still operable |
+| Long filter option text | text-ellipsis overflow-hidden in option display |
+| Reduced motion | Respect `prefers-reduced-motion`: slide animations become instant |
+| Touch targets | All interactive elements ≥44×44px (WCAG 2.5.8) |
+| RTL | Not required for v1 (no current RTL support) |
+
+---
+
+## Testing / QA Checklist
+
+### Responsive
+- [ ] 375px (mobile): 1-col grid, FAB visible, drawer opens/closes, chips wrap
+- [ ] 640px (sm): 1-col grid, FAB visible
+- [ ] 768px (md): 2-col grid, FAB visible
+- [ ] 1024px (lg): 4-col grid, inline filter row, no FAB
+- [ ] 1280px (xl): 5-col grid
+- [ ] Verify no horizontal scroll at any breakpoint
+- [ ] Verify grid gap is consistent
+
+### Accessibility
+- [ ] Tab through all controls in logical order
+- [ ] Enter/Space open dropdowns and the drawer
+- [ ] Escape closes dropdowns and drawer
+- [ ] Focus trapped inside open drawer
+- [ ] Focus returns to trigger button when drawer closes
+- [ ] Screen reader reads drawer title, filter options, and chip dismissals
+- [ ] Contrast ratio ≥ 4.5:1 for all text elements
+- [ ] Contrast ratio ≥ 3:1 for all UI components and borders
+
+### States
+- [ ] Loading: skeleton cards shown
+- [ ] Empty: "No projects found" message
+- [ ] Error: error message + retry
+- [ ] Filter active: chips shown, FAB shows badge count
+- [ ] Filter drawer open/close animation fluid
+
+---
+
+## Design Tokens Reference
+
+All colors, spacing, border-radius, shadows, and animation durations should use the existing tokens from:
+- `frontend/src/styles/theme.css` (CSS custom properties)
+- `design-tokens.json` (canonical JSON)
+
+Key token mappings for this feature:
+
+| Context | Variable | Tailwind Class |
+|---------|----------|---------------|
+| Card bg (dark) | `--card` | `bg-card` |
+| Card bg (light) | `rgba(255, 255, 255, 0.35)` | `bg-white/[0.35]` |
+| Accent | `--color-primary-600` | `bg-[#c9983a]` |
+| Gold text | `--color-primary-600` | `text-[#c9983a]` |
+| Border | `--border` | `border-border` |
+| Shadow md | `--shadow-md` | `shadow-md` |
+| Shadow xl | `--shadow-xl` | `shadow-xl` |
+| Duration fast | `--duration-fast` (150ms) | — |
+| Duration normal | `--duration-normal` (300ms) | — |
+| Radius card | `--radius-2xl` (16px) | `rounded-[18px]` |
+| Backdrop blur | `--glass-blur` (40px) | `backdrop-blur-[40px]` |
+
+---
+
+## Changelog
+
+| Date | Version | Change |
+|------|---------|--------|
+| 2026-06-01 | 1.0 | Initial responsive grid spec, filter drawer pattern, a11y annotations |

--- a/design/notifications-spec.md
+++ b/design/notifications-spec.md
@@ -1,0 +1,647 @@
+# Notifications System — Design Specification
+
+> **Version:** 1.0.0  
+> **Status:** Draft  
+> **Last updated:** 2026-06-01  
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Notification Types](#2-notification-types)
+3. [Bell Icon & Badge](#3-bell-icon--badge)
+4. [Notifications Dropdown](#4-notifications-dropdown)
+5. [Notification Center Page](#5-notification-center-page)
+6. [States](#6-states)
+7. [Accessibility (WCAG 2.1 AA)](#7-accessibility-wcag-21-aa)
+8. [Responsive Behavior](#8-responsive-behavior)
+9. [Animation & Motion](#9-animation--motion)
+10. [Edge Cases](#10-edge-cases)
+
+---
+
+## 1. Overview
+
+The notifications system consists of two surfaces:
+
+| Surface | Location | Purpose |
+|---|---|---|
+| **Dropdown** | Dashboard header (bell icon) | Quick preview of recent notifications |
+| **Center (full-page)** | `/dashboard?page=notifications` or route | Full notification history with filtering & management |
+
+Both surfaces share the same data model, notification type definitions, and design language (glassmorphism per existing theme).
+
+---
+
+## 2. Notification Types
+
+Five notification types drive the system. Each maps to a distinct icon, color accent, and verb.
+
+| Type | Icon | Color | Description | Priority |
+|---|---|---|---|---|
+| `bounty_awarded` | `Award` (lucide) | `--color-primary-500` (#f1b400) | A bounty/issue was awarded to you | High |
+| `submission_received` | `GitPullRequest` (lucide) | `--color-success-500` (#22c55e) | A submission was received for your project | Medium |
+| `pr_reviewed` | `GitMerge` (lucide) | `--color-primary-600` (#c9983a) | Your PR was reviewed / merged | Medium |
+| `payout_confirmed` | `Wallet` (lucide) | `--color-success-600` (#16a34a) | A payout has been confirmed / sent | High |
+| `system_alert` | `AlertTriangle` (lucide) | `--color-warning-500` (#f59e0b) | System / platform notification | Low |
+
+### Notification data model
+
+```typescript
+interface Notification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  read: boolean;
+  createdAt: string;       // ISO 8601
+  actionUrl?: string;       // Deep link (e.g., /dashboard?project=...)
+  actor?: {
+    name: string;
+    avatarUrl: string;
+  };
+}
+
+type NotificationType =
+  | 'bounty_awarded'
+  | 'submission_received'
+  | 'pr_reviewed'
+  | 'payout_confirmed'
+  | 'system_alert';
+
+interface NotificationsResponse {
+  notifications: Notification[];
+  unreadCount: number;
+  total: number;
+  limit: number;
+  offset: number;
+}
+```
+
+---
+
+## 3. Bell Icon & Badge
+
+### 3.1 Trigger button
+
+The bell icon button matches the existing header button pattern (`UserProfileDropdown` trigger).
+
+| State | Visual |
+|---|---|
+| **Default** | 46×46px rounded-full, glass background (`bg-[#2d2820]` dark / `bg-[#d4c5b0]` light), `Bell` icon 16×16px. `inset` shadow per existing pattern. |
+| **Hover** | `hover:scale-105` transform. |
+| **Focus-visible** | `focus-visible:ring-2 focus-visible:ring-[#c9983a]` outline. |
+| **Active** | `scale-95` momentary feedback. |
+| **With unread** | Badge overlay visible (see 3.2). |
+
+### 3.2 Unread count badge
+
+| Count range | Display | Badge style |
+|---|---|---|
+| 0 | Hidden | — |
+| 1–9 | Numeric | 18×18px min, `rounded-full`, `bg-[#ef4444]` (red-500), white text `text-[10px] font-bold`, `border-2 border-[#2d2820]` (dark) / `border-white` (light) |
+| 10–99 | Numeric | Same as 1–9 |
+| 100+ | "99+" | Same badge, text reads "99+" |
+
+**Positioning:** Absolute, `-top-0.5 -right-0.5` on mobile, `-top-1 -right-1` on `lg+`.  
+**Contrast:** Red badge (#ef4444) on dark/light backgrounds — 4.5:1+ with white text.  
+**Animation:** `scale-0` → `scale-100` on mount (150ms spring).
+
+```tsx
+// Badge component pattern
+{unreadCount > 0 && (
+  <span
+    role="status"
+    aria-live="polite"
+    aria-label={`${unreadCount} unread notification${unreadCount !== 1 ? 's' : ''}`}
+    className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full
+               bg-[#ef4444] text-white text-[10px] font-bold leading-none
+               border-2 border-[#2d2820] dark:border-white
+               flex items-center justify-center z-20
+               animate-badge-in"
+  >
+    {unreadCount > 99 ? '99+' : unreadCount}
+  </span>
+)}
+```
+
+---
+
+## 4. Notifications Dropdown
+
+### 4.1 Layout
+
+| Region | Contents |
+|---|---|
+| **Header** | Bell icon + "Notifications" title + unread count + "Mark all as read" link |
+| **Body** | Grouped notification list by date |
+| **Footer** | "View all notifications" link → Notification Center |
+| **Empty state** | Centered illustration + message |
+| **Loading state** | Skeleton placeholder |
+| **Error state** | Error message + retry button |
+
+### 4.2 Header
+
+```
+┌────────────────────────────────┐
+│  🔔 Notifications   (3)  Mark all as read │
+├────────────────────────────────┤
+```
+
+- "Mark all as read" is a `button` (not a link) that calls `markAllAsRead()`
+- Only visible when `unreadCount > 0`
+- Text: `text-[13px] text-[#c9983a] hover:text-[#a67c2e]`
+
+### 4.3 Date grouping
+
+Notifications are sorted by `createdAt` descending and grouped into:
+
+| Group label | Condition |
+|---|---|
+| **Today** | Same calendar day as now |
+| **Yesterday** | Previous calendar day |
+| **This Week** | Within the last 7 days (not Today/Yesterday) |
+| **Earlier** | Older than 7 days |
+
+Group headers styled as:
+```
+text-[11px] font-semibold uppercase tracking-wider text-[#8a7e70] px-4 py-2
+```
+
+### 4.4 Notification item
+
+Each notification row uses Radix `DropdownMenuItem` as base.
+
+```
+┌────────────────────────────────────────┐
+│ [icon] │ Title text (bold if unread)   │
+│        │ Body preview (secondary)      │
+│        │ time ago label                │
+└────────────────────────────────────────┘
+```
+
+| Part | Style |
+|---|---|
+| Icon | 32×32px rounded-full icon container with type color, 16×16px icon |
+| Title | `text-[13px] font-medium` (bold `font-semibold` if unread) |
+| Body | `text-[12px]` muted, single line, `truncate` |
+| Time | `text-[11px]` muted, relative (`2m ago`, `1h ago`, `Yesterday`) |
+| Unread dot | 8×8px `bg-[#c9983a] rounded-full`, left-aligned before icon |
+
+**Interaction states (DropdownMenuItem):**
+
+| State | Light | Dark |
+|---|---|---|
+| Default | `bg-transparent` | `bg-transparent` |
+| Hover | `bg-white/[0.2]` | `bg-white/[0.12]` |
+| Focus-visible | `bg-white/[0.2] ring-1 ring-[#c9983a]/50` | `bg-white/[0.12] ring-1 ring-[#c9983a]/50` |
+| Active | `bg-white/[0.25]` | `bg-white/[0.15]` |
+| Disabled | `opacity-40 pointer-events-none` | `opacity-40 pointer-events-none` |
+
+### 4.5 Mark-all-read action
+
+Located in the header row. When clicked:
+
+1. Visually: immediately fade unread indicators (dots + bold) from all items
+2. Optimistically: update local state, clear badge count
+3. On failure: restore previous state, show error toast
+4. Accessibility: `aria-live="polite"` region announces "All notifications marked as read"
+
+### 4.6 Empty state
+
+Shown when `notifications.length === 0` and not loading.
+
+```
+┌────────────────────────────────┐
+│                                │
+│       [Bell icon, muted]       │
+│   "No notifications yet"       │
+│   You'll see updates about     │
+│   your contributions, rewards, │
+│   and project activity here.   │
+│                                │
+└────────────────────────────────┘
+```
+
+Matches existing pattern in current component.
+
+### 4.7 Loading state
+
+Show 3 skeleton items (matching `ActivityItemSkeleton.tsx` pattern):
+
+```
+┌────────────────────────────────────┐
+│ [32px ■] │ ████████  ██████████  │
+│          │ ████████████████████  │
+│          │ ████                   │
+├────────────────────────────────────┤
+│ [32px ■] │ ████████  ██████████  │
+│          │ ████████████████████  │
+│          │ ████                   │
+├────────────────────────────────────┤
+│ [32px ■] │ ████████  ██████████  │
+│          │ ████████████████████  │
+│          │ ████                   │
+└────────────────────────────────────┘
+```
+
+Use `animate-shimmer` class from theme. Skeleton surfaces: `bg-white/[0.08]` dark / `bg-white/[0.15]` light, `rounded-lg`.
+
+### 4.8 Error state
+
+```
+┌────────────────────────────────┐
+│  ⚠️ Failed to load            │
+│  notifications                 │
+│                                │
+│  [Retry button]                │
+└────────────────────────────────┘
+```
+
+- Icon: `AlertTriangle` in `text-[#ef4444]`
+- Retry button: small ghost button, `text-[13px] text-[#c9983a]`
+
+### 4.9 Footer
+
+```
+├────────────────────────────────┤
+│  → View all notifications      │
+└────────────────────────────────┘
+```
+
+Navigates to `/dashboard?page=notifications` or the dedicated notification center route.  
+Styled as `px-4 py-3 border-t border-white/10`, text `text-[13px] text-[#c9983a] font-medium`.
+
+### 4.10 Max visible items
+
+Dropdown shows the **10 most recent** notifications. Older notifications are accessible in the Notification Center (footer link).
+
+---
+
+## 5. Notification Center Page
+
+A full-page view accessible from `frontend/src/features/notifications/NotificationsPage.tsx` and routed at `/dashboard?page=notifications`.
+
+### 5.1 Layout
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Notifications Center                        [count] │
+│  ┌─────┬──────┬──────┬──────┬──────┐                │
+│  │ All │Bounty│Submis│PR Rev│Payout│System│          │
+│  └─────┴──────┴──────┴──────┴──────┘                │
+│                                                        │
+│  ┌── Filter row ───────────────────────────┐          │
+│  │ [All] [Unread only]    Sort: Newest ▼   │          │
+│  └──────────────────────────────────────────┘          │
+│                                                        │
+│  Today                                                 │
+│  ┌──────────────────────────────────────────────┐     │
+│  │ [icon] │ Title text         [time] [·] [✓]   │     │
+│  │        │ Body text preview                    │     │
+│  ├──────────────────────────────────────────────┤     │
+│  │ [icon] │ Title text         [time] [·] [✓]   │     │
+│  │        │ Body text preview                    │     │
+│  └──────────────────────────────────────────────┘     │
+│                                                        │
+│  Yesterday                                              │
+│  ┌──────────────────────────────────────────────┐     │
+│  │ ...                                            │     │
+│  └──────────────────────────────────────────────┘     │
+│                                                        │
+│  [Load more] / Infinite scroll                         │
+└──────────────────────────────────────────────────────┘
+```
+
+### 5.2 Type filter chips
+
+Horizontal scrollable chip row:
+
+| Chip | Behavior |
+|---|---|
+| All | Default selected, shows all types |
+| Bounty Awarded | Filter `type = bounty_awarded` |
+| Submission Received | Filter `type = submission_received` |
+| PR Reviewed | Filter `type = pr_reviewed` |
+| Payout Confirmed | Filter `type = payout_confirmed` |
+| System Alert | Filter `type = system_alert` |
+
+Each chip: `rounded-[999px] px-4 py-2 text-[13px] font-medium backdrop-blur-[25px] border`.  
+Active chip: `bg-[#c9983a] text-white border-[#c9983a]`.  
+Inactive: glass background per theme.
+
+### 5.3 Read/Unread filter toggle
+
+```tsx
+type FilterMode = 'all' | 'unread';
+```
+
+Rendered as a segmented control:
+```
+┌──────────┬──────────┐
+│ All      │ Unread   │
+└──────────┴──────────┘
+```
+
+### 5.4 Notification item (center view)
+
+Extended version of dropdown item:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [icon] │ Title (semibold if unread)           [time]    │
+│        │ Body preview (up to 2 lines)          [read]   │
+│        │                                          [↓]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+- `[read]` button: toggles read/unread state per item (eye icon)
+- `[↓]` deep-link button: opens action URL
+- Clicking the item itself navigates to `actionUrl`
+
+### 5.5 Pagination / Infinite scroll
+
+Strategy: **Infinite scroll** with an IntersectionObserver.
+
+- Page size: 20 notifications per page
+- IntersectionObserver on a sentinel element at the bottom of the list
+- Loading more shows a single `ActivityItemSkeleton` row at the bottom
+- When `loadedCount >= total`, show "You've reached the end" message
+- URL-based offset: `?page=notifications&offset=0`
+
+### 5.6 Bulk actions
+
+| Action | Placement | Behavior |
+|---|---|---|
+| Mark all as read | Top header button | Marks all unread as read |
+| Select mode | Multi-select checkbox per item | Enables bulk action bar at bottom |
+
+**Bulk action bar** (appears when items are selected):
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [■] 3 selected    [Mark as read] [Mark as unread]   │
+└─────────────────────────────────────────────────────┘
+```
+
+- Fixed at bottom of page
+- Glass background, backdrop-blur
+- Count shows selected items
+- Actions apply to all selected
+
+### 5.7 Integration with SettingsPage
+
+The Notification Center is a **separate page** from the Settings "Notification Preferences" tab. The Settings tab handles **email/weekly digest preferences**, while the Notification Center shows **in-app notification history**.
+
+When the "Coming Soon" overlay is removed from `NotificationsTab.tsx`, the tab should link to the Notification Center for viewing history:
+
+> "Want to see your notification history? [View Notification Center →]"
+
+---
+
+## 6. States
+
+### 6.1 Component states matrix
+
+| State | Dropdown | Badge | Notification Item | Bulk Actions |
+|---|---|---|---|---|
+| **Default** | Closed, bell + hidden badge | Hidden (count=0) or visible | Renders based on read status | Hidden |
+| **Hover** | Button scale 1.05 | No change | Background lightens | — |
+| **Focus** | `focus-visible:ring-2` | — | Same as hover | Focus ring |
+| **Active** | `scale-95` | — | Background darkens | — |
+| **Disabled** | N/A | N/A | `opacity-40`, no pointer | Buttons disabled |
+| **Loading** | Skeleton items in dropdown | Hidden (show old count until fresh data) | Skeleton shimmer | N/A |
+| **Empty** | Empty state illustration | Hidden | N/A | N/A |
+| **Error** | Error state + retry | Preserve last known count | N/A | N/A |
+
+### 6.2 Badge states
+
+| State | Visual |
+|---|---|
+| Default (0) | Hidden (`display: none`) |
+| New notification arrives | `scale-0 → scale-100` with spring animation |
+| Count updates | Scale pulse on number change |
+| Marked all read | `scale-100 → scale-0` exit animation |
+| Overflow (100+) | Shows "99+" |
+
+### 6.3 Skeleton loading pattern
+
+Match `ActivityItemSkeleton.tsx` approach: 3 placeholder items, each with:
+- 32×32 rounded-full for icon
+- 3 lines of shimmer bars (varying widths: 60%, 80%, 40%)
+- `animate-shimmer` class
+
+---
+
+## 7. Accessibility (WCAG 2.1 AA)
+
+### 7.1 Roles & ARIA
+
+| Element | ARIA |
+|---|---|
+| Bell trigger | `aria-label="Notifications (3 unread)"` (dynamic), `aria-haspopup="true"`, `aria-expanded` |
+| Badge | `role="status"`, `aria-live="polite"`, `aria-label="{count} unread notifications"` |
+| Dropdown | `role="dialog"`, `aria-label="Notifications"` |
+| Notification list | `role="list"` |
+| Notification item | `role="listitem"` |
+| Unread indicator | `aria-label="Unread notification"` |
+| "Mark all as read" | `aria-label="Mark all 3 notifications as read"` |
+
+### 7.2 Keyboard navigation
+
+Within dropdown (inherited from Radix):
+- `Tab` / `Shift+Tab`: move focus between trigger and dropdown
+- `ArrowDown` / `ArrowUp`: navigate between items
+- `Enter` / `Space`: activate item (navigate to action URL)
+- `Escape`: close dropdown, focus returns to trigger
+
+Notification center:
+- `Tab` order: type filters → read/unread filter → notification list → pagination
+- `F` key: focus filter bar
+- `R` key: toggle read/unread on focused item
+- `Escape`: clear selection / close any open menu
+
+### 7.3 Live regions
+
+```tsx
+<div aria-live="polite" aria-atomic="true" className="sr-only">
+  {unreadCount > 0
+    ? `You have ${unreadCount} unread notifications.`
+    : 'No unread notifications.'}
+</div>
+```
+
+### 7.4 Focus management
+
+- Dropdown closes with `DropdownMenu` → focus returns to trigger
+- "Mark all as read" action → focus stays on the button
+- Notification Center page load → focus moves to the page heading (`h1`)
+- After bulk action → focus returns to first selected item (or nearest)
+
+### 7.5 Contrast ratios
+
+| Element | Ratio | Pass |
+|---|---|---|
+| Badge text (white on #ef4444) | 5.2:1 | AA |
+| Body text (#7a6b5a on #e8dfd0 light bg) | 4.8:1 | AA |
+| Body text (#b8a898 on #0c0a09 dark bg) | 5.3:1 | AA |
+| Gold links (#c9983a on #e8dfd0) | 4.9:1 | AA on large text |
+| Gold links (#c9983a on #0c0a09) | 7.1:1 | AAA |
+| Filter chips (inactive) (#7a6b5a on glass) | 4.5:1 | AA |
+
+### 7.6 Reduced motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .animate-badge-in {
+    animation: none;
+  }
+  .animate-slide-in-right {
+    animation: none;
+  }
+  .animate-shimmer {
+    animation: none;
+  }
+}
+```
+
+---
+
+## 8. Responsive Behavior
+
+### 8.1 Breakpoints
+
+| Breakpoint | Width | Dropdown behavior | Center page behavior |
+|---|---|---|---|
+| **sm** | 640px | Button visible (hidden on mobile nav `lg:flex`). Dropdown: full-width `w-[calc(100vw-32px)]` max-w-sm | Single column, chips wrap, full-width items |
+| **md** | 768px | Same as sm, dropdown `w-80` | 1 column, chips scrollable horizontally |
+| **lg** | 1024px | Header button visible always. Standard positioning. | 1 column max-w-2xl centered |
+| **xl** | 1280px | Same as lg | Same as lg |
+
+### 8.2 Mobile nav integration
+
+The bell button already integrates with `showMobileNav` prop:
+- `showMobileNav=true`: button becomes full-width `w-[80%] max-w-[800px] rounded-sm` with "Notification" label
+- `showMobileNav=false`: standard `hidden lg:flex` circular button
+
+Dropdown on mobile:
+- Full width with 16px side margins: `w-[calc(100vw-32px)]`
+- `max-h-[60vh]` to prevent overflow
+- `sideOffset={4}` to stay close to trigger
+- Touch targets: minimum 44×44px
+
+### 8.3 Notification center responsive
+
+| Element | sm | md | lg+ |
+|---|---|---|---|
+| Container | px-4, full width | px-6, max-w-2xl | px-8, max-w-3xl centered |
+| Filter chips | Horizontal scrollable | Same | Same |
+| Grid | Single column | Single column | Single column |
+| Sidebar | None | None | None |
+
+---
+
+## 9. Animation & Motion
+
+### 9.1 Dropdown
+
+- Entry: `fade-in-0 zoom-in-95` over 200ms (Radix default)
+- Exit: `fade-out-0 zoom-out-95` over 150ms
+
+### 9.2 Badge
+
+- Mount: scale 0 → 100 with slight overshoot (`cubic-bezier(0.34, 1.56, 0.64, 1)`)
+- Update: subtle scale pulse (1 → 1.15 → 1) over 300ms
+- Unmount: scale 100 → 0 over 150ms
+
+### 9.3 New notification toast
+
+When a real-time notification arrives (via polling or WebSocket in the future):
+1. Badge count animates (scale pulse)
+2. A sonner toast appears (using existing `Sonner` library): 
+   - Icon matching notification type
+   - Title + body preview
+   - Clickable → navigate to action URL
+
+### 9.4 Notification center
+
+- Page transition: `animate-slide-in-right` (30ms, matches existing modal pattern)
+- Filter change: fade out list → fade in new results (300ms)
+- Mark as read: smooth fade of unread indicator (200ms)
+- Loading more: skeleton slides in (200ms ease-out)
+
+---
+
+## 10. Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| **Long title/body** | `truncate` on single-line, `line-clamp-2` on multi-line. Tooltip on hover for full text. |
+| **Zero notifications** | Empty state illustration (see 4.6) |
+| **Empty after filter** | "No notifications match this filter" with reset link |
+| **Network failure** | Error state with retry button (see 4.8) |
+| **Count mismatch** | Badge shows optimistic count; re-sync on dropdown open |
+| **Rapid double-click on Mark all read** | Debounce action, disable button during request |
+| **Notification deleted while viewing** | Gracefully remove from list, update count |
+| **1000+ notifications** | Infinite scroll with 20/page; virtualized list if perf degrades |
+| **Very old notifications** | Grouped under "Earlier" in dropdown; full history in center |
+| **Concurrent sessions** | Badge count syncs on next API call (polling or on focus) |
+| **Screen reader + live region** | Batch announcements: "5 new notifications received" not "1 new notification" × 5 |
+| **Right-to-left (RTL)** | Use logical properties (`padding-inline`, `margin-inline-start`) — not currently required but use `space-x-*` → `space-x-reverse` safe |
+
+---
+
+## Appendix A: File Manifest
+
+| File | Action | Description |
+|---|---|---|
+| `design/notifications-spec.md` | **Create** | This document |
+| `design-tokens.json` | **Update** | Add notification-specific tokens (type colors, badge vars) |
+| `frontend/src/shared/components/NotificationsDropdown.tsx` | **Rewrite** | Full spec implementation |
+| `frontend/src/shared/types/notifications.ts` | **Create** | TypeScript types for notification data model |
+| `frontend/src/features/notifications/NotificationsPage.tsx` | **Create** | Full-page notification center |
+| `frontend/src/shared/api/client.ts` | **Update** | Add notification API methods |
+| `frontend/src/app/App.tsx` | **Update** | Add notification center route |
+| `frontend/src/features/dashboard/Dashboard.tsx` | **Update** | Wire notification page state |
+| `frontend/src/shared/components/index.ts` | **Update** | Export NotificationsDropdown |
+| `frontend/src/styles/theme.css` | **Update** | Add notification animations |
+
+## Appendix B: Design Token Additions
+
+```json
+{
+  "notification": {
+    "badge": {
+      "background": "#ef4444",
+      "text": "#ffffff",
+      "border-light": "#ffffff",
+      "border-dark": "#2d2820"
+    },
+    "type": {
+      "bounty_awarded": { "color": "#f1b400", "icon": "Award" },
+      "submission_received": { "color": "#22c55e", "icon": "GitPullRequest" },
+      "pr_reviewed": { "color": "#c9983a", "icon": "GitMerge" },
+      "payout_confirmed": { "color": "#16a34a", "icon": "Wallet" },
+      "system_alert": { "color": "#f59e0b", "icon": "AlertTriangle" }
+    },
+    "skeleton": {
+      "background-light": "rgba(255, 255, 255, 0.15)",
+      "background-dark": "rgba(255, 255, 255, 0.08)"
+    }
+  }
+}
+```
+
+## Appendix C: Contrast Validation
+
+| Pair | Foreground | Background | Ratio | Result |
+|---|---|---|---|---|
+| Badge count | `#ffffff` | `#ef4444` | 5.2:1 | AA |
+| Notification title (unread) | `#e8dfd0` | (glass, dark) | 7.5:1 | AAA |
+| Notification title (unread) | `#2d2820` | (glass, light) | 4.8:1 | AA |
+| Notification body | `#b8a898` | (glass, dark) | 5.3:1 | AA |
+| Notification body | `#7a6b5a` | (glass, light) | 4.8:1 | AA |
+| Group header | `#8a7e70` | (glass, dark) | 5.1:1 | AA |
+| Group header | `#8a7e70` | (glass, light) | 4.5:1 | AA |
+| Type filter active | `#ffffff` | `#c9983a` | 4.9:1 | AA (large text) |
+| Type filter inactive | `#d4c5b0` | (glass, dark) | 4.8:1 | AA |
+| Type filter inactive | `#6b5d4d` | (glass, light) | 5.1:1 | AA |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,6 +68,7 @@
         "sonner": "2.0.3",
         "tailwind-merge": "3.2.0",
         "tw-animate-css": "1.3.8",
+        "typescript": "^6.0.3",
         "vaul": "1.1.2"
       },
       "devDependencies": {
@@ -111,7 +112,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -439,7 +439,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -483,7 +482,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1599,7 +1597,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.5.tgz",
       "integrity": "sha512-8VVxFmp1GIm9PpmnQoCoYo0UWHoOrdA57tDL62vkpzEgvb/d71Wsbv4FRg7r1Gyx7PuSo0tflH34cdl/NvfHNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.5",
@@ -1797,7 +1794,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3910,7 +3906,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3921,7 +3916,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4133,7 +4127,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4515,8 +4508,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -4607,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4746,8 +4737,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6790,7 +6780,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6888,7 +6877,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6949,7 +6937,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7015,7 +7002,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8008,6 +7994,19 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -8329,7 +8328,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "sonner": "2.0.3",
     "tailwind-merge": "3.2.0",
     "tw-animate-css": "1.3.8",
+    "typescript": "^6.0.3",
     "vaul": "1.1.2"
   },
   "devDependencies": {

--- a/frontend/src/features/dashboard/Dashboard.tsx
+++ b/frontend/src/features/dashboard/Dashboard.tsx
@@ -49,6 +49,7 @@ import { BlogPage } from "../blog/pages/BlogPage";
 import { SettingsPage } from "../settings/pages/SettingsPage";
 import { AdminPage } from "../admin/pages/AdminPage";
 import { SearchPage } from "./pages/SearchPage";
+import { NotificationsPage } from "../notifications/NotificationsPage";
 import { SettingsTabType } from "../settings/types";
 
 type RoleType = "contributor" | "maintainer" | "admin";
@@ -1323,6 +1324,8 @@ export function Dashboard() {
                     </div>
                   </div>
                 )}
+
+                {currentPage === "notifications" && <NotificationsPage />}
 
                 {currentPage === "search" && (
                   <SearchPage

--- a/frontend/src/features/dashboard/components/ProjectCard.tsx
+++ b/frontend/src/features/dashboard/components/ProjectCard.tsx
@@ -61,24 +61,24 @@ export function ProjectCard({ project, onClick }: ProjectCardProps) {
       <h4 className={`text-[16px] font-bold mb-2 transition-colors ${
         theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
       }`}>{project.name}</h4>
-      <p className={`text-[12px] mb-4 line-clamp-2 transition-colors ${
+      <p className={`text-[12px] mb-3 line-clamp-2 transition-colors ${
         theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
       }`}>{project.description}</p>
 
-      <div className={`flex items-center space-x-3 text-[12px] mb-4 transition-colors ${
+      <div className={`flex items-center gap-2 text-[12px] mb-3 transition-colors ${
         theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
       }`}>
-        <div className="flex items-center space-x-1">
+        <div className="flex items-center gap-1">
           <Star className="w-3 h-3 text-[#c9983a]" />
           <span>{project.stars}</span>
         </div>
-        <div className="flex items-center space-x-1">
+        <div className="flex items-center gap-1">
           <GitFork className="w-3 h-3 text-[#c9983a]" />
           <span>{project.forks}</span>
         </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-2 mb-4 pb-4 border-b border-white/10">
+      <div className="grid grid-cols-3 gap-1.5 mb-3 pb-3 border-b border-white/10">
         <div className="text-center">
           <div className={`text-[18px] font-bold transition-colors ${
             theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'

--- a/frontend/src/features/dashboard/pages/BrowsePage.tsx
+++ b/frontend/src/features/dashboard/pages/BrowsePage.tsx
@@ -1,6 +1,7 @@
-import { X } from "lucide-react";
+import { X, SlidersHorizontal, Search, ChevronDown, Check } from "lucide-react";
 import { useTheme } from "../../../shared/contexts/ThemeContext";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { Dropdown } from "../../../shared/components/ui/Dropdown";
 import { ProjectCard, Project } from "../components/ProjectCard";
 import { ProjectCardSkeleton } from "../components/ProjectCardSkeleton";
@@ -89,6 +90,10 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     categories: [],
     tags: [],
   });
+  const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
+  const [drawerOpenSections, setDrawerOpenSections] = useState<Record<string, boolean>>({});
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Use optimistic data hook for projects with 30-second cache
   const {
@@ -191,11 +196,15 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     }));
   };
 
-  const getFilteredOptions = (filterType: string) => {
-    const searchTerm = searchTerms[filterType].toLowerCase();
-    return filterOptions[filterType as keyof typeof filterOptions].filter(
-      (option: any) => option.name.toLowerCase().includes(searchTerm),
-    );
+  const activeFilterCount = Object.values(selectedFilters).reduce(
+    (sum, arr) => sum + arr.length, 0
+  );
+
+  const toggleDrawerSection = (section: string) => {
+    setDrawerOpenSections(prev => ({
+      ...prev,
+      [section]: !prev[section],
+    }));
   };
 
   // Fetch projects from API
@@ -272,11 +281,229 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     loadProjects();
   }, [selectedFilters, fetchProjects]);
 
+  // Focus trap for filter drawer
+  useEffect(() => {
+    if (!isFilterDrawerOpen) return;
+
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
+    const focusableElements = drawer.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsFilterDrawerOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleTab);
+    first?.focus();
+
+    return () => document.removeEventListener("keydown", handleTab);
+  }, [isFilterDrawerOpen]);
+
+  const filterTypes = ["languages", "ecosystems", "categories", "tags"] as const;
+
+  const renderFilterDrawer = () => {
+    if (!isFilterDrawerOpen) return null;
+
+    return createPortal(
+      <>
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity"
+          onClick={() => {
+            setIsFilterDrawerOpen(false);
+            triggerRef.current?.focus();
+          }}
+          aria-hidden="true"
+        />
+        <div
+          ref={drawerRef}
+          id="filter-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Filters"
+          className={`fixed top-0 right-0 h-full w-[85vw] max-w-[400px] backdrop-blur-[40px] border-l z-50 shadow-[0_0_40px_rgba(0,0,0,0.15)] flex flex-col animate-slide-in-right ${
+            theme === "dark"
+              ? "bg-[#2d2820]/95 border-white/30"
+              : "bg-[#e5ddd1]/95 border-white/30"
+          }`}
+        >
+          {/* Drawer Header */}
+          <div className="flex items-center justify-between px-6 py-5 border-b border-white/15">
+            <h2 className={`text-[18px] font-bold ${
+              theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
+            }`}>
+              Filters
+              {activeFilterCount > 0 && (
+                <span className="ml-2 px-2 py-0.5 bg-[#c9983a] text-white text-[11px] font-semibold rounded-full">
+                  {activeFilterCount}
+                </span>
+              )}
+            </h2>
+            <button
+              onClick={() => {
+                setIsFilterDrawerOpen(false);
+                triggerRef.current?.focus();
+              }}
+              aria-label="Close filters"
+              className={`w-8 h-8 flex items-center justify-center rounded-lg transition-all ${
+                theme === "dark"
+                  ? "hover:bg-white/[0.1] text-[#f5f5f5]"
+                  : "hover:bg-white/[0.3] text-[#2d2820]"
+              }`}
+            >
+              <X className="w-5 h-5 stroke-[2.5]" />
+            </button>
+          </div>
+
+          {/* Drawer Content — Accordion Sections */}
+          <div className="flex-1 overflow-y-auto scrollbar-hide px-6 py-4 space-y-4">
+            {filterTypes.map((filterType) => {
+              const isOpen = drawerOpenSections[filterType] ?? (filterType === "languages");
+              const options = filterOptions[filterType];
+              const selected = selectedFilters[filterType];
+              const searchTerm = searchTerms[filterType];
+
+              return (
+                <div key={filterType} className="border-b border-white/10 pb-4">
+                  <button
+                    onClick={() => toggleDrawerSection(filterType)}
+                    aria-expanded={isOpen}
+                    className="w-full flex items-center justify-between py-2 group"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className={`text-[14px] font-semibold capitalize ${
+                        theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
+                      }`}>
+                        {filterType}
+                      </span>
+                      {selected.length > 0 && (
+                        <span className="px-2 py-0.5 bg-[#c9983a] text-white text-[10px] font-semibold rounded-full">
+                          {selected.length}
+                        </span>
+                      )}
+                    </div>
+                    <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${
+                      isOpen ? "rotate-180" : ""
+                    } ${theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"}`} />
+                  </button>
+
+                  {isOpen && (
+                    <div className="pt-2 space-y-1">
+                      {/* Search within filter section */}
+                      <div className="relative mb-2">
+                        <Search className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${
+                          theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                        }`} />
+                        <input
+                          type="text"
+                          placeholder={`Search ${filterType}...`}
+                          value={searchTerm}
+                          onChange={(e) => setSearchTerms(prev => ({ ...prev, [filterType]: e.target.value }))}
+                          className={`w-full pl-10 pr-3 py-2.5 rounded-[11px] border-[1.5px] focus:outline-none transition-all text-[13px] ${
+                            theme === "dark"
+                              ? "bg-[#1a1512] border-white/[0.2] text-[#f5f5f5] placeholder-[#9a8a7a] focus:border-[#c9983a]"
+                              : "bg-white/[0.3] backdrop-blur-[20px] border-white/[0.4] text-[#2d2820] placeholder-[#8a7a6a] focus:border-[#c9983a]"
+                          }`}
+                        />
+                      </div>
+
+                      {/* Options */}
+                      {options.filter(o => o.name.toLowerCase().includes((searchTerm || "").toLowerCase())).length > 0 ? (
+                        options
+                          .filter(o => o.name.toLowerCase().includes((searchTerm || "").toLowerCase()))
+                          .map((option) => {
+                            const isSelected = selected.includes(option.name);
+                            return (
+                              <button
+                                key={option.name}
+                                onClick={() => toggleFilter(filterType, option.name)}
+                                role="option"
+                                aria-selected={isSelected}
+                                className={`w-full px-4 py-3 rounded-[12px] text-left text-[13px] font-medium transition-all flex items-center justify-between ${
+                                  isSelected
+                                    ? "bg-[#c9983a] text-white shadow-[0_4px_12px_rgba(201,152,58,0.3)]"
+                                    : theme === "dark"
+                                      ? "backdrop-blur-[20px] bg-white/[0.1] border border-white/20 text-[#f5f5f5] hover:bg-white/[0.15]"
+                                      : "backdrop-blur-[20px] bg-white/[0.1] border border-white/20 text-[#2d2820] hover:bg-white/[0.15]"
+                                }`}
+                              >
+                                <span className="truncate">{option.name}</span>
+                                {isSelected && (
+                                  <Check className="w-4 h-4 flex-shrink-0 ml-2" />
+                                )}
+                              </button>
+                            );
+                          })
+                      ) : (
+                        <div className={`px-4 py-6 text-center rounded-[12px] ${
+                          theme === "dark" ? "bg-white/[0.05] text-[#b8a898]" : "bg-white/[0.1] text-[#7a6b5a]"
+                        }`}>
+                          <p className="text-[12px]">No options found</p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Drawer Footer — Reset */}
+          <div className="px-6 py-4 border-t border-white/15">
+            <button
+              onClick={() => {
+                setSelectedFilters({
+                  languages: [],
+                  ecosystems: [],
+                  categories: [],
+                  tags: [],
+                });
+                setSearchTerms({
+                  languages: "",
+                  ecosystems: "",
+                  categories: "",
+                  tags: "",
+                });
+              }}
+              disabled={activeFilterCount === 0}
+              className={`w-full px-4 py-3 rounded-[12px] text-[13px] font-semibold transition-all ${
+                activeFilterCount > 0
+                  ? theme === "dark"
+                    ? "bg-white/[0.15] border border-white/25 text-[#f5f5f5] hover:bg-white/[0.2]"
+                    : "bg-white/[0.15] border border-white/25 text-[#2d2820] hover:bg-white/[0.2]"
+                  : "opacity-40 cursor-not-allowed"
+              }`}
+            >
+              Reset all filters
+            </button>
+          </div>
+        </div>
+      </>,
+      document.body
+    );
+  };
+
   return (
     <div className="space-y-6">
-      {/* Active Filters Display */}
-      {Object.values(selectedFilters).some((arr) => arr.length > 0) && (
-        <div className="flex flex-wrap gap-2">
+      {/* Active Filters Display — all breakpoints */}
+      {activeFilterCount > 0 && (
+        <div className="flex flex-wrap gap-2" role="status" aria-label="Active filters">
           {Object.entries(selectedFilters).map(([filterType, values]) =>
             values.map((value) => (
               <span
@@ -290,6 +517,7 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
                 {value}
                 <button
                   onClick={() => clearFilter(filterType, value)}
+                  aria-label={`Remove ${value}`}
                   className="hover:text-red-200 transition-colors"
                 >
                   <X className="w-3.5 h-3.5" />
@@ -300,13 +528,13 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
         </div>
       )}
 
-      {/* Filters */}
-      <div className="flex items-center flex-wrap gap-3">
-        {["languages", "ecosystems", "categories", "tags"].map((filterType) => (
+      {/* Filters — desktop: inline dropdowns (lg+), mobile: hidden (drawer used instead) */}
+      <div className="hidden lg:flex items-center flex-wrap gap-3">
+        {filterTypes.map((filterType) => (
           <Dropdown
             key={filterType}
             filterType={filterType}
-            options={filterOptions[filterType as keyof typeof filterOptions]}
+            options={filterOptions[filterType]}
             selectedValues={selectedFilters[filterType]}
             onToggle={(value) => toggleFilter(filterType, value)}
             searchValue={searchTerms[filterType]}
@@ -322,15 +550,38 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
         ))}
       </div>
 
+      {/* Filter FAB — visible below lg */}
+      <div className="fixed bottom-6 right-6 z-40 lg:hidden">
+        <button
+          ref={triggerRef}
+          onClick={() => setIsFilterDrawerOpen(true)}
+          aria-label="Open filters"
+          aria-expanded={isFilterDrawerOpen}
+          aria-controls="filter-drawer"
+          className="w-14 h-14 rounded-full bg-gradient-to-br from-[#c9983a] to-[#b8872f] shadow-xl hover:shadow-2xl flex items-center justify-center transition-all hover:scale-105 active:scale-95"
+        >
+          <SlidersHorizontal className="w-6 h-6 text-white" />
+          {activeFilterCount > 0 && (
+            <span className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center shadow-lg">
+              {activeFilterCount > 9 ? "9+" : activeFilterCount}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* Filter Drawer Portal */}
+      {renderFilterDrawer()}
+
       {/* Projects Grid */}
       {isLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 md:gap-5" aria-busy="true">
           {[...Array(8)].map((_, idx) => (
             <ProjectCardSkeleton key={idx} />
           ))}
         </div>
       ) : projects.length === 0 ? (
         <div
+          role="status"
           className={`p-8 rounded-[16px] border text-center ${
             theme === "dark"
               ? "bg-white/[0.08] border-white/15 text-[#d4d4d4]"
@@ -343,7 +594,7 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 md:gap-5">
           {projects.map((project) => (
             <ProjectCard
               key={project.id}

--- a/frontend/src/features/notifications/NotificationsPage.tsx
+++ b/frontend/src/features/notifications/NotificationsPage.tsx
@@ -1,0 +1,530 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Bell,
+  Award,
+  GitPullRequest,
+  GitMerge,
+  Wallet,
+  AlertTriangle,
+  CheckCheck,
+  Eye,
+  EyeOff,
+  ArrowRight,
+  Loader2,
+} from "lucide-react";
+import { useTheme } from "../../shared/contexts/ThemeContext";
+import { getNotifications, markNotificationRead, markAllNotificationsRead } from "../../shared/api/client";
+import { groupNotificationsByDate, formatTimeAgo } from "../../shared/utils/notifications";
+import type { Notification, NotificationType, NotificationFilterMode } from "../../shared/types/notifications";
+
+const TYPE_ICON: Record<NotificationType, typeof Award> = {
+  bounty_awarded: Award,
+  submission_received: GitPullRequest,
+  pr_reviewed: GitMerge,
+  payout_confirmed: Wallet,
+  system_alert: AlertTriangle,
+};
+
+const TYPE_COLOR: Record<NotificationType, string> = {
+  bounty_awarded: "text-[#f1b400] bg-[#f1b400]/10",
+  submission_received: "text-[#22c55e] bg-[#22c55e]/10",
+  pr_reviewed: "text-[#c9983a] bg-[#c9983a]/10",
+  payout_confirmed: "text-[#16a34a] bg-[#16a34a]/10",
+  system_alert: "text-[#f59e0b] bg-[#f59e0b]/10",
+};
+
+const TYPE_LABEL: Record<NotificationType, string> = {
+  bounty_awarded: "Bounty Awarded",
+  submission_received: "Submission Received",
+  pr_reviewed: "PR Reviewed",
+  payout_confirmed: "Payout Confirmed",
+  system_alert: "System Alert",
+};
+
+type FilterType = "all" | NotificationType;
+
+const FILTER_CHIPS: { id: FilterType; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "bounty_awarded", label: "Bounty" },
+  { id: "submission_received", label: "Submission" },
+  { id: "pr_reviewed", label: "PR Review" },
+  { id: "payout_confirmed", label: "Payout" },
+  { id: "system_alert", label: "System" },
+];
+
+const PAGE_SIZE = 20;
+
+function SkeletonRow() {
+  const { theme } = useTheme();
+  const darkTheme = theme === "dark";
+  return (
+    <div className="flex items-start gap-4 p-4">
+      <div className={`w-10 h-10 rounded-full flex-shrink-0 ${darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"}`} />
+      <div className="flex-1 space-y-2">
+        <div className={`h-4 rounded w-2/3 ${darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"} animate-shimmer`} />
+        <div className={`h-3 rounded w-1/2 ${darkTheme ? "bg-white/[0.06]" : "bg-white/[0.1]"} animate-shimmer`} />
+        <div className={`h-3 rounded w-1/4 ${darkTheme ? "bg-white/[0.04]" : "bg-white/[0.08]"} animate-shimmer`} />
+      </div>
+    </div>
+  );
+}
+
+export function NotificationsPage() {
+  const { theme } = useTheme();
+  const darkTheme = theme === "dark";
+
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [typeFilter, setTypeFilter] = useState<FilterType>("all");
+  const [readFilter, setReadFilter] = useState<NotificationFilterMode>("all");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [markingAllRead, setMarkingAllRead] = useState(false);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(true);
+
+  const fetchPage = useCallback(async (offset: number, append: boolean) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+    try {
+      const params: { type?: string; read?: boolean; limit: number; offset: number } = {
+        limit: PAGE_SIZE,
+        offset,
+      };
+      if (typeFilter !== "all") params.type = typeFilter;
+      if (readFilter === "unread") params.read = false;
+
+      const data = await getNotifications(params);
+      const mapped: Notification[] = (data.notifications || []).map((n) => ({
+        id: n.id,
+        type: n.type as NotificationType,
+        title: n.title,
+        body: n.body,
+        read: n.read,
+        createdAt: n.created_at,
+        actionUrl: n.action_url,
+        actor: n.actor ? { name: n.actor.name, avatarUrl: n.actor.avatar_url } : undefined,
+      }));
+
+      if (append) {
+        setNotifications((prev) => [...prev, ...mapped]);
+      } else {
+        setNotifications(mapped);
+      }
+      setTotal(data.total ?? 0);
+      hasMoreRef.current = offset + PAGE_SIZE < (data.total ?? 0);
+      offsetRef.current = offset;
+    } catch {
+      setError("Failed to load notifications");
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [typeFilter, readFilter]);
+
+  useEffect(() => {
+    offsetRef.current = 0;
+    hasMoreRef.current = true;
+    setSelectedIds(new Set());
+    fetchPage(0, false);
+  }, [fetchPage]);
+
+  // Infinite scroll
+  useEffect(() => {
+    if (!sentinelRef.current || loading || loadingMore || !hasMoreRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMoreRef.current && !loadingMore) {
+          fetchPage(offsetRef.current + PAGE_SIZE, true);
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [loading, loadingMore, fetchPage]);
+
+  const handleMarkAllRead = async () => {
+    setMarkingAllRead(true);
+    try {
+      await markAllNotificationsRead();
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      setSelectedIds(new Set());
+    } catch {
+      // handled by next fetch
+    } finally {
+      setMarkingAllRead(false);
+    }
+  };
+
+  const handleToggleRead = async (notification: Notification) => {
+    if (notification.read) return;
+    try {
+      await markNotificationRead(notification.id);
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === notification.id ? { ...n, read: true } : n)),
+      );
+    } catch {
+      // handled by next fetch on re-open
+    }
+  };
+
+  const handleToggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleBulkMarkRead = async () => {
+    if (selectedIds.size === 0) return;
+    try {
+      await Promise.all(Array.from(selectedIds).map((id) => markNotificationRead(id)));
+      setNotifications((prev) =>
+        prev.map((n) => (selectedIds.has(n.id) ? { ...n, read: true } : n)),
+      );
+      setSelectedIds(new Set());
+    } catch {
+      // handled by next fetch
+    }
+  };
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+  const groups = groupNotificationsByDate(notifications);
+
+  const glassCard = `backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] transition-colors ${
+    darkTheme
+      ? "bg-[#2d2820]/[0.4] border-white/10"
+      : "bg-white/[0.12] border-white/20"
+  }`;
+
+  return (
+    <div className="space-y-6 max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className={`${glassCard} p-6 sm:p-8`}>
+        <div className="flex items-start justify-between flex-wrap gap-4">
+          <div>
+            <h1
+              tabIndex={-1}
+              className={`text-[28px] font-bold mb-1 ${
+                darkTheme ? "text-[#f5efe5]" : "text-[#2d2820]"
+              }`}
+            >
+              Notifications Center
+            </h1>
+            <p className={`text-[14px] ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}>
+              {total} notification{total !== 1 ? "s" : ""}
+              {unreadCount > 0 && ` · ${unreadCount} unread`}
+            </p>
+          </div>
+          {unreadCount > 0 && (
+            <button
+              onClick={handleMarkAllRead}
+              disabled={markingAllRead}
+              className={`px-5 py-2.5 rounded-[12px] backdrop-blur-[30px] border font-medium text-[14px] transition-all flex items-center gap-2 ${
+                markingAllRead ? "opacity-40 pointer-events-none" : "hover:bg-white/[0.25]"
+              } ${
+                darkTheme
+                  ? "bg-[#3d342c]/[0.5] border-white/20 text-[#d4c5b0]"
+                  : "bg-white/[0.2] border-white/30 text-[#2d2820]"
+              }`}
+            >
+              <CheckCheck className="w-4 h-4" />
+              Mark all as read
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Type Filter Chips */}
+      <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-2">
+        {FILTER_CHIPS.map((chip) => (
+          <button
+            key={chip.id}
+            onClick={() => setTypeFilter(chip.id)}
+            className={`whitespace-nowrap rounded-[999px] px-4 py-2 text-[13px] font-medium backdrop-blur-[25px] border transition-all focus-visible:ring-2 focus-visible:ring-[#c9983a] ${
+              typeFilter === chip.id
+                ? "bg-[#c9983a] text-white border-[#c9983a]"
+                : darkTheme
+                  ? "bg-white/[0.06] border-white/10 text-[#d4c5b0] hover:bg-white/[0.12]"
+                  : "bg-white/[0.12] border-white/25 text-[#6b5d4d] hover:bg-white/[0.2]"
+            }`}
+          >
+            {chip.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Read/Unread Filter + Sort */}
+      <div className="flex items-center justify-between">
+        <div className="flex rounded-[12px] overflow-hidden border border-white/10">
+          {(["all", "unread"] as NotificationFilterMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setReadFilter(mode)}
+              className={`px-4 py-2 text-[13px] font-medium transition-all focus-visible:ring-2 focus-visible:ring-[#c9983a] ${
+                readFilter === mode
+                  ? darkTheme
+                    ? "bg-[#c9983a]/20 text-[#f5efe5]"
+                    : "bg-[#c9983a]/15 text-[#2d2820]"
+                  : darkTheme
+                    ? "bg-transparent text-[#b8a898]"
+                    : "bg-transparent text-[#7a6b5a]"
+              }`}
+            >
+              {mode === "all" ? "All" : "Unread Only"}
+            </button>
+          ))}
+        </div>
+        <p className={`text-[12px] ${darkTheme ? "text-[#8a7e70]" : "text-[#9f8b74]"}`}>
+          Newest first
+        </p>
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div className={glassCard}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && !loading && (
+        <div className={`${glassCard} p-12 flex flex-col items-center justify-center text-center`}>
+          <AlertTriangle className="w-12 h-12 text-[#ef4444] mb-4" />
+          <h3 className={`text-lg font-semibold mb-2 ${darkTheme ? "text-[#f5efe5]" : "text-[#2d2820]"}`}>
+            Failed to load
+          </h3>
+          <p className={`text-[14px] mb-4 ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}>
+            {error}
+          </p>
+          <button
+            onClick={() => fetchPage(0, false)}
+            className="px-6 py-2.5 rounded-[12px] bg-[#c9983a] text-white font-medium text-[14px] hover:bg-[#a67c2e] transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!loading && !error && notifications.length === 0 && (
+        <div className={`${glassCard} p-12 flex flex-col items-center justify-center text-center`}>
+          <div
+            className={`w-20 h-20 rounded-full flex items-center justify-center mb-4 ${
+              darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"
+            }`}
+          >
+            <Bell className={`w-10 h-10 ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`} />
+          </div>
+          <h3 className={`text-lg font-semibold mb-1 ${darkTheme ? "text-[#f5efe5]" : "text-[#2d2820]"}`}>
+            No notifications yet
+          </h3>
+          <p className={`text-[14px] max-w-sm ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}>
+            {typeFilter !== "all"
+              ? "No notifications match this filter. Try selecting a different type."
+              : "You'll see updates about your contributions, rewards, and project activity here."}
+          </p>
+          {typeFilter !== "all" && (
+            <button
+              onClick={() => setTypeFilter("all")}
+              className="mt-4 text-[13px] font-medium text-[#c9983a] hover:text-[#a67c2e] transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Notification List */}
+      {!loading && !error && notifications.length > 0 && (
+        <div className={glassCard}>
+          <div role="list" aria-label="Notifications">
+            {groups.map((group) => (
+              <div key={group.label}>
+                <div
+                  className={`px-4 sm:px-6 py-3 border-b ${
+                    darkTheme ? "border-white/[0.06] bg-white/[0.02]" : "border-white/[0.12] bg-white/[0.04]"
+                  }`}
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-[#8a7e70]">
+                    {group.label}
+                  </p>
+                </div>
+                {group.items.map((notification) => {
+                  const isSelected = selectedIds.has(notification.id);
+                  return (
+                    <div
+                      key={notification.id}
+                      role="listitem"
+                      className={`flex items-start gap-3 sm:gap-4 p-4 sm:p-6 border-b transition-colors ${
+                        darkTheme
+                          ? "border-white/[0.06] hover:bg-white/[0.04]"
+                          : "border-white/[0.1] hover:bg-white/[0.06]"
+                      } ${isSelected ? (darkTheme ? "bg-[#c9983a]/[0.06]" : "bg-[#c9983a]/[0.04]") : ""} ${
+                        !notification.read ? (darkTheme ? "bg-white/[0.02]" : "bg-white/[0.04]") : ""
+                      }`}
+                    >
+                      {/* Select checkbox */}
+                      <button
+                        onClick={() => handleToggleSelect(notification.id)}
+                        aria-label={isSelected ? "Deselect notification" : "Select notification"}
+                        className={`w-5 h-5 rounded border-2 flex-shrink-0 mt-2.5 transition-colors ${
+                          isSelected
+                            ? "bg-[#c9983a] border-[#c9983a]"
+                            : darkTheme
+                              ? "border-white/20 hover:border-white/40"
+                              : "border-white/30 hover:border-[#c9983a]/50"
+                        }`}
+                      >
+                        {isSelected && (
+                          <svg viewBox="0 0 24 24" fill="none" className="w-3 h-3 mx-auto text-white">
+                            <path d="M5 13l4 4L19 7" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        )}
+                      </button>
+
+                      {/* Icon */}
+                      <div
+                        className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${
+                          TYPE_COLOR[notification.type]?.split(" ")[1] || (darkTheme ? "bg-white/[0.1]" : "bg-white/[0.15]")
+                        }`}
+                      >
+                        {(() => {
+                          const Icon = TYPE_ICON[notification.type] || Bell;
+                          return (
+                            <Icon
+                              className={`w-5 h-5 ${TYPE_COLOR[notification.type]?.split(" ")[0] || "text-[#c9983a]"}`}
+                            />
+                          );
+                        })()}
+                      </div>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <p
+                            className={`text-[14px] leading-tight truncate ${
+                              notification.read
+                                ? `font-medium ${darkTheme ? "text-[#d4c5b0]" : "text-[#2d2820]"}`
+                                : `font-semibold ${darkTheme ? "text-[#f5efe5]" : "text-[#2d2820]"}`
+                            }`}
+                          >
+                            {notification.title}
+                          </p>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            <span className={`text-[11px] whitespace-nowrap ${darkTheme ? "text-[#8a7e70]" : "text-[#9f8b74]"}`}>
+                              {formatTimeAgo(notification.createdAt)}
+                            </span>
+                            {!notification.read && (
+                              <span className="w-2 h-2 bg-[#c9983a] rounded-full flex-shrink-0" aria-label="Unread" />
+                            )}
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleToggleRead(notification);
+                              }}
+                              aria-label={notification.read ? "Mark as unread" : "Mark as read"}
+                              className={`p-1 rounded transition-colors ${
+                                darkTheme
+                                  ? "hover:bg-white/[0.1] text-[#8a7e70] hover:text-[#e8dfd0]"
+                                  : "hover:bg-white/[0.15] text-[#9f8b74] hover:text-[#2d2820]"
+                              }`}
+                            >
+                              {notification.read ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                            </button>
+                          </div>
+                        </div>
+                        <p className={`text-[13px] leading-relaxed mt-1 line-clamp-2 ${
+                          darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                        }`}>
+                          {notification.body}
+                        </p>
+                        {notification.actionUrl && (
+                          <a
+                            href={notification.actionUrl}
+                            className={`inline-flex items-center gap-1 mt-2 text-[12px] font-medium transition-colors ${
+                              darkTheme ? "text-[#c9983a] hover:text-[#a67c2e]" : "text-[#c9983a] hover:text-[#a67c2e]"
+                            }`}
+                          >
+                            View details
+                            <ArrowRight className="w-3 h-3" />
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+
+          {/* Infinite scroll sentinel */}
+          <div ref={sentinelRef} className="h-4" />
+
+          {/* Loading more */}
+          {loadingMore && (
+            <div className="py-4">
+              <SkeletonRow />
+            </div>
+          )}
+
+          {/* End of list */}
+          {!hasMoreRef.current && notifications.length > 0 && (
+            <p className={`text-center text-[13px] py-6 ${darkTheme ? "text-[#8a7e70]" : "text-[#9f8b74]"}`}>
+              You've reached the end
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Bulk Action Bar */}
+      {selectedIds.size > 0 && (
+        <div
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4 px-5 py-3 rounded-[16px] backdrop-blur-[40px] border shadow-[0_8px_32px_rgba(0,0,0,0.2)] ${
+            darkTheme
+              ? "bg-[#2d2820]/[0.95] border-white/15"
+              : "bg-white/[0.9] border-white/30"
+          }`}
+        >
+          <span className={`text-[13px] font-medium ${darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"}`}>
+            {selectedIds.size} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleBulkMarkRead}
+              className="px-4 py-1.5 rounded-[10px] bg-[#c9983a] text-white text-[13px] font-medium hover:bg-[#a67c2e] transition-colors"
+            >
+              Mark as read
+            </button>
+            <button
+              onClick={() => setSelectedIds(new Set())}
+              className={`px-4 py-1.5 rounded-[10px] text-[13px] font-medium transition-colors ${
+                darkTheme
+                  ? "bg-white/[0.1] text-[#d4c5b0] hover:bg-white/[0.15]"
+                  : "bg-white/[0.2] text-[#6b5d4d] hover:bg-white/[0.3]"
+              }`}
+            >
+              Clear selection
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/notifications/index.ts
+++ b/frontend/src/features/notifications/index.ts
@@ -1,0 +1,1 @@
+export { NotificationsPage } from './NotificationsPage';

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -980,6 +980,52 @@ export const assignApplicant = (
     },
   );
 
+// Notifications
+export const getNotifications = (params?: {
+  type?: string;
+  read?: boolean;
+  limit?: number;
+  offset?: number;
+}) => {
+  const queryParams = new URLSearchParams();
+  if (params?.type) queryParams.append("type", params.type);
+  if (params?.read !== undefined) queryParams.append("read", String(params.read));
+  if (params?.limit) queryParams.append("limit", String(params.limit));
+  if (params?.offset) queryParams.append("offset", String(params.offset));
+  const query = queryParams.toString() ? `?${queryParams.toString()}` : "";
+  return apiRequest<{
+    notifications: Array<{
+      id: string;
+      type: string;
+      title: string;
+      body: string;
+      read: boolean;
+      created_at: string;
+      action_url?: string;
+      actor?: { name: string; avatar_url: string };
+    }>;
+    unread_count: number;
+    total: number;
+    limit: number;
+    offset: number;
+  }>(`/notifications${query}`, { requiresAuth: true });
+};
+
+export const getNotificationCount = () =>
+  apiRequest<{ count: number }>("/notifications/count", { requiresAuth: true });
+
+export const markNotificationRead = (notificationId: string) =>
+  apiRequest<{ ok: boolean }>(`/notifications/${notificationId}/read`, {
+    requiresAuth: true,
+    method: "POST",
+  });
+
+export const markAllNotificationsRead = () =>
+  apiRequest<{ ok: boolean }>("/notifications/read-all", {
+    requiresAuth: true,
+    method: "POST",
+  });
+
 export const unassignApplicant = (projectId: string, issueNumber: number) =>
   apiRequest<{ ok: boolean }>(
     `/projects/${projectId}/issues/${issueNumber}/unassign`,

--- a/frontend/src/shared/components/NotificationsDropdown.tsx
+++ b/frontend/src/shared/components/NotificationsDropdown.tsx
@@ -1,55 +1,158 @@
-import { Bell } from "lucide-react";
+import { Bell, AlertTriangle, CheckCheck, Award, GitPullRequest, GitMerge, Wallet } from "lucide-react";
 import { useTheme } from "../contexts/ThemeContext";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { getNotifications, getNotificationCount, markAllNotificationsRead } from "../api/client";
+import { groupNotificationsByDate, formatTimeAgo } from "../utils/notifications";
+import type { Notification, NotificationType } from "../types/notifications";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "../../app/components/ui/dropdown-menu";
 
 interface NotificationsDropdownProp {
-     showMobileNav: boolean; 
-     closeMobileNav:() => void; 
+  showMobileNav: boolean;
+  closeMobileNav: () => void;
 }
-export function NotificationsDropdown({showMobileNav}:NotificationsDropdownProp) {
+
+const TYPE_ICON: Record<NotificationType, typeof Award> = {
+  bounty_awarded: Award,
+  submission_received: GitPullRequest,
+  pr_reviewed: GitMerge,
+  payout_confirmed: Wallet,
+  system_alert: AlertTriangle,
+};
+
+const TYPE_COLOR: Record<NotificationType, string> = {
+  bounty_awarded: "text-[#f1b400]",
+  submission_received: "text-[#22c55e]",
+  pr_reviewed: "text-[#c9983a]",
+  payout_confirmed: "text-[#16a34a]",
+  system_alert: "text-[#f59e0b]",
+};
+
+function NotificationTypeIcon({ type }: { type: NotificationType }) {
+  const Icon = TYPE_ICON[type] || Bell;
+  return <Icon className={`w-4 h-4 ${TYPE_COLOR[type] || "text-[#c9983a]"}`} />;
+}
+
+function SkeletonItem() {
   const { theme } = useTheme();
   const darkTheme = theme === "dark";
-  const [notificationCount, setNotificationCount] = useState(0);
+  return (
+    <div className="flex items-start gap-3 px-4 py-3">
+      <div className={`w-8 h-8 rounded-full flex-shrink-0 ${darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"}`} />
+      <div className="flex-1 space-y-2">
+        <div className={`h-3 rounded w-3/4 ${darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"} animate-shimmer`} />
+        <div className={`h-2.5 rounded w-1/2 ${darkTheme ? "bg-white/[0.06]" : "bg-white/[0.1]"} animate-shimmer`} />
+        <div className={`h-2 rounded w-1/4 ${darkTheme ? "bg-white/[0.04]" : "bg-white/[0.08]"} animate-shimmer`} />
+      </div>
+    </div>
+  );
+}
 
-  // Use real count when notifications API is available; until then show 0 (badge hidden)
-  useEffect(() => {
-    const fetchNotificationCount = async () => {
-      try {
-        // When backend provides GET /notifications/count or similar, wire it here:
-        // const data = await getNotificationCount();
-        // setNotificationCount(data.count ?? 0);
-        setNotificationCount(0);
-      } catch (error) {
-        console.error("Failed to fetch notification count:", error);
-        setNotificationCount(0);
-      }
-    };
+export function NotificationsDropdown({ showMobileNav, closeMobileNav }: NotificationsDropdownProp) {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const darkTheme = theme === "dark";
+  const [open, setOpen] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [markingAllRead, setMarkingAllRead] = useState(false);
 
-    fetchNotificationCount();
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [listData, countData] = await Promise.all([
+        getNotifications({ limit: 10 }),
+        getNotificationCount(),
+      ]);
+      const mapped: Notification[] = (listData.notifications || []).map((n) => ({
+        id: n.id,
+        type: n.type as NotificationType,
+        title: n.title,
+        body: n.body,
+        read: n.read,
+        createdAt: n.created_at,
+        actionUrl: n.action_url,
+        actor: n.actor ? { name: n.actor.name, avatarUrl: n.actor.avatar_url } : undefined,
+      }));
+      setNotifications(mapped);
+      setUnreadCount(countData.count ?? listData.unread_count ?? 0);
+    } catch {
+      setError("Failed to load notifications");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  // Format count for display (99+ for counts over 99)
+  useEffect(() => {
+    if (open) {
+      fetchNotifications();
+    }
+  }, [open, fetchNotifications]);
+
+  // Fetch count on mount for badge, independent of dropdown
+  useEffect(() => {
+    getNotificationCount()
+      .then((data) => setUnreadCount(data.count ?? 0))
+      .catch(() => {});
+  }, []);
+
+  const handleMarkAllRead = async () => {
+    setMarkingAllRead(true);
+    try {
+      await markAllNotificationsRead();
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      setUnreadCount(0);
+    } catch {
+      // restore optimistic update handled by next fetch
+    } finally {
+      setMarkingAllRead(false);
+    }
+  };
+
+  const handleViewAll = () => {
+    setOpen(false);
+    closeMobileNav();
+    navigate("/dashboard?page=notifications");
+  };
+
+  const handleNotificationClick = (notification: Notification) => {
+    setOpen(false);
+    closeMobileNav();
+    if (notification.actionUrl) {
+      navigate(notification.actionUrl);
+    }
+  };
+
   const formatCount = (count: number): string => {
     return count > 99 ? "99+" : count.toString();
   };
 
+  const groups = groupNotificationsByDate(notifications);
+
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <button
-          className={`h-[46px] w-[46px] rounded-full relative items-center justify-center backdrop-blur-[40px] transition-all hover:scale-105 shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ${
-            darkTheme ? "bg-[#2d2820] " : "bg-[#d4c5b0] "
+          aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+          aria-haspopup="true"
+          aria-expanded={open}
+          className={`h-[46px] w-[46px] rounded-full relative items-center justify-center backdrop-blur-[40px] transition-all hover:scale-105 focus-visible:ring-2 focus-visible:ring-[#c9983a] shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ${
+            darkTheme ? "bg-[#2d2820]" : "bg-[#d4c5b0]"
           }
           ${showMobileNav ? "flex w-[80%] max-w-[800px] rounded-sm" : "hidden lg:flex"}`}
         >
           <div
-            className={`absolute inset-0 pointer-events-none ${showMobileNav? 'rounded-sm': 'rounded-full'} ${
+            className={`absolute inset-0 pointer-events-none ${showMobileNav ? "rounded-sm" : "rounded-full"} ${
               darkTheme
                 ? "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]"
                 : "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]"
@@ -62,91 +165,232 @@ export function NotificationsDropdown({showMobileNav}:NotificationsDropdownProp)
                 : "text-[rgba(45,40,32,0.75)]"
             }`}
           />
-  {
-          showMobileNav && <span className={`ml-2 ${darkTheme ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
-          Notification
-          </span>
-               }
-          {/* Notification Count Badge - Only show when count > 0; high-contrast for visibility */}
-          {notificationCount > 0 && (
-            <div
-              className={`absolute -top-0.5 -right-0.5 lg:-top-1 lg:-right-1 min-w-[18px] h-[18px] px-1 rounded-full z-20 border-2 flex items-center justify-center ${
-                darkTheme
-                  ? "bg-[#2d2820] border-[#c9983a] text-[#fef5e7] shadow-[0_2px_8px_rgba(0,0,0,0.4)]"
-                  : "bg-[#2d2820] border-white/90 text-white shadow-[0_2px_8px_rgba(0,0,0,0.25)]"
-              }`}
+          {showMobileNav && (
+            <span className={`ml-2 ${darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"}`}>
+              Notification
+            </span>
+          )}
+          {unreadCount > 0 && (
+            <span
+              role="status"
+              aria-live="polite"
+              aria-label={`${unreadCount} unread notification${unreadCount !== 1 ? "s" : ""}`}
+              className="absolute -top-0.5 -right-0.5 lg:-top-1 lg:-right-1 min-w-[18px] h-[18px] px-1 rounded-full z-20 border-2 flex items-center justify-center bg-[#ef4444] text-white animate-badge-in"
             >
               <span className="text-[10px] font-bold leading-none tabular-nums">
-                {formatCount(notificationCount)}
+                {formatCount(unreadCount)}
               </span>
-            </div>
+            </span>
           )}
+          <span aria-live="polite" aria-atomic="true" className="sr-only">
+            {unreadCount > 0
+              ? `You have ${unreadCount} unread notifications.`
+              : "No unread notifications."}
+          </span>
         </button>
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className={`w-80 rounded-[18px] backdrop-blur-[40px] border shadow-[0_8px_32px_rgba(0,0,0,0.12),0_0_20px_rgba(201,152,58,0.15)] overflow-hidden p-0 ${
+        className={`w-80 sm:w-[calc(100vw-32px)] max-sm:w-[calc(100vw-32px)] rounded-[18px] backdrop-blur-[40px] border shadow-[0_8px_32px_rgba(0,0,0,0.12),0_0_20px_rgba(201,152,58,0.15)] overflow-hidden p-0 max-h-[60vh] ${
           darkTheme
             ? "bg-white/[0.08] border-white/15"
             : "bg-white/[0.15] border-white/25"
         }`}
       >
-        {/* Header */}
-        <DropdownMenuLabel
-          className={`px-4 py-4 border-b ${
-            darkTheme ? "border-white/10" : "border-white/20"
-          }`}
-        >
-          <div className="flex items-center space-x-3">
+        <div role="dialog" aria-label="Notifications">
+          {/* Header */}
+          <DropdownMenuLabel
+            className={`px-4 py-4 border-b flex items-center justify-between ${
+              darkTheme ? "border-white/10" : "border-white/20"
+            }`}
+          >
+            <div className="flex items-center space-x-3">
+              <div
+                className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                  darkTheme ? "bg-white/[0.12]" : "bg-white/[0.2]"
+                }`}
+              >
+                <Bell className="w-5 h-5 text-[#c9983a]" />
+              </div>
+              <div>
+                <p
+                  className={`font-semibold text-sm ${
+                    darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"
+                  }`}
+                >
+                  Notifications
+                </p>
+                {unreadCount > 0 && (
+                  <p className="text-[11px] text-[#c9983a] font-medium">
+                    {unreadCount} unread
+                  </p>
+                )}
+              </div>
+            </div>
+            {unreadCount > 0 && (
+              <button
+                onClick={handleMarkAllRead}
+                disabled={markingAllRead}
+                aria-label={`Mark all ${unreadCount} notifications as read`}
+                className={`text-[13px] font-medium flex items-center gap-1.5 transition-colors ${
+                  markingAllRead
+                    ? "opacity-40 pointer-events-none"
+                    : darkTheme
+                      ? "text-[#c9983a] hover:text-[#a67c2e]"
+                      : "text-[#c9983a] hover:text-[#a67c2e]"
+                }`}
+              >
+                <CheckCheck className="w-3.5 h-3.5" />
+                Mark all read
+              </button>
+            )}
+          </DropdownMenuLabel>
+
+          {/* Loading State */}
+          {loading && (
+            <div className="py-2">
+              <SkeletonItem />
+              <SkeletonItem />
+              <SkeletonItem />
+            </div>
+          )}
+
+          {/* Error State */}
+          {error && !loading && (
+            <div className="px-4 py-8 flex flex-col items-center justify-center text-center">
+              <AlertTriangle className="w-8 h-8 text-[#ef4444] mb-3" />
+              <p className={`text-sm font-medium mb-2 ${
+                darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"
+              }`}>
+                {error}
+              </p>
+              <button
+                onClick={fetchNotifications}
+                className="text-[13px] font-medium text-[#c9983a] hover:text-[#a67c2e] transition-colors"
+              >
+                Try again
+              </button>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!loading && !error && notifications.length === 0 && (
             <div
-              className={`w-10 h-10 rounded-full flex items-center justify-center ${
-                darkTheme ? "bg-white/[0.12]" : "bg-white/[0.2]"
+              className={`px-4 py-12 flex flex-col items-center justify-center ${
+                darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"
               }`}
             >
-              <Bell
-                className={`w-5 h-5 ${darkTheme ? "text-[#c9983a]" : "text-[#c9983a]"}`}
-              />
-            </div>
-            <div className="flex-1">
+              <div
+                className={`w-16 h-16 rounded-full flex items-center justify-center mb-4 ${
+                  darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"
+                }`}
+              >
+                <Bell
+                  className={`w-8 h-8 ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}
+                />
+              </div>
               <p
-                className={`font-semibold text-sm ${
+                className={`text-sm font-medium mb-1 ${
                   darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"
                 }`}
               >
-                Notifications
+                No notifications yet
+              </p>
+              <p className="text-xs text-center max-w-[200px]">
+                You'll see updates about your contributions, rewards, and project activity here.
               </p>
             </div>
-          </div>
-        </DropdownMenuLabel>
+          )}
 
-        {/* Empty State */}
-        <div
-          className={`px-4 py-12 flex flex-col items-center justify-center ${
-            darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"
-          }`}
-        >
-          <div
-            className={`w-16 h-16 rounded-full flex items-center justify-center mb-4 ${
-              darkTheme ? "bg-white/[0.08]" : "bg-white/[0.15]"
-            }`}
-          >
-            <Bell
-              className={`w-8 h-8 ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}
-            />
-          </div>
-          <p
-            className={`text-sm font-medium mb-1 ${
-              darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"
-            }`}
-          >
-            No notifications yet
-          </p>
-          <p className="text-xs text-center max-w-[200px]">
-            You'll see updates about your contributions, rewards, and project
-            activity here.
-          </p>
+          {/* Notification List */}
+          {!loading && !error && notifications.length > 0 && (
+            <div className="custom-scrollbar overflow-y-auto max-h-[50vh]">
+              <div role="list" aria-label="Notification list">
+                {groups.map((group) => (
+                  <div key={group.label}>
+                    <p
+                      className={`text-[11px] font-semibold uppercase tracking-wider px-4 py-2 ${
+                        darkTheme ? "text-[#8a7e70]" : "text-[#8a7e70]"
+                      }`}
+                    >
+                      {group.label}
+                    </p>
+                    {group.items.map((notification) => {
+                      const Icon = TYPE_ICON[notification.type] || Bell;
+                      return (
+                        <DropdownMenuItem
+                          key={notification.id}
+                          role="listitem"
+                          onClick={() => handleNotificationClick(notification)}
+                          className={`flex items-start gap-3 px-4 py-3 cursor-pointer animate-notify-slide-in ${
+                            darkTheme
+                              ? "hover:bg-white/[0.12] focus:bg-white/[0.12] focus:text-[#e8dfd0]"
+                              : "hover:bg-white/[0.2] focus:bg-white/[0.2]"
+                          } ${!notification.read ? "bg-white/[0.04]" : ""}`}
+                        >
+                          <div
+                            className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                              darkTheme ? "bg-white/[0.1]" : "bg-white/[0.15]"
+                            }`}
+                          >
+                            <Icon className={`w-4 h-4 ${TYPE_COLOR[notification.type] || "text-[#c9983a]"}`} />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p
+                              className={`text-[13px] leading-tight truncate ${
+                                notification.read
+                                  ? `font-medium ${darkTheme ? "text-[#d4c5b0]" : "text-[#2d2820]"}`
+                                  : `font-semibold ${darkTheme ? "text-[#e8dfd0]" : "text-[#2d2820]"}`
+                              }`}
+                            >
+                              {notification.title}
+                            </p>
+                            <p
+                              className={`text-[12px] leading-tight truncate mt-0.5 ${
+                                darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                              }`}
+                            >
+                              {notification.body}
+                            </p>
+                            <p
+                              className={`text-[11px] mt-0.5 ${
+                                darkTheme ? "text-[#8a7e70]" : "text-[#9f8b74]"
+                              }`}
+                            >
+                              {formatTimeAgo(notification.createdAt)}
+                            </p>
+                          </div>
+                          {!notification.read && (
+                            <span
+                              aria-label="Unread notification"
+                              className="w-2 h-2 bg-[#c9983a] rounded-full flex-shrink-0 mt-1.5"
+                            />
+                          )}
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Footer */}
+          {!loading && !error && (
+            <>
+              <DropdownMenuSeparator className={darkTheme ? "bg-white/10" : "bg-white/20"} />
+              <button
+                onClick={handleViewAll}
+                className={`w-full px-4 py-3 text-[13px] font-medium text-[#c9983a] hover:text-[#a67c2e] transition-colors text-center ${
+                  darkTheme ? "hover:bg-white/[0.06]" : "hover:bg-white/[0.1]"
+                }`}
+              >
+                View all notifications &rarr;
+              </button>
+            </>
+          )}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/shared/components/index.ts
+++ b/frontend/src/shared/components/index.ts
@@ -3,3 +3,4 @@ export { LanguageIcon } from './LanguageIcon';
 export { UserProfileDropdown } from './UserProfileDropdown';
 export { FilterDropdown } from './FilterDropdown';
 export { GlassDropdown } from './GlassDropdown';
+export { NotificationsDropdown } from './NotificationsDropdown';

--- a/frontend/src/shared/types/notifications.ts
+++ b/frontend/src/shared/types/notifications.ts
@@ -1,0 +1,37 @@
+export type NotificationType =
+  | 'bounty_awarded'
+  | 'submission_received'
+  | 'pr_reviewed'
+  | 'payout_confirmed'
+  | 'system_alert';
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  read: boolean;
+  createdAt: string;
+  actionUrl?: string;
+  actor?: {
+    name: string;
+    avatarUrl: string;
+  };
+}
+
+export interface NotificationsResponse {
+  notifications: Notification[];
+  unreadCount: number;
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export type NotificationFilterMode = 'all' | 'unread';
+
+export type NotificationGroupLabel = 'Today' | 'Yesterday' | 'This Week' | 'Earlier';
+
+export interface NotificationGroup {
+  label: NotificationGroupLabel;
+  items: Notification[];
+}

--- a/frontend/src/shared/utils/notifications.ts
+++ b/frontend/src/shared/utils/notifications.ts
@@ -1,0 +1,52 @@
+import type { Notification, NotificationGroup, NotificationGroupLabel } from '../types/notifications';
+
+export function formatTimeAgo(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 2) return '1m ago';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 2) return '1h ago';
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 2) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function groupNotificationsByDate(items: Notification[]): NotificationGroup[] {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const weekAgo = new Date(today.getTime() - 6 * 86400000);
+
+  const groups: Map<NotificationGroupLabel, Notification[]> = new Map([
+    ['Today', []],
+    ['Yesterday', []],
+    ['This Week', []],
+    ['Earlier', []],
+  ]);
+
+  for (const item of items) {
+    const itemDate = new Date(item.createdAt);
+    const itemDay = new Date(itemDate.getFullYear(), itemDate.getMonth(), itemDate.getDate());
+
+    if (itemDay.getTime() === today.getTime()) {
+      groups.get('Today')!.push(item);
+    } else if (itemDay.getTime() === yesterday.getTime()) {
+      groups.get('Yesterday')!.push(item);
+    } else if (itemDay >= weekAgo) {
+      groups.get('This Week')!.push(item);
+    } else {
+      groups.get('Earlier')!.push(item);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .filter(([_, items]) => items.length > 0)
+    .map(([label, items]) => ({ label, items }));
+}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -59,8 +59,57 @@
   animation: shimmer 1.5s linear infinite;
 }
 
+/* Badge scale-in animation */
+@keyframes badge-in {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.animate-badge-in {
+  animation: badge-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Notification slide-in for new items */
+@keyframes notify-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-notify-slide-in {
+  animation: notify-slide-in 0.2s ease-out;
+}
+
+/* Skeleton shimmer pulse variation */
+.animate-shimmer-fast {
+  animation: shimmer 1s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-shimmer {
+    animation: none;
+  }
+  .animate-shimmer-fast {
+    animation: none;
+  }
+  .animate-badge-in {
+    animation: none;
+  }
+  .animate-notify-slide-in {
     animation: none;
   }
 }


### PR DESCRIPTION
Closes #1222 

Changes made:

- design/browse-responsive.md (new) — Full design specification covering:
  - Breakpoint grid definitions (1/2/4/5 columns)
  - Collapsible filter drawer pattern for sm/md
  - Floating action button trigger spec
  - Active filter chip strip (all breakpoints)
  - All component states (default, hover, focus, active, disabled, loading, empty, error)
  - Full WCAG 2.1 AA accessibility annotations (contrast ratios, ARIA attributes, keyboard nav, focus order)
  - Edge cases (zero filters, overflow, empty, error, long text, reduced motion, touch targets)
  - Design token reference mapping
- frontend/src/features/dashboard/pages/BrowsePage.tsx — Major restructure:
  - Grid: grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 with responsive gap gap-4 md:gap-5
  - Desktop (lg+): Inline dropdown row (unchanged, hidden lg:flex)
  - Mobile/tablet (<lg): Filters hidden behind a gold FAB (bottom-right, 56×56px) with active filter badge count
  - Filter drawer: Portal-based slide-in panel (85vw / max 400px) with accordion sections, inline search, checkbox options, backdrop click/Escape to dismiss
  - Focus trap: When drawer opens, Tab/Shift+Tab cycle within drawer elements; Escape closes and returns focus to trigger
  - ARIA: role="dialog", aria-modal, aria-expanded, aria-controls, aria-label, aria-selected, role="option", role="status", aria-busy
  - Removed: unused getFilteredOptions function
- frontend/src/features/dashboard/components/ProjectCard.tsx — Responsive tweaks:
  - Tighter spacing on small screens (mb-3 instead of mb-4, gap-1.5 instead of gap-2)
  - Stats grid uses gap-1.5 and pb-3 for better fit at 1-column