### PR TITLE
fix: optimize ProgramData struct field ordering to reduce Soroban XDR…

### DIFF
--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -671,27 +671,33 @@ pub enum ProgramStatus {
 /// contract.set_program_circuit_breaker_threshold(&program_id, &None);
 /// ```
 
+// schema_version: 2
+// Field ordering optimized for Soroban XDR write cost: fixed-size hot-path fields
+// come first so partial-update patterns touch the smallest possible XDR prefix.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramData {
-    pub program_id: String,
-    pub total_funds: i128,
+    // --- Hot path: small fixed-size fields accessed on every operation ---
+    pub status: ProgramStatus,
     pub remaining_balance: i128,
+    pub total_funds: i128,
     pub authorized_payout_key: Address,
+    pub token_address: Address,
+    // --- Moderate: access-control and security fields ---
     pub delegate: Option<Address>,
     pub delegate_permissions: u32,
-    pub payout_history: soroban_sdk::Vec<PayoutRecord>,
-    pub token_address: Address,
-    pub initial_liquidity: i128,
     pub risk_flags: u32,
-    pub reference_hash: Option<soroban_sdk::Bytes>,
     pub archived: bool,
     pub archived_at: Option<u64>,
-    pub status: ProgramStatus,
+    pub initial_liquidity: i128,
     /// Optional per-program circuit breaker failure threshold.
     /// If set, overrides the global default (3) for this program.
     /// Must be between 1 and 100 inclusive when set.
     pub circuit_breaker_threshold: Option<u8>,
+    // --- Cold path: variable-size fields written infrequently ---
+    pub program_id: String,
+    pub payout_history: soroban_sdk::Vec<PayoutRecord>,
+    pub reference_hash: Option<soroban_sdk::Bytes>,
 }
 
 /// Program delegate audit record used for bulk reporting and indexer views.
@@ -1635,7 +1641,8 @@ pub const MAX_BATCH_SIZE: u32 = 100;
 pub const DEFAULT_MAX_HISTORY_PAGE_LIMIT: u32 = 200;
 
 /// Current storage schema version constant (upgrade-safe marker).
-pub const STORAGE_SCHEMA_VERSION: u32 = 1;
+/// Bumped to 2 after ProgramData field reordering (schema_version: 2).
+pub const STORAGE_SCHEMA_VERSION: u32 = 2;
 
 /// Current spend-limit threshold storage schema version.
 ///
@@ -1779,6 +1786,7 @@ mod test_granular_pause;
 
 mod test_maintenance_mode;
 mod test_risk_flags;
+mod test_struct_layout;
 // #[cfg(test)] mod test_serialization_compatibility; // pre-existing breakage
 // #[cfg(test)] mod test_payout_splits; // pre-existing breakage
 

