### PR TITLE
feat(grainlify): add-dust-payout-reputation-gaming-resistance-tes

### DIFF
--- a/contracts/program-escrow/Cargo.toml
+++ b/contracts/program-escrow/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "=21.7.7"
@@ -20,24 +20,6 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
-[package]
-name = "program-escrow"
-version = "0.1.0"
-edition = "2021"
-
-[lib]
-crate-type = ["cdylib", "rlib"]
-
-[dependencies]
-
-[dev-dependencies]
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
 debug = 0
 strip = "symbols"
 debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -674,11 +674,10 @@ pub enum ProgramStatus {
 /// contract.set_program_circuit_breaker_threshold(&program_id, &None);
 /// ```
 
-<<<<<<< fix/optimize-program-data-struct-field-ordering
 // schema_version: 2
 // Field ordering optimized for Soroban XDR write cost: fixed-size hot-path fields
 // come first so partial-update patterns touch the smallest possible XDR prefix.
-=======
+
 /// Configuration for fee-on-transfer (FoT) token routing via an AMM router.
 ///
 /// When set, the contract queries the router for a quote before each payout
@@ -714,7 +713,6 @@ pub struct FotRouterClearedEvent {
     pub timestamp: u64,
 }
 
->>>>>>> master
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramData {
@@ -734,15 +732,11 @@ pub struct ProgramData {
     /// Optional per-program circuit breaker failure threshold.
     /// If set, overrides the global default (3) for this program.
     /// Must be between 1 and 100 inclusive when set.
-<<<<<<< fix/optimize-program-data-struct-field-ordering
     pub circuit_breaker_threshold: Option<u8>,
     // --- Cold path: variable-size fields written infrequently ---
     pub program_id: String,
     pub payout_history: soroban_sdk::Vec<PayoutRecord>,
     pub reference_hash: Option<soroban_sdk::Bytes>,
-=======
-    pub circuit_breaker_threshold: Option<u32>,
->>>>>>> master
 }
 
 /// Program delegate audit record used for bulk reporting and indexer views.
@@ -1513,8 +1507,10 @@ pub struct Analytics {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramReputation {
-    /// Total number of direct payouts executed
+    /// Total number of payout records in history (includes dust; not used in `overall_score_bps`)
     pub total_payouts: u32,
+    /// Payouts with amount >= [`REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT`]
+    pub qualified_payout_count: u32,
     /// Total number of release schedules created
     pub total_scheduled: u32,
     /// Number of schedules successfully released
@@ -1535,10 +1531,13 @@ pub struct ProgramReputation {
     /// Defaults to 10_000 if no schedules exist
     pub completion_rate_bps: u32,
     /// Payout fulfillment rate: (total_funds_distributed / total_funds_locked) * 10_000
-    /// Defaults to 0 if no funds locked, capped at 10_000
+    /// Defaults to 0 if no funds locked, capped at 10_000.
+    /// Value-weighted: dust payouts contribute proportionally to their size, not per-call.
     pub payout_fulfillment_rate_bps: u32,
     /// Overall reputation score in basis points (0-10_000)
-    /// Returns 0 if any overdue releases exist (reputation penalty for overdue milestones)
+    /// Weighted 60% schedule completion + 40% payout fulfillment.
+    /// Returns 0 if any overdue releases exist (reputation penalty for overdue milestones).
+    /// Resistant to dust spam on score: inflating `total_payouts` alone does not raise this field.
     pub overall_score_bps: u32,
 }
 
@@ -1831,11 +1830,19 @@ mod test_circuit_breaker_enforcement;
 mod fot_routing;
 mod threshold_monitor;
 mod token_math;
+mod reputation;
+pub use reputation::{
+    REPUTATION_DUST_PAYOUT_AMOUNT, REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT,
+    REPUTATION_TYPICAL_PAYOUT_AMOUNT,
+};
 
 // #[cfg(test)] mod reentrancy_guard_standalone_test; // pre-existing breakage
 // #[cfg(test)] mod malicious_reentrant; // pre-existing breakage
 #[cfg(test)]
 mod test_granular_pause;
+
+#[cfg(test)]
+mod test_reputation;
 
 // ========================================================================
 // Property-based test suite — `src/tests/` submodule hierarchy
@@ -4949,9 +4956,11 @@ impl ProgramEscrowContract {
             }
         }
 
-        let previous_threshold = program_data.circuit_breaker_threshold;
+        let previous_threshold = program_data
+            .circuit_breaker_threshold
+            .map(|value| value as u32);
         let mut updated_data = program_data.clone();
-        updated_data.circuit_breaker_threshold = threshold;
+        updated_data.circuit_breaker_threshold = threshold.map(|value| value as u8);
 
         // Update program data
         let program_key = DataKey::Program(program_id.clone());
@@ -7589,8 +7598,11 @@ impl ProgramEscrowContract {
     }
 
     /// Get reputation metrics for the current program.
-    /// Computes reputation based on schedules, payouts, and funds.
-    /// Returns zero overall_score_bps if any releases are overdue (penalty for missed milestones).
+    ///
+    /// Computes reputation from schedules, payout **amounts**, and locked funds.
+    /// `overall_score_bps` is value-weighted; dust-sized payouts cannot cheaply max the score
+    /// while most funds stay locked. See `docs/program-escrow-reputation-gaming.md`.
+    /// Returns zero `overall_score_bps` if any releases are overdue (missed milestone penalty).
     pub fn get_program_reputation(env: Env) -> ProgramReputation {
         let program_data: Option<ProgramData> = env.storage().instance().get(&PROGRAM_DATA);
 
@@ -7598,6 +7610,7 @@ impl ProgramEscrowContract {
             // Return zero reputation for uninitialized program
             return ProgramReputation {
                 total_payouts: 0,
+                qualified_payout_count: 0,
                 total_scheduled: 0,
                 completed_releases: 0,
                 pending_releases: 0,
@@ -7641,48 +7654,35 @@ impl ProgramEscrowContract {
             }
         }
 
-        // Compute distributed funds from payout history
+        // Compute distributed funds and qualifying activity from payout history
         let mut total_funds_distributed: i128 = 0;
+        let mut qualified_payout_count: u32 = 0;
         for payout in program_data.payout_history.iter() {
-            total_funds_distributed = total_funds_distributed.saturating_add(payout.amount);
+            total_funds_distributed =
+                total_funds_distributed.saturating_add(payout.amount);
+            if payout.amount >= reputation::REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT {
+                qualified_payout_count = qualified_payout_count.saturating_add(1);
+            }
         }
 
         let total_payouts = program_data.payout_history.len() as u32;
         let total_funds_locked = program_data.total_funds;
 
-        // Compute completion_rate_bps
-        let completion_rate_bps = if total_scheduled == 0 {
-            10_000 // Default to perfect if no schedules
-        } else {
-            let rate = (completed_releases as u64)
-                .saturating_mul(10_000)
-                .saturating_div(total_scheduled as u64);
-            (rate.min(10_000)) as u32
-        };
+        let completion_rate_bps =
+            reputation::completion_rate_bps(completed_releases, total_scheduled);
 
-        // Compute payout_fulfillment_rate_bps
-        let payout_fulfillment_rate_bps = if total_funds_locked == 0 {
-            10_000 // Default to perfect if no funds locked
-        } else {
-            let rate = total_funds_distributed
-                .saturating_mul(10_000)
-                .saturating_div(total_funds_locked);
-            (rate.min(10_000)) as u32
-        };
+        let payout_fulfillment_rate_bps =
+            reputation::payout_fulfillment_rate_bps(total_funds_distributed, total_funds_locked);
 
-        // Compute overall_score_bps: 0 if overdue releases exist, else weighted average
-        let overall_score_bps = if overdue_releases > 0 {
-            0 // Reputation penalty: any overdue release results in zero overall score
-        } else {
-            let weighted = (completion_rate_bps as u64)
-                .saturating_mul(60)
-                .saturating_add((payout_fulfillment_rate_bps as u64).saturating_mul(40))
-                .saturating_div(100);
-            (weighted.min(10_000)) as u32
-        };
+        let overall_score_bps = reputation::overall_score_bps(
+            completion_rate_bps,
+            payout_fulfillment_rate_bps,
+            overdue_releases,
+        );
 
         ProgramReputation {
             total_payouts,
+            qualified_payout_count,
             total_scheduled,
             completed_releases,
             pending_releases,

--- a/contracts/program-escrow/src/reputation.rs
+++ b/contracts/program-escrow/src/reputation.rs
@@ -1,0 +1,121 @@
+//! Reputation scoring helpers for program-escrow.
+//!
+//! The on-chain [`ProgramReputation`](crate::ProgramReputation) snapshot combines
+//! schedule completion and **value-weighted** payout fulfillment. Raw payout
+//! counts are exposed for analytics but do not drive `overall_score_bps`.
+//!
+//! # Dust payout gaming
+//!
+//! Attackers may spam minimum-size `single_payout` calls to inflate `total_payouts`
+//! cheaply. Value-based fulfillment prevents dust from raising `overall_score_bps`
+//! when meaningful funds remain locked. Activity that counts toward
+//! `qualified_payout_count` requires amounts at or above
+//! [`REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT`].
+
+/// Smallest payout amount (token base units) treated as a full reputation activity event.
+pub const REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT: i128 = 1_000;
+
+/// Reference payout size used in tests and documentation for “typical” prize amounts.
+pub const REPUTATION_TYPICAL_PAYOUT_AMOUNT: i128 = 10_000;
+
+/// Minimum viable positive payout accepted by `single_payout` validation.
+pub const REPUTATION_DUST_PAYOUT_AMOUNT: i128 = 1;
+
+const BPS_SCALE: u32 = 10_000;
+const COMPLETION_WEIGHT_PERCENT: u64 = 60;
+const PAYOUT_FULFILLMENT_WEIGHT_PERCENT: u64 = 40;
+
+/// Sum payout amounts from history (saturating).
+pub fn total_funds_distributed_from_amounts<I>(amounts: I) -> i128
+where
+    I: Iterator<Item = i128>,
+{
+    amounts.fold(0i128, |acc, amount| acc.saturating_add(amount))
+}
+
+/// Count payouts whose amount meets the qualifying floor for activity metrics.
+pub fn count_qualified_payouts<I>(amounts: I) -> u32
+where
+    I: Iterator<Item = i128>,
+{
+    amounts
+        .filter(|amount| *amount >= REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT)
+        .count() as u32
+}
+
+/// Completion rate in basis points; defaults to perfect when no schedules exist.
+pub fn completion_rate_bps(completed_releases: u32, total_scheduled: u32) -> u32 {
+    if total_scheduled == 0 {
+        BPS_SCALE
+    } else {
+        let rate = (completed_releases as u64)
+            .saturating_mul(BPS_SCALE as u64)
+            .saturating_div(total_scheduled as u64);
+        (rate.min(BPS_SCALE as u64)) as u32
+    }
+}
+
+/// Distributed / locked ratio in basis points; defaults to perfect when nothing is locked.
+pub fn payout_fulfillment_rate_bps(total_funds_distributed: i128, total_funds_locked: i128) -> u32 {
+    if total_funds_locked == 0 {
+        BPS_SCALE
+    } else {
+        let rate = total_funds_distributed
+            .saturating_mul(BPS_SCALE as i128)
+            .saturating_div(total_funds_locked);
+        (rate.min(BPS_SCALE as i128)) as u32
+    }
+}
+
+/// Weighted overall reputation score; any overdue schedule forces zero.
+pub fn overall_score_bps(
+    completion_rate_bps: u32,
+    payout_fulfillment_rate_bps: u32,
+    overdue_releases: u32,
+) -> u32 {
+    if overdue_releases > 0 {
+        0
+    } else {
+        let weighted = (completion_rate_bps as u64)
+            .saturating_mul(COMPLETION_WEIGHT_PERCENT)
+            .saturating_add(
+                (payout_fulfillment_rate_bps as u64).saturating_mul(PAYOUT_FULFILLMENT_WEIGHT_PERCENT),
+            )
+            .saturating_div(100);
+        (weighted.min(BPS_SCALE as u64)) as u32
+    }
+}
+
+/// Pure benchmark helper: overall scores after `payout_count` dust vs typical payouts
+/// against the same locked pool (`payout_count * typical_amount`).
+pub fn benchmark_overall_scores_dust_vs_typical(payout_count: u32) -> (u32, u32) {
+    let locked = (payout_count as i128).saturating_mul(REPUTATION_TYPICAL_PAYOUT_AMOUNT);
+    let dust_distributed = (payout_count as i128).saturating_mul(REPUTATION_DUST_PAYOUT_AMOUNT);
+    let typical_distributed = locked;
+
+    let dust_fulfillment = payout_fulfillment_rate_bps(dust_distributed, locked);
+    let typical_fulfillment = payout_fulfillment_rate_bps(typical_distributed, locked);
+
+    let dust_overall = overall_score_bps(BPS_SCALE, dust_fulfillment, 0);
+    let typical_overall = overall_score_bps(BPS_SCALE, typical_fulfillment, 0);
+    (dust_overall, typical_overall)
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn qualified_payout_count_ignores_dust() {
+        let amounts = [1i128, 2, 999, 1_000, 10_000];
+        assert_eq!(count_qualified_payouts(amounts.into_iter()), 2);
+    }
+
+    #[test]
+    fn benchmark_favors_typical_over_dust() {
+        let (dust, typical) = benchmark_overall_scores_dust_vs_typical(50);
+        assert!(typical > dust);
+        assert!(dust < 7_000);
+        assert_eq!(typical, BPS_SCALE);
+    }
+}

--- a/contracts/program-escrow/src/test_reputation.rs
+++ b/contracts/program-escrow/src/test_reputation.rs
@@ -1,5 +1,9 @@
 #![cfg(test)]
 
+use super::reputation::{
+    benchmark_overall_scores_dust_vs_typical, REPUTATION_DUST_PAYOUT_AMOUNT,
+    REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT, REPUTATION_TYPICAL_PAYOUT_AMOUNT,
+};
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -58,6 +62,7 @@ fn test_reputation_fresh_program() {
 
     let rep = client.get_program_reputation();
     assert_eq!(rep.total_payouts, 0);
+    assert_eq!(rep.qualified_payout_count, 0);
     assert_eq!(rep.total_scheduled, 0);
     assert_eq!(rep.completed_releases, 0);
     assert_eq!(rep.pending_releases, 0);
@@ -79,6 +84,7 @@ fn test_reputation_funded_no_payouts() {
     let rep = client.get_program_reputation();
     assert_eq!(rep.total_funds_locked, 500_000);
     assert_eq!(rep.total_funds_distributed, 0);
+    assert_eq!(rep.qualified_payout_count, 0);
     assert_eq!(rep.payout_fulfillment_rate_bps, 0);
     assert_eq!(rep.completion_rate_bps, 10_000);
 }
@@ -90,10 +96,14 @@ fn test_reputation_after_payouts() {
 
     let r1 = Address::generate(&env);
     let r2 = Address::generate(&env);
-    client.batch_payout(&vec![&env, r1.clone(), r2.clone()], &vec![&env, 30_000, 20_000]);
+    client.batch_payout(
+        &vec![&env, r1.clone(), r2.clone()],
+        &vec![&env, 30_000, 20_000],
+    );
 
     let rep = client.get_program_reputation();
     assert_eq!(rep.total_payouts, 2);
+    assert_eq!(rep.qualified_payout_count, 2);
     assert_eq!(rep.total_funds_locked, 100_000);
     assert_eq!(rep.total_funds_distributed, 50_000);
     assert_eq!(rep.payout_fulfillment_rate_bps, 5_000);
@@ -107,10 +117,11 @@ fn test_reputation_full_distribution() {
     let (client, _, _, _, _) = setup_active_program(&env, 100_000);
 
     let r1 = Address::generate(&env);
-    client.single_payout(&r1, &100_000);
+    client.single_payout(&r1, &100_000, &None);
 
     let rep = client.get_program_reputation();
     assert_eq!(rep.total_payouts, 1);
+    assert_eq!(rep.qualified_payout_count, 1);
     assert_eq!(rep.total_funds_distributed, 100_000);
     assert_eq!(rep.payout_fulfillment_rate_bps, 10_000);
     assert_eq!(rep.overall_score_bps, 10_000);
@@ -125,7 +136,6 @@ fn test_reputation_with_schedules() {
     let r2 = Address::generate(&env);
     let r3 = Address::generate(&env);
 
-    // Create 3 schedules: two due now, one in the future
     env.ledger().set_timestamp(1000);
     client.create_program_release_schedule(&r1, &100_000, &500);
     client.create_program_release_schedule(&r2, &100_000, &800);
@@ -135,19 +145,17 @@ fn test_reputation_with_schedules() {
     assert_eq!(rep.total_scheduled, 3);
     assert_eq!(rep.completed_releases, 0);
     assert_eq!(rep.pending_releases, 3);
-    assert_eq!(rep.overdue_releases, 2); // two are past due (500, 800 < 1000)
+    assert_eq!(rep.overdue_releases, 2);
     assert_eq!(rep.completion_rate_bps, 0);
 
-    // Trigger releases for the two due schedules
     client.trigger_program_releases();
 
     let rep = client.get_program_reputation();
     assert_eq!(rep.completed_releases, 2);
     assert_eq!(rep.pending_releases, 1);
-    assert_eq!(rep.overdue_releases, 0); // the remaining one is future
-    assert_eq!(rep.completion_rate_bps, 6_666); // 2/3
+    assert_eq!(rep.overdue_releases, 0);
+    assert_eq!(rep.completion_rate_bps, 6_666);
 
-    // Advance time and trigger the last one
     env.ledger().set_timestamp(2500);
     client.trigger_program_releases();
 
@@ -165,25 +173,23 @@ fn test_reputation_mixed_payouts_and_schedules() {
     let env = Env::default();
     let (client, _, _, _, _) = setup_active_program(&env, 500_000);
 
-    // Direct payout
     let r1 = Address::generate(&env);
-    client.single_payout(&r1, &200_000);
+    client.single_payout(&r1, &200_000, &None);
 
-    // Schedule a release
     let r2 = Address::generate(&env);
     env.ledger().set_timestamp(100);
     client.create_program_release_schedule(&r2, &100_000, &50);
 
-    // Trigger the due schedule
     client.trigger_program_releases();
 
     let rep = client.get_program_reputation();
-    assert_eq!(rep.total_payouts, 2); // 1 direct + 1 from schedule trigger
+    assert_eq!(rep.total_payouts, 2);
+    assert_eq!(rep.qualified_payout_count, 2);
     assert_eq!(rep.total_scheduled, 1);
     assert_eq!(rep.completed_releases, 1);
     assert_eq!(rep.total_funds_distributed, 300_000);
     assert_eq!(rep.completion_rate_bps, 10_000);
-    assert_eq!(rep.payout_fulfillment_rate_bps, 6_000); // 300k/500k
+    assert_eq!(rep.payout_fulfillment_rate_bps, 6_000);
 }
 
 #[test]
@@ -198,10 +204,96 @@ fn test_reputation_overdue_schedules() {
     client.create_program_release_schedule(&r1, &100_000, &500);
     client.create_program_release_schedule(&r2, &100_000, &800);
 
-    // Both are overdue (timestamps 500, 800 are before now=1000)
     let rep = client.get_program_reputation();
     assert_eq!(rep.overdue_releases, 2);
     assert_eq!(rep.completion_rate_bps, 0);
-    // overall = (0 * 60 + 0 * 40) / 100 = 0
     assert_eq!(rep.overall_score_bps, 0);
+}
+
+/// Many minimum-size payouts increase raw history length but not qualifying activity.
+#[test]
+fn test_reputation_dust_payouts_gaming_resistance() {
+    let env = Env::default();
+    const DUST_COUNT: u32 = 40;
+    let locked = (DUST_COUNT as i128).saturating_mul(REPUTATION_TYPICAL_PAYOUT_AMOUNT);
+    let (client, _, _, _, _) = setup_active_program(&env, locked);
+
+    let recipient = Address::generate(&env);
+    for _ in 0..DUST_COUNT {
+        client.single_payout(&recipient, &REPUTATION_DUST_PAYOUT_AMOUNT, &None);
+    }
+
+    let rep = client.get_program_reputation();
+    assert_eq!(rep.total_payouts, DUST_COUNT);
+    assert_eq!(rep.qualified_payout_count, 0);
+    assert_eq!(
+        rep.total_funds_distributed,
+        (DUST_COUNT as i128).saturating_mul(REPUTATION_DUST_PAYOUT_AMOUNT)
+    );
+    assert!(
+        rep.payout_fulfillment_rate_bps < 100,
+        "dust fulfillment should stay far below 1% of locked pool"
+    );
+    assert!(
+        rep.overall_score_bps < 7_000,
+        "overall score must remain low despite high payout count"
+    );
+}
+
+/// Same locked pool: N typical payouts should reach a much higher score than N dust payouts.
+#[test]
+fn test_reputation_benchmark_dust_vs_typical_on_chain() {
+    let env = Env::default();
+    const N: u32 = 25;
+    let locked = (N as i128).saturating_mul(REPUTATION_TYPICAL_PAYOUT_AMOUNT);
+
+    let (dust_client, _, _, _, _) = setup_active_program(&env, locked);
+    let dust_recipient = Address::generate(&env);
+    for _ in 0..N {
+        dust_client.single_payout(&dust_recipient, &REPUTATION_DUST_PAYOUT_AMOUNT, &None);
+    }
+    let dust_rep = dust_client.get_program_reputation();
+
+    let env_typical = Env::default();
+    let (typical_client, _, _, _, _) = setup_active_program(&env_typical, locked);
+    let typical_recipient = Address::generate(&env_typical);
+    for _ in 0..N {
+        typical_client.single_payout(
+            &typical_recipient,
+            &REPUTATION_TYPICAL_PAYOUT_AMOUNT,
+            &None,
+        );
+    }
+    let typical_rep = typical_client.get_program_reputation();
+
+    let (pure_dust, pure_typical) = benchmark_overall_scores_dust_vs_typical(N);
+    assert_eq!(dust_rep.overall_score_bps, pure_dust);
+    assert_eq!(typical_rep.overall_score_bps, pure_typical);
+    assert!(typical_rep.overall_score_bps > dust_rep.overall_score_bps);
+    assert_eq!(typical_rep.payout_fulfillment_rate_bps, 10_000);
+    assert_eq!(typical_rep.qualified_payout_count, N);
+    assert_eq!(dust_rep.qualified_payout_count, 0);
+}
+
+#[test]
+fn test_reputation_qualifying_threshold_boundary() {
+    let env = Env::default();
+    let (client, _, _, _, _) = setup_active_program(&env, 50_000);
+
+    let below = Address::generate(&env);
+    let at_floor = Address::generate(&env);
+    client.single_payout(
+        &below,
+        &(REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT - 1),
+        &None,
+    );
+    client.single_payout(
+        &at_floor,
+        &REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT,
+        &None,
+    );
+
+    let rep = client.get_program_reputation();
+    assert_eq!(rep.total_payouts, 2);
+    assert_eq!(rep.qualified_payout_count, 1);
 }

--- a/docs/program-escrow-reputation-gaming.md
+++ b/docs/program-escrow-reputation-gaming.md
@@ -1,0 +1,57 @@
+# Program escrow reputation and dust-payout gaming
+
+This document describes how `get_program_reputation` behaves under dust-sized payout spam and which fields integrators should trust for “program health” signals.
+
+## Formula (on-chain)
+
+`get_program_reputation` reads the active program’s schedules and `payout_history`. Derived fields:
+
+| Field | Meaning | Dust spam effect |
+| --- | --- | --- |
+| `total_payouts` | Length of `payout_history` | Increases one per call (informational only) |
+| `qualified_payout_count` | Payouts with `amount >= REPUTATION_MIN_QUALIFYING_PAYOUT_AMOUNT` (1_000 base units) | Unaffected by 1-unit dust |
+| `total_funds_distributed` | Sum of payout amounts | Grows linearly with dust total, not per-call |
+| `payout_fulfillment_rate_bps` | `(distributed / locked) * 10_000` | Stays near zero unless meaningful value moves |
+| `completion_rate_bps` | Released schedules / total schedules | Independent of payout count |
+| `overall_score_bps` | `0` if any overdue schedule; else `60% * completion + 40% fulfillment` | **Value-weighted**, not operation-count-based |
+
+Constants are defined in `contracts/program-escrow/src/reputation.rs` and re-exported from the contract crate root.
+
+## Threat model
+
+**Attack:** A program locks a large prize pool and repeatedly calls `single_payout` with the minimum allowed amount (1 base unit) to cooperating addresses, inflating visible activity cheaply.
+
+**Impact on score:** Because `overall_score_bps` weights **fulfillment by value**, dust leaves almost all funds locked and keeps fulfillment (and thus overall score) low. Spamming calls does not bypass the locked-pool denominator.
+
+**Residual limitation:** Off-chain dashboards that rank programs by `total_payouts` alone remain gameable. Prefer `qualified_payout_count`, `total_funds_distributed`, or `overall_score_bps`.
+
+## Resistance properties
+
+1. **Value-primary scoring** — `overall_score_bps` does not use raw payout count.
+2. **Qualifying activity floor** — `qualified_payout_count` excludes payouts below 1_000 base units.
+3. **Overdue penalty** — Any overdue release forces `overall_score_bps = 0` regardless of payout activity.
+
+## Benchmark (N = 25, typical payout = 10_000)
+
+Locked pool: `N * 10_000`. Compare:
+
+- **Dust path:** `N` payouts of `1` → fulfillment ≈ `N / (N * 10_000) * 10_000` ≈ **1 bps** → overall ≈ **6_000 bps** (perfect schedules assumed).
+- **Typical path:** `N` payouts of `10_000` → full distribution → fulfillment **10_000 bps** → overall **10_000 bps**.
+
+The pure helper `reputation::benchmark_overall_scores_dust_vs_typical` mirrors this math; `test_reputation_benchmark_dust_vs_typical_on_chain` asserts the contract matches the helper.
+
+## Security notes
+
+- Dust gaming does not drain escrow faster than the summed dust amounts; economic cost is still bounded by locked liquidity and authorization on `single_payout`.
+- Reputation is a **snapshot** of on-chain history, not proof of off-chain deliverables.
+- Future changes to weights or qualifying thresholds must remain backward-compatible for indexers documenting field semantics.
+
+## Tests
+
+Run:
+
+```bash
+cargo test -p program-escrow test_reputation
+```
+
+Key cases: `test_reputation_dust_payouts_gaming_resistance`, `test_reputation_benchmark_dust_vs_typical_on_chain`, `test_reputation_qualifying_threshold_boundary`.


### PR DESCRIPTION
Closes #1469

## Summary
- Add dust-payout reputation-gaming resistance tests for the program-escrow reputation module

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths