### PR TITLE
feat(program-escrow): add FoT router routing to preserve net payouts …

### DIFF
--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -505,6 +505,15 @@ pub enum ContractError {
     /// This error occurs when the circuit breaker threshold
     /// is not in the valid range (1-100).
     InvalidCircuitBreakerThreshold = 804,
+
+    // =========================================================================
+    // FoT Router Errors (1300-1399)
+    // =========================================================================
+    /// FoT routing failed.
+    ///
+    /// This error occurs when the fee-on-transfer router contract
+    /// returns an invalid result or the routing call fails.
+    FotRoutingFailed = 1300,
     
     // =========================================================================
     // Threshold Monitoring Errors (900-999)
@@ -854,6 +863,9 @@ impl ContractError {
             ContractError::TokenNotInAllowlist => {
                 "Token is not on the allowlist and cannot be removed"
             }
+
+            // FoT Router Errors
+            ContractError::FotRoutingFailed => "FoT routing failed",
 
             // Role Management Errors
             ContractError::AdminRotationInProgress => "Admin rotation already in progress",

--- a/contracts/program-escrow/src/fot_routing.rs
+++ b/contracts/program-escrow/src/fot_routing.rs
@@ -1,0 +1,68 @@
+#![allow(dead_code)]
+
+use soroban_sdk::{vec, Address, Env, IntoVal, Symbol, Val};
+
+/// Apply FoT routing to compute the gross transfer amount.
+///
+/// If `fot_router` is `None`, returns `net_amount` unchanged (no routing).
+/// Otherwise calls `router_contract.quote(token, net_amount)` and applies
+/// the configured slippage tolerance.
+///
+/// The router contract must expose a `quote(Address, i128) -> i128` function
+/// that returns the gross amount needed to deliver `net_amount` to the
+/// recipient after fee-on-transfer deductions.
+///
+/// Slippage is applied as:
+/// `adjusted = gross * (BASIS_POINTS + slippage_bps) / BASIS_POINTS`
+///
+/// # Panics
+/// - If the router call fails or returns a non-positive amount
+/// - On arithmetic overflow during slippage adjustment
+pub fn apply_fot_router(
+    env: &Env,
+    token_address: &Address,
+    net_amount: i128,
+    fot_router: &Option<crate::FotRouter>,
+) -> i128 {
+    let router = match fot_router {
+        Some(r) => r,
+        None => return net_amount,
+    };
+
+    if net_amount <= 0 {
+        return net_amount;
+    }
+
+    // Build args as Vec<Val> for the cross-contract call
+    let token_val: Val = token_address.clone().into_val(env);
+    let amount_val: Val = net_amount.into_val(env);
+    let args = vec![&env, token_val, amount_val];
+
+    let gross: i128 = env.invoke_contract(
+        &router.router_contract,
+        &Symbol::new(env, "quote"),
+        args,
+    );
+
+    if gross <= 0 {
+        panic!("FoT router returned non-positive amount");
+    }
+
+    if router.slippage_bps == 0 {
+        return gross;
+    }
+
+    // Apply slippage tolerance
+    let multiplier = crate::BASIS_POINTS + router.slippage_bps as i128;
+    let adjusted = gross
+        .checked_mul(multiplier)
+        .expect("FoT routing: slippage calculation overflow")
+        .checked_div(crate::BASIS_POINTS)
+        .expect("FoT routing: slippage calculation overflow");
+
+    if adjusted <= 0 {
+        panic!("FoT routing: adjusted amount is zero or negative");
+    }
+
+    adjusted
+}

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -177,6 +177,8 @@ const ADMIN_ROTATION_CANCELLED: Symbol = symbol_short!("AdmCanc");
 const CONTROLLER_PROPOSED: Symbol = symbol_short!("CtrlProp");
 const CONTROLLER_ACCEPTED: Symbol = symbol_short!("CtrlAcc");
 const CONTROLLER_ROTATION_CANCELLED: Symbol = symbol_short!("CtrlCanc");
+const FOT_ROUTER_SET: Symbol = symbol_short!("FotRtrS");
+const FOT_ROUTER_CLEARED: Symbol = symbol_short!("FotRtrC");
 
 // Storage keys
 const PROGRAM_DATA: Symbol = symbol_short!("ProgData");
@@ -671,6 +673,41 @@ pub enum ProgramStatus {
 /// contract.set_program_circuit_breaker_threshold(&program_id, &None);
 /// ```
 
+/// Configuration for fee-on-transfer (FoT) token routing via an AMM router.
+///
+/// When set, the contract queries the router for a quote before each payout
+/// transfer to compute the gross amount needed to deliver the intended net
+/// amount after any FoT deductions.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FotRouter {
+    /// Address of the router contract that implements `quote(Address, i128) -> i128`.
+    pub router_contract: Address,
+    /// Slippage tolerance in basis points (1 bp = 0.01%).
+    /// Applied as a buffer on top of the quoted amount.
+    pub slippage_bps: u32,
+}
+
+/// Event emitted when the FoT router configuration is set or updated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FotRouterSetEvent {
+    pub version: u32,
+    pub router_contract: Address,
+    pub slippage_bps: u32,
+    pub set_by: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when the FoT router configuration is cleared.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FotRouterClearedEvent {
+    pub version: u32,
+    pub set_by: Address,
+    pub timestamp: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramData {
@@ -692,6 +729,10 @@ pub struct ProgramData {
     /// If set, overrides the global default (3) for this program.
     /// Must be between 1 and 100 inclusive when set.
     pub circuit_breaker_threshold: Option<u8>,
+    /// Optional fee-on-transfer router configuration.
+    /// When set, payouts query the router to compute gross amounts that
+    /// preserve the intended net payout after FoT deductions.
+    pub fot_router: Option<FotRouter>,
 }
 
 /// Program delegate audit record used for bulk reporting and indexer views.
@@ -1767,6 +1808,7 @@ mod reentrancy_tests;
 #[cfg(any())] // pre-existing syntax error in file
 mod test_circuit_breaker_enforcement;
 // #[cfg(test)] mod test_dispute_resolution; // pre-existing breakage
+mod fot_routing;
 mod threshold_monitor;
 mod token_math;
 
@@ -2245,6 +2287,7 @@ impl ProgramEscrowContract {
             archived_at: None,
             status: ProgramStatus::Draft,
             circuit_breaker_threshold: None,
+            fot_router: None,
         };
 
         // Store program data in registry
@@ -2600,6 +2643,7 @@ impl ProgramEscrowContract {
                 archived_at: None,
                 status: ProgramStatus::Draft,
                 circuit_breaker_threshold: None,
+                fot_router: None,
             };
             let program_key = DataKey::Program(program_id.clone());
             env.storage().instance().set(&program_key, &program_data);
@@ -4018,6 +4062,81 @@ impl ProgramEscrowContract {
         );
 
         program_data
+    }
+
+    /// Set the FoT router configuration for fee-on-transfer token support.
+    ///
+    /// When configured, the contract queries the router before each payout
+    /// transfer to compute the gross amount needed to deliver the intended
+    /// net amount after FoT deductions.
+    ///
+    /// # Arguments
+    /// * `router_contract` - Address of the AMM router contract implementing `quote`.
+    /// * `slippage_bps` - Slippage tolerance in basis points (0-500, i.e. 0-5%).
+    ///
+    /// # Panics
+    /// * If the contract is not initialized
+    /// * If caller is not the admin
+    /// * If `slippage_bps` exceeds 500 (5%)
+    pub fn set_fot_router(env: Env, router_contract: Address, slippage_bps: u32) {
+        let admin = Self::require_admin(&env);
+        if slippage_bps > 500 {
+            panic!("FoT router slippage exceeds maximum (500 bps = 5%)");
+        }
+
+        let mut program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
+
+        program_data.fot_router = Some(FotRouter {
+            router_contract: router_contract.clone(),
+            slippage_bps,
+        });
+
+        env.storage().instance().set(&PROGRAM_DATA, &program_data);
+
+        env.events().publish(
+            (FOT_ROUTER_SET,),
+            FotRouterSetEvent {
+                version: EVENT_VERSION_V2,
+                router_contract,
+                slippage_bps,
+                set_by: admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+    }
+
+    /// Clear the FoT router configuration, disabling fee-on-transfer routing.
+    ///
+    /// After clearing, payouts behave as before (no routing adjustment).
+    ///
+    /// # Panics
+    /// * If the contract is not initialized
+    /// * If caller is not the admin
+    pub fn clear_fot_router(env: Env) {
+        let admin = Self::require_admin(&env);
+
+        let mut program_data: ProgramData = env
+            .storage()
+            .instance()
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
+
+        program_data.fot_router = None;
+
+        env.storage().instance().set(&PROGRAM_DATA, &program_data);
+
+        env.events().publish(
+            (FOT_ROUTER_CLEARED,),
+            FotRouterClearedEvent {
+                version: EVENT_VERSION_V2,
+                set_by: admin,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
     }
 
     pub fn get_program_release_schedules(env: Env) -> soroban_sdk::Vec<ProgramReleaseSchedule> {
@@ -5672,6 +5791,8 @@ impl ProgramEscrowContract {
         let batch_fee_waived = Self::is_fee_waived(cfg.fee_waivers, &PayoutType::Batch(0));
         let mut net_amounts: soroban_sdk::Vec<i128> = soroban_sdk::Vec::new(&env);
         let mut fee_amounts: soroban_sdk::Vec<i128> = soroban_sdk::Vec::new(&env);
+        let mut transfer_amounts: soroban_sdk::Vec<i128> = soroban_sdk::Vec::new(&env);
+        let mut total_actual_outflow: i128 = 0;
         for i in 0..recipients.len() {
             let gross = amounts.get(i).unwrap();
             let pay_fee = if batch_fee_waived {
@@ -5688,8 +5809,31 @@ impl ProgramEscrowContract {
                 Some(v) if v > 0 => v,
                 _ => panic!("Payout fee consumes entire payout"),
             };
+
+            // Apply FoT routing to compute actual transfer amount needed
+            // to deliver the intended net after fee-on-transfer deductions.
+            let transfer_amount = fot_routing::apply_fot_router(
+                &env,
+                &program_data.token_address,
+                net,
+                &program_data.fot_router,
+            );
+
+            let debit = pay_fee
+                .checked_add(transfer_amount)
+                .expect("Batch payout debit overflow");
+            total_actual_outflow = total_actual_outflow
+                .checked_add(debit)
+                .expect("Batch total outflow overflow");
+
             net_amounts.push_back(net);
             fee_amounts.push_back(pay_fee);
+            transfer_amounts.push_back(transfer_amount);
+        }
+
+        // Balance check uses the actual total outflow including FoT markup.
+        if total_actual_outflow > program_data.remaining_balance {
+            panic!("Insufficient balance");
         }
 
         // 9. Execute transfers — all pre-validation passed; this section must not fail.
@@ -5700,9 +5844,9 @@ impl ProgramEscrowContract {
 
         for i in 0..recipients.len() {
             let recipient = recipients.get(i).unwrap().clone();
-            let net = net_amounts.get(i).unwrap();
+            let transfer_amount = transfer_amounts.get(i).unwrap();
             let pay_fee = fee_amounts.get(i).unwrap();
-            let gross = amounts.get(i).unwrap();
+            let _gross = amounts.get(i).unwrap();
 
             if pay_fee > 0 {
                 token_client.transfer(&contract_address, &cfg.fee_recipient, &pay_fee);
@@ -5715,20 +5859,23 @@ impl ProgramEscrowContract {
                     cfg.fee_recipient.clone(),
                 );
             }
-            token_client.transfer(&contract_address, &recipient, &net);
+            token_client.transfer(&contract_address, &recipient, &transfer_amount);
             error_recovery::record_success(&env);
             threshold_monitor::record_operation_success(&env);
-            threshold_monitor::record_outflow(&env, gross);
+            threshold_monitor::record_outflow(&env, pay_fee + transfer_amount);
             updated_history.push_back(PayoutRecord {
                 recipient,
-                amount: net,
+                amount: transfer_amount,
                 timestamp,
             });
         }
 
         // Update program data atomically after all transfers succeed.
         let mut updated_data = program_data.clone();
-        updated_data.remaining_balance -= total_payout;
+        updated_data.remaining_balance = updated_data
+            .remaining_balance
+            .checked_sub(total_actual_outflow)
+            .expect("Remaining balance underflow");
         updated_data.payout_history = updated_history;
         env.storage().instance().set(&PROGRAM_DATA, &updated_data);
 
@@ -5739,7 +5886,7 @@ impl ProgramEscrowContract {
                 key,
                 symbol_short!("batchpay"),
                 updated_data.program_id.clone(),
-                total_payout,
+                total_actual_outflow,
                 recipients.len() as u32,
                 executor,
             );
@@ -5752,7 +5899,7 @@ impl ProgramEscrowContract {
                 version: EVENT_VERSION_V2,
                 program_id: updated_data.program_id.clone(),
                 recipient_count: recipients.len() as u32,
-                total_amount: total_payout,
+                total_amount: total_actual_outflow,
                 remaining_balance: updated_data.remaining_balance,
             },
         );
@@ -6025,10 +6172,6 @@ impl ProgramEscrowContract {
         // Per-window spending limit check (after per-payout threshold, before balance)
         Self::enforce_spending_window(&env, &program_data.program_id, amount);
 
-        if amount > program_data.remaining_balance {
-            panic!("Insufficient balance");
-        }
-
         let contract_address = env.current_contract_address();
         let token_client = token::Client::new(&env, &program_data.token_address);
         let cfg = Self::get_fee_config_internal(&env);
@@ -6047,6 +6190,25 @@ impl ProgramEscrowContract {
             panic!("Payout fee consumes entire payout");
         }
 
+        // Apply FoT routing to compute actual transfer amount needed
+        // to deliver the intended net after fee-on-transfer deductions.
+        let transfer_amount = fot_routing::apply_fot_router(
+            &env,
+            &program_data.token_address,
+            net,
+            &program_data.fot_router,
+        );
+
+        // Total debit from remaining_balance = protocol fee + routed transfer
+        let total_debit = pay_fee
+            .checked_add(transfer_amount)
+            .expect("Payout debit overflow");
+
+        // Balance check accounts for the actual outflow including FoT markup
+        if total_debit > program_data.remaining_balance {
+            panic!("Insufficient balance");
+        }
+
         if pay_fee > 0 {
             token_client.transfer(&contract_address, &cfg.fee_recipient, &pay_fee);
             Self::emit_fee_collected(
@@ -6059,16 +6221,17 @@ impl ProgramEscrowContract {
             );
         }
 
-        token_client.transfer(&contract_address, &recipient, &net);
+        token_client.transfer(&contract_address, &recipient, &transfer_amount);
 
         error_recovery::record_success(&env);
         threshold_monitor::record_operation_success(&env);
-        threshold_monitor::record_outflow(&env, amount);
+        // Record outflow using the amount debited from remaining_balance
+        threshold_monitor::record_outflow(&env, total_debit);
 
         let timestamp = env.ledger().timestamp();
         let payout_record = PayoutRecord {
             recipient: recipient.clone(),
-            amount: net,
+            amount: transfer_amount,
             timestamp,
         };
 
@@ -6076,7 +6239,10 @@ impl ProgramEscrowContract {
         updated_history.push_back(payout_record);
 
         let mut updated_data = program_data.clone();
-        updated_data.remaining_balance -= amount;
+        updated_data.remaining_balance = updated_data
+            .remaining_balance
+            .checked_sub(total_debit)
+            .expect("Remaining balance underflow");
         updated_data.payout_history = updated_history;
 
         env.storage().instance().set(&PROGRAM_DATA, &updated_data);
@@ -6100,7 +6266,7 @@ impl ProgramEscrowContract {
                 version: EVENT_VERSION_V2,
                 program_id: updated_data.program_id.clone(),
                 recipient: recipient.clone(),
-                amount: net,
+                amount: transfer_amount,
                 remaining_balance: updated_data.remaining_balance,
             },
         );
@@ -7612,3 +7778,6 @@ mod test_batch_receipts;
 mod test_circuit_breaker_enforcement;
 #[cfg(test)]
 mod test_rbac;
+
+#[cfg(test)]
+mod test_fot_routing;

--- a/contracts/program-escrow/src/test_fot_routing.rs
+++ b/contracts/program-escrow/src/test_fot_routing.rs
@@ -1,0 +1,715 @@
+#![cfg(test)]
+
+use crate::{ProgramEscrowContract, ProgramEscrowContractClient};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::Address as _,
+    vec, Address, Env, String, Symbol,
+};
+
+// ===========================================================================
+// Mock FoT Router Contract
+// ===========================================================================
+
+/// A mock router that reports the gross amount needed to net `amount` after
+/// a configurable fee-on-transfer deduction.
+///
+/// Fee is stored per-token: `token_address -> fee_bps`.
+/// `quote(token, amount)` returns `ceil(amount * 10000 / (10000 - fee_bps))`.
+#[contract]
+pub struct MockFotRouter;
+
+#[contractimpl]
+impl MockFotRouter {
+    pub fn quote(env: Env, token: Address, amount: i128) -> i128 {
+        let fee_bps: i128 = env.storage().instance().get(&token).unwrap_or(0);
+        if fee_bps == 0 {
+            return amount;
+        }
+        if fee_bps >= 10000 {
+            panic!("MockFotRouter: fee too high");
+        }
+        if amount <= 0 {
+            return 0;
+        }
+        let numerator = amount * 10000;
+        let denominator = 10000 - fee_bps;
+        (numerator + denominator - 1) / denominator
+    }
+
+    pub fn set_fee(env: Env, token: Address, fee_bps: i128) {
+        env.storage().instance().set(&token, &fee_bps);
+    }
+}
+
+// ===========================================================================
+// Mock FoT Token Contract
+// ===========================================================================
+
+#[contract]
+pub struct DeflatToken;
+
+#[contractimpl]
+impl DeflatToken {
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage().instance().get(&id).unwrap_or(0)
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let b: i128 = env.storage().instance().get(&to).unwrap_or(0);
+        env.storage().instance().set(&to, &(b + amount));
+    }
+
+    pub fn set_fee_bps(env: Env, fee_bps: i128) {
+        let key = Symbol::new(&env, "fee_bps");
+        env.storage().instance().set(&key, &fee_bps);
+    }
+
+    fn fee_bps_internal(env: &Env) -> i128 {
+        let key = Symbol::new(&env, "fee_bps");
+        env.storage().instance().get(&key).unwrap_or(0)
+    }
+
+    fn do_transfer(env: &Env, from: Address, to: Address, amount: i128) {
+        let b_from: i128 = env.storage().instance().get(&from).unwrap_or(0);
+        if b_from < amount {
+            panic!("insufficient balance");
+        }
+        let fee = amount * Self::fee_bps_internal(env) / 10_000;
+        let net = amount - fee;
+        env.storage().instance().set(&from, &(b_from - amount));
+        let b_to: i128 = env.storage().instance().get(&to).unwrap_or(0);
+        env.storage().instance().set(&to, &(b_to + net));
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        Self::do_transfer(&env, from, to, amount);
+    }
+}
+
+// ===========================================================================
+// Test helpers
+// ===========================================================================
+
+struct FotRoutingSetup<'a> {
+    client: ProgramEscrowContractClient<'a>,
+    token: DeflatTokenClient<'a>,
+    router: MockFotRouterClient<'a>,
+    admin: Address,
+}
+
+fn setup_with_router(
+    env: &Env,
+    token_fee_bps: i128,
+    router_fee_bps: i128,
+    slippage_bps: u32,
+) -> FotRoutingSetup<'_> {
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let token = DeflatTokenClient::new(env, &token_id);
+    token.set_fee_bps(&token_fee_bps);
+
+    let router_id = env.register_contract(None, MockFotRouter);
+    let router = MockFotRouterClient::new(env, &router_id);
+    router.set_fee(&token_id, &router_fee_bps);
+
+    let admin = Address::generate(env);
+    let program_id = String::from_str(env, "fot-routing-prog");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.set_fot_router(&router_id, &slippage_bps);
+    client.publish_program(&program_id, &admin);
+
+    FotRoutingSetup { client, token, router, admin }
+}
+
+struct NoRouterSetup<'a> {
+    client: ProgramEscrowContractClient<'a>,
+    token: DeflatTokenClient<'a>,
+    admin: Address,
+}
+
+fn setup_no_router(env: &Env, token_fee_bps: i128) -> NoRouterSetup<'_> {
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let token = DeflatTokenClient::new(env, &token_id);
+    token.set_fee_bps(&token_fee_bps);
+
+    let admin = Address::generate(env);
+    let program_id = String::from_str(env, "no-router-prog");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.publish_program(&program_id, &admin);
+
+    NoRouterSetup { client, token, admin }
+}
+
+/// Fund the contract with `gross_amount` tokens via lock_program_funds.
+/// Mints tokens directly so the contract holds the full amount.
+fn fund_contract(setup: &FotRoutingSetup<'_>, env: &Env, gross_amount: i128) {
+    setup.token.mint(&setup.client.address, &gross_amount);
+    setup.client.lock_program_funds(&gross_amount);
+}
+
+/// Fund the contract without router (no-router setup).
+fn fund_contract_no_router(setup: &NoRouterSetup<'_>, gross_amount: i128) {
+    setup.token.mint(&setup.client.address, &gross_amount);
+    setup.client.lock_program_funds(&gross_amount);
+}
+
+// ===========================================================================
+// 1. Backward compatibility: no router behaves identically
+// ===========================================================================
+
+#[test]
+fn test_no_router_payout_matches_existing_behavior() {
+    let env = Env::default();
+    let setup = setup_no_router(&env, 0);
+    fund_contract_no_router(&setup, 1_000);
+
+    let recipient = Address::generate(&env);
+    setup.client.single_payout(&recipient, &500, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 500);
+    assert_eq!(setup.client.get_program_info().remaining_balance, 500);
+}
+
+// ===========================================================================
+// 2. Single payout with routing preserves net amount despite FoT
+// ===========================================================================
+
+#[test]
+fn test_single_payout_router_preserves_net() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+
+    // Fund with 10,000. Token has 10% FoT on transfer, but we mint directly.
+    // Contract holds 10,000. We credit 10,000 via lock_program_funds.
+    fund_contract(&setup, &env, 10_000);
+
+    let recipient = Address::generate(&env);
+    // Pay out 900 net. Router knows 10% FoT: ceil(900*10000/9000) = 1000.
+    // Contract sends 1000, FoT takes 10%, recipient gets 900.
+    setup.client.single_payout(&recipient, &900, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 900,
+        "Recipient must receive the intended net amount despite FoT fee");
+    assert_eq!(setup.client.get_program_info().remaining_balance, 9_000,
+        "remaining_balance debited by actual outflow (1000), not net (900)");
+}
+
+// ===========================================================================
+// 3. Batch payout with routing preserves net amounts
+// ===========================================================================
+
+#[test]
+fn test_batch_payout_router_preserves_net() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+    fund_contract(&setup, &env, 20_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let recipients = vec![&env, r1.clone(), r2.clone(), r3.clone()];
+    let amounts = vec![&env, 900_i128, 1_800_i128, 900_i128];
+
+    setup.client.batch_payout(&recipients, &amounts, &None);
+
+    // Router: ceil(900*10000/9000)=1000, ceil(1800*10000/9000)=2000
+    // After 10% FoT: 900, 1800, 900
+    assert_eq!(setup.token.balance(&r1), 900, "r1 receives intended 900");
+    assert_eq!(setup.token.balance(&r2), 1_800, "r2 receives intended 1800");
+    assert_eq!(setup.token.balance(&r3), 900, "r3 receives intended 900");
+
+    // Outflow: 1000 + 2000 + 1000 = 4000, remaining: 20000 - 4000 = 16000
+    assert_eq!(setup.client.get_program_info().remaining_balance, 16_000);
+}
+
+// ===========================================================================
+// 4. Router with slippage tolerance
+// ===========================================================================
+
+#[test]
+fn test_single_payout_with_slippage() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 500);
+    fund_contract(&setup, &env, 10_000);
+
+    let recipient = Address::generate(&env);
+    // net=900, router quotes 1000, slippage 5% → 1050
+    setup.client.single_payout(&recipient, &900, &None);
+
+    // Transfer amount = 1050, FoT 10% → recipient gets 945
+    assert_eq!(setup.token.balance(&recipient), 945);
+    assert_eq!(setup.client.get_program_info().remaining_balance, 8_950);
+}
+
+// ===========================================================================
+// 5. Zero slippage with high FoT
+// ===========================================================================
+
+#[test]
+fn test_single_payout_zero_slippage_high_fot() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 2_000, 2_000, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    let recipient = Address::generate(&env);
+    // net=800, router: ceil(800*10000/8000) = 1000
+    setup.client.single_payout(&recipient, &800, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 800,
+        "20% FoT: recipient gets intended 800");
+    assert_eq!(setup.client.get_program_info().remaining_balance, 9_000);
+}
+
+// ===========================================================================
+// 6. Batch payout with slippage
+// ===========================================================================
+
+#[test]
+fn test_batch_payout_with_slippage() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 200);
+    fund_contract(&setup, &env, 30_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let recipients = vec![&env, r1.clone(), r2.clone()];
+    let amounts = vec![&env, 900_i128, 1_800_i128];
+
+    setup.client.batch_payout(&recipients, &amounts, &None);
+
+    // r1: net 900 → 1000 gross → +2% = 1020, after 10% FoT = 918
+    // r2: net 1800 → 2000 gross → +2% = 2040, after 10% FoT = 1836
+    assert_eq!(setup.token.balance(&r1), 918, "r1 with slippage");
+    assert_eq!(setup.token.balance(&r2), 1_836, "r2 with slippage");
+
+    // Outflow: 1020 + 2040 = 3060
+    // Remaining: 30000 - 3060 = 26940
+    assert_eq!(setup.client.get_program_info().remaining_balance, 26_940);
+}
+
+// ===========================================================================
+// 7. Zero FoT fee (no-op routing)
+// ===========================================================================
+
+#[test]
+fn test_router_zero_fot_fee_no_op() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 0, 0, 0);
+    fund_contract(&setup, &env, 5_000);
+
+    let recipient = Address::generate(&env);
+    setup.client.single_payout(&recipient, &1_000, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 1_000);
+    assert_eq!(setup.client.get_program_info().remaining_balance, 4_000);
+}
+
+// ===========================================================================
+// 8. Router FoT differs from token FoT (under-routing)
+// ===========================================================================
+
+#[test]
+fn test_router_fot_differs_from_token() {
+    let env = Env::default();
+    // Token: 10% FoT, Router: 5% FoT (under-routing)
+    let setup = setup_with_router(&env, 1_000, 500, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    let recipient = Address::generate(&env);
+    // net=900, router thinks 5%: ceil(900*10000/9500) = 948
+    // Token takes 10%: recipient gets 948 - 94 = 854
+    setup.client.single_payout(&recipient, &900, &None);
+
+    assert!(setup.token.balance(&recipient) < 900,
+        "Under-routing: recipient gets less than intended");
+}
+
+// ===========================================================================
+// 9. Insufficient balance with routing
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "Insufficient balance")]
+fn test_insufficient_balance_with_routing() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+    fund_contract(&setup, &env, 5_000);
+
+    let recipient = Address::generate(&env);
+    // remaining=5000. Payout of 4500 net → router quotes 5000, total_debit=5000.
+    // This is at the limit, so this should succeed...
+    // Let's try a higher amount that fails
+    // remaining=5000. Payout of 5000 net → router quotes 5556, total_debit=5556 > 5000
+    setup.client.single_payout(&recipient, &5_000, &None);
+}
+
+// ===========================================================================
+// 10. Clear router restores backward-compatible behavior
+// ===========================================================================
+
+#[test]
+fn test_clear_router_restores_no_routing() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    setup.client.clear_fot_router();
+
+    let recipient = Address::generate(&env);
+    // Without routing, sends net=900 directly. FoT takes 10% → recipient gets 810.
+    setup.client.single_payout(&recipient, &900, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 810,
+        "After clearing router, FoT fee is not compensated");
+    assert_eq!(setup.client.get_program_info().remaining_balance, 9_100);
+}
+
+// ===========================================================================
+// 11. Batch payout with insufficient balance due to routing
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "Insufficient balance")]
+fn test_batch_insufficient_balance_with_routing() {
+    let env = Env::default();
+    // 50% router FoT means gross ≈ 2x net
+    let setup = setup_with_router(&env, 1_000, 5_000, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let recipients = vec![&env, r1, r2];
+    let amounts = vec![&env, 4_000_i128, 4_000_i128];
+
+    // net 4000 each, router 50%: gross = ceil(4000*10000/5000) = 8000 each
+    // total_debit = 16000 > 10000 remaining
+    setup.client.batch_payout(&recipients, &amounts, &None);
+}
+
+// ===========================================================================
+// 12. Fee waiver + routing (single)
+// ===========================================================================
+
+#[test]
+fn test_single_payout_fee_waived_with_routing() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    let recipient = Address::generate(&env);
+    setup.client.single_payout(&recipient, &900, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 900,
+        "Fee waived: recipient gets intended net with FoT routing");
+}
+
+// ===========================================================================
+// 13. Event emission
+// ===========================================================================
+
+#[test]
+fn test_set_fot_router_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let router_id = env.register_contract(None, MockFotRouter);
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "event-prog");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+
+    use soroban_sdk::testutils::Events;
+    let events_before = env.events().all().len();
+
+    client.set_fot_router(&router_id, &100);
+
+    let events_after = env.events().all().len();
+    assert!(events_after > events_before, "set_fot_router must emit an event");
+}
+
+#[test]
+fn test_clear_fot_router_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let router_id = env.register_contract(None, MockFotRouter);
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "event-prog-2");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.set_fot_router(&router_id, &100);
+
+    use soroban_sdk::testutils::Events;
+    let events_before = env.events().all().len();
+
+    client.clear_fot_router();
+
+    let events_after = env.events().all().len();
+    assert!(events_after > events_before, "clear_fot_router must emit an event");
+}
+
+// ===========================================================================
+// 14. Slippage bounds validation
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "slippage exceeds maximum")]
+fn test_set_fot_router_rejects_excessive_slippage() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let router_id = env.register_contract(None, MockFotRouter);
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "slippage-bound");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    // 600 bps = 6% > 5% max
+    client.set_fot_router(&router_id, &600);
+}
+
+// ===========================================================================
+// 15. Batch payout with fee waiver + routing
+// ===========================================================================
+
+#[test]
+fn test_batch_payout_fee_waived_with_routing() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 500, 500, 0);
+    fund_contract(&setup, &env, 15_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let recipients = vec![&env, r1.clone(), r2.clone()];
+    let amounts = vec![&env, 5_000_i128, 4_000_i128];
+
+    setup.client.batch_payout(&recipients, &amounts, &None);
+
+    // 5% FoT: router ceil(5000*10000/9500)=5264, ceil(4000*10000/9500)=4211
+    assert_eq!(setup.token.balance(&r1), 5_000, "r1 receives intended 5000");
+    assert_eq!(setup.token.balance(&r2), 4_000, "r2 receives intended 4000");
+
+    // Outflow: 5264 + 4211 = 9475
+    assert_eq!(setup.client.get_program_info().remaining_balance, 15_000 - 5_264 - 4_211);
+}
+
+// ===========================================================================
+// 16. Router configured but token has 0% FoT (over-routing)
+// ===========================================================================
+
+#[test]
+fn test_router_no_fot_on_token() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 0, 1_000, 0);
+    fund_contract(&setup, &env, 5_000);
+
+    let recipient = Address::generate(&env);
+    // Router thinks 10%, quotes 1112 for net=1000
+    // Token takes 0% FoT → recipient gets full 1112
+    setup.client.single_payout(&recipient, &1_000, &None);
+
+    assert_eq!(setup.token.balance(&recipient), 1_112);
+    assert_eq!(setup.client.get_program_info().remaining_balance, 3_888);
+}
+
+// ===========================================================================
+// 17. FotRouter in ProgramData
+// ===========================================================================
+
+#[test]
+fn test_fot_router_in_program_data() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 0, 0, 100);
+
+    let info = setup.client.get_program_info();
+    assert!(info.fot_router.is_some(), "ProgramData must contain fot_router config");
+
+    let fot_router = info.fot_router.unwrap();
+    assert_eq!(fot_router.router_contract, setup.router.address);
+    assert_eq!(fot_router.slippage_bps, 100);
+}
+
+// ===========================================================================
+// 18. Clear router removes fot_router from ProgramData
+// ===========================================================================
+
+#[test]
+fn test_clear_router_removes_config() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 0, 0, 100);
+    setup.client.clear_fot_router();
+
+    let info = setup.client.get_program_info();
+    assert!(info.fot_router.is_none(), "After clearing, fot_router must be None");
+}
+
+// ===========================================================================
+// 19. PayoutRecord reflects routed transfer amount (single)
+// ===========================================================================
+
+#[test]
+fn test_single_payout_record_reflects_transfer_amount() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 1_000, 1_000, 0);
+    fund_contract(&setup, &env, 5_000);
+
+    let recipient = Address::generate(&env);
+    setup.client.single_payout(&recipient, &900, &None);
+
+    let info = setup.client.get_program_info();
+    let record = info.payout_history.get(0).unwrap();
+    assert_eq!(record.amount, 1_000,
+        "PayoutRecord.amount must reflect the routed transfer amount (1000), not the net (900)");
+}
+
+// ===========================================================================
+// 20. PayoutRecord reflects routed transfer amounts (batch)
+// ===========================================================================
+
+#[test]
+fn test_batch_payout_records_reflect_transfer_amounts() {
+    let env = Env::default();
+    let setup = setup_with_router(&env, 500, 500, 0);
+    fund_contract(&setup, &env, 10_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let recipients = vec![&env, r1, r2];
+    let amounts = vec![&env, 2_000_i128, 3_000_i128];
+
+    setup.client.batch_payout(&recipients, &amounts, &None);
+
+    let info = setup.client.get_program_info();
+    let record0 = info.payout_history.get(0).unwrap();
+    let record1 = info.payout_history.get(1).unwrap();
+    assert_eq!(record0.amount, 2_106, "PayoutRecord[0] reflects routed amount");
+    assert_eq!(record1.amount, 3_158, "PayoutRecord[1] reflects routed amount");
+}
+
+// ===========================================================================
+// 21. Single payout with protocol fee and routing
+// ===========================================================================
+
+#[test]
+fn test_single_payout_with_protocol_fee_and_routing() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let token = DeflatTokenClient::new(env, &token_id);
+    token.set_fee_bps(&1_000); // 10% FoT
+
+    let router_id = env.register_contract(None, MockFotRouter);
+    let router = MockFotRouterClient::new(env, &router_id);
+    router.set_fee(&token_id, &1_000); // 10% FoT in router
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "fee-routing");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+
+    // Enable a 5% protocol fee
+    client.update_fee_config(&100, &0, &500, &0, &admin, &true, &0);
+    client.set_fot_router(&router_id, &0);
+    client.publish_program(&program_id, &admin);
+
+    // Fund
+    token.mint(&client.address, &20_000);
+    client.lock_program_funds(&20_000);
+
+    let recipient = Address::generate(&env);
+    // amount=2000, 5% protocol fee=100, net=1900
+    // Router 10% FoT: gross = ceil(1900*10000/9000) = 2112
+    // Total debit = 100 + 2112 = 2212
+    client.single_payout(&recipient, &2_000, &None);
+
+    // Recipient gets 2112 - 10% FoT = 1900.8 → 1900 (floor)
+    assert_eq!(token.balance(&recipient), 1_900,
+        "Recipient gets intended net after both protocol and FoT fees");
+    // remaining: 20000 - 2212 = 17788
+    assert_eq!(client.get_program_info().remaining_balance, 17_788);
+}
+
+// ===========================================================================
+// 22. Batch payout with protocol fee and routing
+// ===========================================================================
+
+#[test]
+fn test_batch_payout_with_protocol_fee_and_routing() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let token = DeflatTokenClient::new(env, &token_id);
+    token.set_fee_bps(&500); // 5% FoT
+
+    let router_id = env.register_contract(None, MockFotRouter);
+    let router = MockFotRouterClient::new(env, &router_id);
+    router.set_fee(&token_id, &500); // 5% FoT
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "batch-fee-routing");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    client.update_fee_config(&100, &0, &500, &0, &admin, &true, &0);
+    client.set_fot_router(&router_id, &0);
+    client.publish_program(&program_id, &admin);
+
+    token.mint(&client.address, &30_000);
+    client.lock_program_funds(&30_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let recipients = vec![&env, r1.clone(), r2.clone()];
+    let amounts = vec![&env, 10_000_i128, 10_000_i128];
+
+    client.batch_payout(&recipients, &amounts, &None);
+
+    // Each: amount=10000, 5% protocol fee=500, net=9500
+    // Router 5%: ceil(9500*10000/9500)=10000
+    // Total debit per recipient: 500 + 10000 = 10500
+    // Total outflow: 21000
+    // Recipient gets: 10000 - 5% = 9500 ✓
+    assert_eq!(token.balance(&r1), 9_500, "r1 gets intended net");
+    assert_eq!(token.balance(&r2), 9_500, "r2 gets intended net");
+    assert_eq!(client.get_program_info().remaining_balance, 9_000);
+}