--- a/contracts/program-escrow/src/test_storage_layout.rs
+++ b/contracts/program-escrow/src/test_storage_layout.rs
@@ -16,7 +16,7 @@ mod test {
 
     #[test]
     fn test_storage_schema_version_constant() {
-        assert_eq!(STORAGE_SCHEMA_VERSION, 1);
+        assert_eq!(STORAGE_SCHEMA_VERSION, 2);
     }
 
     #[test]
@@ -25,7 +25,7 @@ mod test {
         let (client, _admin) = setup_test(&env);
 
         let layout = client.verify_storage_layout();
-        assert_eq!(layout.schema_version, 1);
+        assert_eq!(layout.schema_version, 2);
         assert!(layout.admin_set);
         assert!(layout.pause_flags_set);
         assert!(layout.maintenance_mode_set);

--- a/contracts/program-escrow/src/test_struct_layout.rs
+++ b/contracts/program-escrow/src/test_struct_layout.rs
@@ -1,0 +1,157 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, String as SorobanString};
+
+fn make_minimal_program_data(env: &Env) -> ProgramData {
+    ProgramData {
+        status: ProgramStatus::Active,
+        remaining_balance: 9_000,
+        total_funds: 10_000,
+        authorized_payout_key: Address::generate(env),
+        token_address: Address::generate(env),
+        delegate: None,
+        delegate_permissions: 0,
+        risk_flags: 0,
+        archived: false,
+        archived_at: None,
+        initial_liquidity: 10_000,
+        circuit_breaker_threshold: None,
+        program_id: SorobanString::from_str(env, "test-program"),
+        payout_history: soroban_sdk::Vec::new(env),
+        reference_hash: None,
+    }
+}
+
+fn make_full_program_data(env: &Env) -> ProgramData {
+    let payout = PayoutRecord {
+        recipient: Address::generate(env),
+        amount: 500,
+        timestamp: 12345,
+    };
+    ProgramData {
+        status: ProgramStatus::Draft,
+        remaining_balance: 5_000,
+        total_funds: 10_000,
+        authorized_payout_key: Address::generate(env),
+        token_address: Address::generate(env),
+        delegate: Some(Address::generate(env)),
+        delegate_permissions: 7,
+        risk_flags: 3,
+        archived: true,
+        archived_at: Some(99999),
+        initial_liquidity: 10_000,
+        circuit_breaker_threshold: Some(5),
+        program_id: SorobanString::from_str(env, "full-program"),
+        payout_history: soroban_sdk::vec![env, payout],
+        reference_hash: Some(Bytes::from_array(env, &[0x01, 0x02, 0x03, 0x04])),
+    }
+}
+
+// Verifies schema version was bumped to 2 after the ProgramData field reorder.
+#[test]
+fn test_schema_version_is_2() {
+    assert_eq!(
+        STORAGE_SCHEMA_VERSION, 2,
+        "STORAGE_SCHEMA_VERSION must be 2 after ProgramData field reordering"
+    );
+}
+
+// Verifies that hot-path status field is accessible and correct after construction.
+#[test]
+fn test_status_field_accessible() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.status, ProgramStatus::Active);
+
+    let draft = ProgramData {
+        status: ProgramStatus::Draft,
+        ..make_minimal_program_data(&env)
+    };
+    assert_eq!(draft.status, ProgramStatus::Draft);
+}
+
+// Verifies that hot-path balance fields are accessible and correct.
+#[test]
+fn test_balance_fields_accessible() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.remaining_balance, 9_000);
+    assert_eq!(data.total_funds, 10_000);
+    assert_eq!(data.initial_liquidity, 10_000);
+}
+
+// Verifies that circuit_breaker_threshold round-trips correctly with None and Some.
+#[test]
+fn test_circuit_breaker_threshold_variants() {
+    let env = Env::default();
+
+    let no_threshold = make_minimal_program_data(&env);
+    assert_eq!(no_threshold.circuit_breaker_threshold, None);
+
+    let with_threshold = ProgramData {
+        circuit_breaker_threshold: Some(10),
+        ..make_minimal_program_data(&env)
+    };
+    assert_eq!(with_threshold.circuit_breaker_threshold, Some(10));
+}
+
+// Verifies that a struct with all optional fields set retains correct values.
+#[test]
+fn test_full_struct_field_values() {
+    let env = Env::default();
+    let data = make_full_program_data(&env);
+
+    assert_eq!(data.status, ProgramStatus::Draft);
+    assert_eq!(data.remaining_balance, 5_000);
+    assert_eq!(data.total_funds, 10_000);
+    assert_eq!(data.delegate_permissions, 7);
+    assert_eq!(data.risk_flags, 3);
+    assert!(data.archived);
+    assert_eq!(data.archived_at, Some(99999));
+    assert_eq!(data.circuit_breaker_threshold, Some(5));
+    assert_eq!(data.payout_history.len(), 1);
+    assert!(data.reference_hash.is_some());
+}
+
+// Verifies that archived_at is None when not archived.
+#[test]
+fn test_archived_at_default_none() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert!(!data.archived);
+    assert_eq!(data.archived_at, None);
+}
+
+// Verifies payout_history starts empty and can hold a record.
+#[test]
+fn test_payout_history_initially_empty() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.payout_history.len(), 0);
+}
+
+// Verifies reference_hash is None by default.
+#[test]
+fn test_reference_hash_default_none() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.reference_hash, None);
+}
+
+// Verifies delegate fields default to None / zero.
+#[test]
+fn test_delegate_defaults() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.delegate, None);
+    assert_eq!(data.delegate_permissions, 0);
+}
+
+// Verifies risk_flags defaults to zero.
+#[test]
+fn test_risk_flags_default_zero() {
+    let env = Env::default();
+    let data = make_minimal_program_data(&env);
+    assert_eq!(data.risk_flags, 0);
+}


### PR DESCRIPTION
 closes #1383 

Reorder ProgramData fields so fixed-size hot-path fields (status, remaining_balance, total_funds, authorized_payout_key, token_address) come first, followed by access-control fields, and large variable-size fields (payout_history, reference_hash, program_id) last.

- Bump STORAGE_SCHEMA_VERSION from 1 to 2 (breaking wire-format change)
- Add // schema_version: 2 comment above struct declaration
- Add test_struct_layout.rs covering all field groups and edge cases
- Update test_storage_layout.rs assertions to expect version 2