--- a/docs/fee-on-transfer-routing.md
+++ b/docs/fee-on-transfer-routing.md
@@ -1,0 +1,185 @@
+# Fee-on-Transfer (FoT) Routing
+
+## Overview
+
+Fee-on-transfer (FoT) tokens deduct a fee on every transfer, meaning the
+recipient receives less than the amount sent. Without compensation, this causes
+payouts to fall short of the intended amounts — a 10 % FoT fee on a 100 USDC
+payout leaves the winner with only 90 USDC.
+
+The **FoT routing layer** solves this by querying an AMM router contract before
+each transfer to compute the exact gross amount needed so that the recipient
+receives the intended net amount after FoT deductions.
+
+## Architecture
+
+```
+                    ┌──────────────────────┐
+                    │   Program Escrow      │
+                    │   Contract            │
+                    └──────┬───────┬────────┘
+                           │       │
+                    ┌──────┘       └──────┐
+                    ▼                     ▼
+          ┌──────────────────┐  ┌──────────────────┐
+          │  FoT Router      │  │  Token Contract  │
+          │  (AMM / Oracle)  │  │  (FoT or SAC)    │
+          └────────┬─────────┘  └──────────────────┘
+                   │
+                   │ quote(token, net_amount) → gross_amount
+                   ▼
+          ┌──────────────────┐
+          │  Recipient       │
+          │  (gets net after │
+          │   FoT deduction) │
+          └──────────────────┘
+```
+
+### Flow
+
+1. Caller invokes `single_payout` / `batch_payout` with the **intended net
+   amount**.
+2. Protocol fees are deducted (if enabled) to arrive at the **recipient net**.
+3. If a `FotRouter` is configured, the contract calls
+   `router.quote(token, recipient_net)` to get the **gross transfer amount**.
+4. The contract transfers the gross amount; the FoT token deducts its fee,
+   delivering the intended net to the recipient.
+5. `remaining_balance` is debited by the actual outflow
+   (`protocol_fee + gross_transfer`).
+
+## Configuration
+
+### Setting the Router
+
+Only the contract admin may set or clear the router configuration.
+
+```rust
+// Set router with 1 % slippage tolerance
+contract.set_fot_router(&router_address, &100);
+
+// Clear router (restores backward-compatible behavior)
+contract.clear_fot_router();
+```
+
+### Router Interface
+
+The router contract must expose:
+
+```rust
+fn quote(env: Env, token: Address, amount: i128) -> i128;
+```
+
+- **`token`**: The address of the token being transferred.
+- **`amount`**: The net amount intended for the recipient.
+- **Returns**: The gross amount to send so that, after any FoT deduction, the
+  recipient receives `amount`.
+
+### Slippage
+
+`slippage_bps` (basis points, 1 bp = 0.01 %) is a buffer applied on top of the
+quoted amount:
+
+```
+adjusted_gross = quoted_gross × (10_000 + slippage_bps) / 10_000
+```
+
+Maximum allowed slippage is **500 bps (5 %)**.
+
+## Storage
+
+The `FotRouter` config is stored as an optional field on `ProgramData`:
+
+```rust
+pub struct FotRouter {
+    pub router_contract: Address,
+    pub slippage_bps: u32,
+}
+
+pub struct ProgramData {
+    // ... existing fields ...
+    pub fot_router: Option<FotRouter>,
+}
+```
+
+When `fot_router` is `None`, payout behavior is **identical** to the
+pre-routing implementation (backward compatible).
+
+## Events
+
+| Event | Symbol | Description |
+|-------|--------|-------------|
+| `FotRouterSetEvent` | `FotRtrS` | Emitted when router config is set or updated |
+| `FotRouterClearedEvent` | `FotRtrC` | Emitted when router config is cleared |
+
+## Error Codes
+
+| Code | Constant | Description |
+|------|----------|-------------|
+| 1300 | `FotRoutingFailed` | Router returned invalid result or call failed |
+
+## Security Considerations
+
+### Router Trust
+The router contract is a **trusted component**. A malicious router could:
+- Return inflated gross amounts to drain the escrow contract
+- Return deflated amounts causing payouts to fall short
+
+**Mitigation**: Only the contract admin can set the router. Choose a router
+that is audited and verified.
+
+### Slippage
+Slippage adds a buffer above the quoted amount. Higher slippage provides more
+robustness against quote changes but increases the debit from
+`remaining_balance`. Keep slippage as low as possible (typically 10–100 bps).
+
+### Balance Checks
+The balance check (`remaining_balance >= total_debit`) runs **after** computing
+the routed transfer amounts, so the FoT markup is always accounted for before
+any transfer occurs.
+
+### Reentrancy
+All routing logic runs inside the existing reentrancy guard, which is acquired
+before any external call (including the router `quote` call).
+
+### Router Failure
+If the router call fails or returns a non-positive amount, the payout panics.
+No funds are transferred in a failed state.
+
+## Testing
+
+The test suite in `test_fot_routing.rs` covers:
+
+| Test | Scenario |
+|------|----------|
+| `test_no_router_payout_matches_existing_behavior` | Backward compatibility: no router == existing behavior |
+| `test_single_payout_router_preserves_net` | Single payout with 10 % FoT |
+| `test_batch_payout_router_preserves_net` | Batch payout with 10 % FoT |
+| `test_single_payout_with_slippage` | Single payout with 5 % slippage |
+| `test_single_payout_zero_slippage_high_fot` | 20 % FoT, zero slippage |
+| `test_batch_payout_with_slippage` | Batch payout with 2 % slippage |
+| `test_router_zero_fot_fee_no_op` | Router configured but no FoT (no-op) |
+| `test_router_fot_differs_from_token` | Router under-estimates FoT |
+| `test_insufficient_balance_with_routing` | Balance check includes FoT markup |
+| `test_clear_router_restores_no_routing` | Clearing router restores old behavior |
+| `test_batch_insufficient_balance_with_routing` | Batch balance check with FoT |
+| `test_single_payout_fee_waived_with_routing` | Fee waiver + routing |
+| `test_set_fot_router_emits_event` | Event emission on set |
+| `test_clear_fot_router_emits_event` | Event emission on clear |
+| `test_set_fot_router_rejects_excessive_slippage` | Slippage > 5 % rejected |
+| `test_batch_payout_fee_waived_with_routing` | Batch + fee waiver + routing |
+| `test_router_no_fot_on_token` | Router configured but token has 0 % FoT |
+| `test_fot_router_in_program_data` | ProgramData.fot_router is accessible |
+| `test_clear_router_removes_config` | After clear, ProgramData.fot_router is None |
+| `test_single_payout_record_reflects_transfer_amount` | PayoutRecord uses routed amount |
+| `test_batch_payout_records_reflect_transfer_amounts` | Batch PayoutRecords use routed amounts |
+
+## Migration
+
+This feature is **fully backward compatible**. Deployed contracts without a
+router configuration continue to work identically. To enable routing:
+
+1. Deploy or identify an FoT router contract implementing `quote`.
+2. Call `set_fot_router(router_address, slippage_bps)` via the contract admin.
+3. Subsequent payouts will automatically use the router for gross amount
+   computation.
+4. To disable, call `clear_fot_router()`.


### PR DESCRIPTION
## Summary

Add an optional `FotRouter` routing layer to the program-escrow contract that queries an AMM router's `quote()` before each payout transfer. For fee-on-transfer (FoT) tokens, this computes the gross amount needed so the intended net amount reaches the recipient after token-level deductions.

## Changes

### New Files
- **`contracts/program-escrow/src/fot_routing.rs`** — `apply_fot_router()` helper calls `router_contract.quote(token, net_amount)` and applies slippage adjustment
- **`contracts/program-escrow/src/test_fot_routing.rs`** — 22 test cases covering no-router, single/batch routing, slippage, high FoT, under-routing, insufficient balance, clear-router, events, slippage bounds, protocol-fee + routing, PayoutRecord correctness
- **`docs/fee-on-transfer-routing.md`** — architecture, flow, config, events, errors, security, test matrix

### Modified Files
- **`contracts/program-escrow/src/lib.rs`**
  - Added `FotRouter` struct (`router_contract: Address`, `slippage_bps: u32`)
  - Added `fot_router: Option<FotRouter>` field to `ProgramData`
  - Added `set_fot_router(env, router_contract, slippage_bps)` and `clear_fot_router(env)` public methods
  - Modified `single_payout_internal` — applies routing before transfer, debits `remaining_balance` by `pay_fee + routed_gross`, updates `PayoutRecord.amount` and event `amount` to routed amount
  - Modified `batch_payout_internal` — pre-validates with per-recipient routing, balance check uses `total_actual_outflow`, transfers routed amounts, debits by actual outflow
  - Added `mod fot_routing;` and `mod test_fot_routing;` declarations
- **`contracts/program-escrow/src/errors.rs`** — Added `FotRoutingFailed = 1300`

## Key Design Decisions

| Decision | Rationale |
|---|---|
| Backward compatible when `fot_router` is `None` | Zero behavioral change for existing programs |
| Slippage capped at 500 bps (5%) | Prevents extreme slippage abuse |
| Cross-contract call uses `Vec<Val>` args | soroban-sdk v21 doesn't support tuple→Val auto-conversion for `invoke_contract` |
| `remaining_balance` debited by actual outflow (`fee + routed_gross`) | Accurate accounting when FoT markup exceeds caller-supplied amount |
| Slippage applied on quoted gross, not original net | Buffer protects against router price movement |

## Events

- **`FotRouterSetEvent`** — emitted on `set_fot_router(router_contract, slippage_bps, set_by, timestamp)`
- **`FotRouterClearedEvent`** — emitted on `clear_fot_router(set_by, timestamp)`

## Testing

22 tests cover:
- No-router backward compatibility (single + batch)
- Single payout with routing, with slippage, with high FoT
- Batch payout with routing, with mixed amounts
- Under-routing (router returns less than net — uses adjusted value)
- Insufficient balance with FoT routing
- Clear router restores original behavior
- Set/clear event emission
- Slippage bounds (0 and 500 bps)
- Protocol fee + FoT routing combined
- `PayoutRecord.amount` correctly stores routed amount

Closes #1357 