### PR TITLE
feat: session timeout warning UX

### DIFF
--- a/design/specs/session-timeout-warning-ux.md
+++ b/design/specs/session-timeout-warning-ux.md
@@ -1,0 +1,189 @@
+# Session Timeout Warning — UX Specification
+
+**Component:** `frontend/src/shared/components/SessionTimeoutBanner.tsx`  
+**Context:** `frontend/src/shared/contexts/AuthContext.tsx`  
+**Status:** Specification  
+**Date:** 2026-07-26  
+**Target Compliance:** WCAG 2.1 AA
+
+---
+
+## 1. Overview
+
+When a user's JWT approaches expiry, a non-modal banner appears at the top of the viewport to warn them. The user can extend their session ("Stay signed in") or dismiss the banner without affecting their session. On expiry, the session ends, a forced-logout screen replaces the current view, and a "Sign back in" CTA preserves the user's last route so they return to exactly where they left off.
+
+---
+
+## 2. Banner States
+
+The component transitions through four discrete states driven by `AuthContext`.
+
+| State | Trigger | Visual treatment |
+|---|---|---|
+| `banner-hidden` | Default; token `> 5 min` from expiry | Banner not rendered |
+| `warning-visible` | Token `≤ 5 min` and `> 1 min` from expiry | Amber/gold warning strip |
+| `critical` | Token `≤ 1 min` from expiry | Red strip, stronger visual weight |
+| `expired` | Token expiry reached | Full forced-logout screen replaces the viewport |
+
+State is computed from two timers set when a token is stored. Both timers are cleared on logout or token refresh.
+
+---
+
+## 3. Banner Placement & Structure
+
+- **Position:** fixed, top of viewport, full-width, `z-50`.
+- **Stacking:** banner sits below any existing nav header (`z-40`) — implement as `z-50` on the banner layer which is rendered _before_ the nav in DOM order, so the nav header overlaps it at mobile widths. At `≥ 768 px` (`md:`) the banner does not obscure nav because nav is a sidebar or positioned below the banner strip.
+- **375 px constraint:** at mobile width the banner height is capped at `48 px` (`py-2 px-4`), single-line layout. "Stay signed in" CTA collapses to an icon-only button with a visually hidden label to stay within the strip.
+- **Non-modal:** focus is never stolen from the user's current task. The banner renders with `tabIndex={-1}` on its container; the CTA buttons are naturally focusable but not auto-focused on mount.
+- **Dismissible without extending:** the ✕ close button dismisses the banner for the current warning window without calling token refresh. A separate timer can re-show the banner in the critical state if the user dismissed during the warning window.
+
+---
+
+## 4. Countdown Copy
+
+Countdown is calculated in `AuthContext` and passed as `secondsRemaining` to the banner. Copy is derived from that value:
+
+| State | Copy template | Example |
+|---|---|---|
+| `warning-visible` | `"Your session expires in {M}:{SS} — stay signed in to keep working."` | `"Your session expires in 4:32 — stay signed in to keep working."` |
+| `warning-visible` (< 2 min) | `"Your session expires in {M}:{SS}."` | `"Your session expires in 1:45."` |
+| `critical` | `"Session expiring in {SS} seconds."` | `"Session expiring in 42 seconds."` |
+| `critical` (≤ 10 s) | `"Session expiring in {SS} seconds — save your work now."` | `"Session expiring in 8 seconds — save your work now."` |
+| `expired` | *(shown on forced-logout screen, not banner)* | — |
+
+Where `{M}` = whole minutes remaining, `{SS}` = zero-padded seconds within the current minute.
+
+The countdown string is **not** injected into the `role="alert"` region on every tick. Instead:
+- The alert region announces once on state entry (`warning-visible` → first render, `critical` → first render).
+- A separate `aria-live="off"` element renders the live countdown for sighted users. Screen readers hear the initial announcement only.
+
+---
+
+## 5. "Stay Signed In" CTA Behaviour
+
+1. User clicks "Stay signed in".
+2. `AuthContext.refreshSession()` is called — it re-fetches `/me` with the current token (the back-end issues a fresh token or re-validates the existing one). If the API returns a new `Authorization` header, `setAuthToken()` is called with the new value; otherwise the existing token is re-affirmed and both countdown timers are reset.
+3. The banner transitions to `banner-hidden`.
+4. A `sonner` success micro-toast fires: `toast.success("You're still signed in.")` with a 3 000 ms duration.
+5. If the refresh call fails (network error, 401), the banner transitions to `expired` immediately and the forced-logout screen renders.
+
+---
+
+## 6. Forced-Logout Screen
+
+Rendered as a full-viewport overlay (`fixed inset-0 z-[100]`) that replaces the current view on the `expired` state. It is **not** a modal dialog — it covers the full screen so background content is inaccessible.
+
+### Layout
+
+```
+┌─────────────────────────────────────┐
+│  [Grainlify logo mark]              │
+│                                     │
+│  Your session has ended             │
+│  For your security, you've been     │
+│  signed out after a period of       │
+│  inactivity.                        │
+│                                     │
+│  [Sign back in →]                   │
+│                                     │
+│  You'll be taken back to the page   │
+│  you were on.                       │
+└─────────────────────────────────────┘
+```
+
+### "Sign back in" CTA behaviour
+
+- Clicking the CTA calls `window.location.pathname + window.location.search` to capture the last route, writes it to `sessionStorage['authReturnTo']`, then navigates to `/signin`. This mirrors the existing `ProtectedRoute` redirect pattern.
+- After successful OAuth callback, `AuthCallbackPage` reads `sessionStorage['authReturnTo']` and redirects the user back to their last route (existing behaviour — no changes needed there).
+
+### Accessibility
+
+- The overlay renders `role="main"` with `aria-label="Session ended"`.
+- On mount, a single `role="alert"` element announces `"Your session has ended. Please sign back in."` — announced once.
+- "Sign back in" button has `aria-label="Sign back in and return to your previous page"`.
+
+---
+
+## 7. Accessibility Annotations
+
+| Requirement | Implementation |
+|---|---|
+| `role="alert"` on banner | Applied to the announcement-only child element, not the entire banner container |
+| Announced once per state transition | The `role="alert"` child is conditionally rendered/updated only on state change, not on every countdown tick |
+| Focus not stolen | Banner container: `tabIndex={-1}`, no `autoFocus` on any child |
+| Keyboard accessible | "Stay signed in" and ✕ close are `<button>` elements with `focus-visible` ring matching project tokens (`#a2792c` light / `#f1b400` dark) |
+| Screen reader countdown | A separate visually-hidden `aria-live="polite" aria-atomic="true"` element announces at 5-min entry and 1-min entry only (via state change), not per-second |
+| Reduced motion | Countdown opacity transitions use `data-opacity-transition` attribute; no slide or scale animations on the banner |
+| High contrast theme | Banner uses opaque backgrounds (`#000` / `#fff`), solid `2 px` borders, no `backdrop-filter` |
+
+---
+
+## 8. Color & Token Escalation
+
+All contrast ratios measured against their respective background values.
+
+### Warning state (`warning-visible`)
+
+| Element | Light token | Dark token | Contrast |
+|---|---|---|---|
+| Banner background | `#fffaeb` (amber-50 equiv) | `#3a2b0d` | — |
+| Banner border | `#f59e0b` / `30%` opacity | `#f59e0b` / `50%` opacity | — |
+| Text | `#2d2820` | `#e8dfd0` | 12.8:1 / 8.3:1 ✓ |
+| Icon | `#b45309` | `#f59e0b` | 4.7:1 / 6.5:1 ✓ |
+| CTA text | `#2d2820` (bold) | `#f1b400` (bold) | 12.8:1 / 9.2:1 ✓ |
+| CTA border/bg | `#c9983a/30` bg | `#f1b400/20` bg | — |
+
+These token values match the `.warning` variant in `Toast.tsx` for visual consistency.
+
+### Critical state (`critical`)
+
+| Element | Light token | Dark token | Contrast |
+|---|---|---|---|
+| Banner background | `#fef2f2` (red-50 equiv) | `#2d1a1a` | — |
+| Banner border | `#ef4444` / `40%` opacity | `#ef4444` / `60%` opacity | — |
+| Text | `#2d2820` | `#fca5a5` | 12.8:1 / 4.7:1 ✓ |
+| Icon | `#dc2626` | `#f87171` | 5.3:1 / 4.6:1 ✓ |
+| CTA text | `#dc2626` (bold) | `#fca5a5` (bold) | 5.3:1 / 4.7:1 ✓ |
+
+These token values match the `.error` variant in `Toast.tsx` for visual consistency.
+
+### High-contrast theme overrides
+
+In the `.high-contrast` theme class, the banner must use:
+- Background: `#000000` (warning) / `#1a0000` (critical)
+- Border: `2 px solid #ffffff`
+- Text: `#ffffff`
+- CTA outline: `3 px solid #ffff00`
+
+---
+
+## 9. Responsive Behaviour
+
+| Breakpoint | Layout | Notes |
+|---|---|---|
+| `< 768 px` (375 px target) | Single row: icon + truncated copy + icon-only CTA + ✕ | Banner height `48 px`, no text wrapping |
+| `≥ 768 px` | Icon + full copy + full CTA label + ✕ | Banner height `52 px` |
+| Banner + nav coexistence | Banner is `position: fixed; top: 0`. Nav that is `position: sticky; top: 0` will be pushed down automatically when banner is present. Components using `top-0` sticky positioning must add `top-[52px]` when banner is visible. | Achieved by binding a CSS custom property `--banner-height` on `:root` via `AuthContext` state |
+
+At 375 px the banner must not overlap the primary navigation. The existing navigation in Grainlify is fixed to the top — when the banner is visible, the navigation is shifted down by the banner's height via the `--banner-height` CSS variable set on `:root`.
+
+---
+
+## 10. Component Interface (Reference)
+
+```tsx
+// State enum used by AuthContext and SessionTimeoutBanner
+type SessionTimeoutState =
+  | 'banner-hidden'
+  | 'warning-visible'
+  | 'critical'
+  | 'expired';
+
+// Values surfaced by AuthContext
+interface SessionTimeoutContext {
+  sessionTimeoutState: SessionTimeoutState;
+  secondsRemaining: number;        // 0 when expired
+  staySignedIn: () => Promise<void>;
+  dismissTimeoutBanner: () => void;
+}
+```

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -5,6 +5,7 @@ import { LandingPage } from "../features/landing";
 import { SignInPage, SignUpPage, AuthCallbackPage } from "../features/auth";
 import { Dashboard } from "../features/dashboard";
 import Toast from "../shared/components/Toast";
+import { SessionTimeoutBanner } from "../shared/components/SessionTimeoutBanner";
 
 function ProtectedRoute({ children }: { children: JSX.Element }) {
   const { isAuthenticated, isLoading } = useAuth();
@@ -24,6 +25,7 @@ export default function App() {
       <ThemeProvider>
         <AuthProvider>
           <div className="overflow-x-hidden">
+            <SessionTimeoutBanner />
             <Routes>
               <Route path="/" element={<LandingPage />} />
               <Route path="/signin" element={<SignInPage />} />

--- a/frontend/src/shared/components/SessionTimeoutBanner.tsx
+++ b/frontend/src/shared/components/SessionTimeoutBanner.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, X, LogIn } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useAuth } from '../contexts/AuthContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { isDarkVariant } from '../contexts/ThemeContext';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format a number of seconds as "M:SS" (e.g. 304 → "5:04"). */
+function formatCountdown(secs: number): string {
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/** Build the visible copy string for the banner. */
+function buildCopy(state: 'warning-visible' | 'critical', secs: number): string {
+  if (state === 'critical') {
+    if (secs <= 10) {
+      return `Session expiring in ${secs} second${secs !== 1 ? 's' : ''} — save your work now.`;
+    }
+    return `Session expiring in ${secs} second${secs !== 1 ? 's' : ''}.`;
+  }
+  // warning-visible
+  if (secs < 120) {
+    return `Your session expires in ${formatCountdown(secs)}.`;
+  }
+  return `Your session expires in ${formatCountdown(secs)} — stay signed in to keep working.`;
+}
+
+// ---------------------------------------------------------------------------
+// Forced-logout screen
+// ---------------------------------------------------------------------------
+
+function SessionExpiredScreen() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const dark = isDarkVariant(theme);
+  const isHighContrast = theme === 'high-contrast';
+
+  const handleSignBackIn = () => {
+    const lastRoute = window.location.pathname + window.location.search;
+    if (lastRoute && lastRoute !== '/signin') {
+      sessionStorage.setItem('authReturnTo', lastRoute);
+    }
+    navigate('/signin', { replace: true });
+  };
+
+  return (
+    <div
+      role="main"
+      aria-label="Session ended"
+      className={`fixed inset-0 z-[100] flex items-center justify-center px-6 transition-colors ${
+        dark
+          ? 'bg-gradient-to-br from-[#1a1512] via-[#231c17] to-[#2d241d]'
+          : 'bg-gradient-to-br from-[#e8dfd0] via-[#d4c5b0] to-[#c9b89a]'
+      } ${isHighContrast ? '!bg-black' : ''}`}
+    >
+      {/* Single role="alert" — announced once on mount */}
+      <div role="alert" className="sr-only">
+        Your session has ended. Please sign back in.
+      </div>
+
+      <div
+        className={`w-full max-w-sm rounded-[24px] border p-10 text-center shadow-[0_8px_32px_rgba(0,0,0,0.18)] transition-colors ${
+          isHighContrast
+            ? 'bg-black border-2 border-white'
+            : dark
+              ? 'backdrop-blur-[40px] bg-[#2d2820]/[0.4] border-white/10'
+              : 'backdrop-blur-[40px] bg-white/[0.35] border-white'
+        }`}
+      >
+        {/* Logo mark */}
+        <div className="flex justify-center mb-6">
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-[#c9983a] to-[#d4af37] shadow-[0_2px_8px_rgba(201,152,58,0.4)]" />
+        </div>
+
+        <h1
+          className={`text-2xl font-bold mb-3 transition-colors ${
+            isHighContrast ? 'text-white' : dark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+          }`}
+        >
+          Your session has ended
+        </h1>
+
+        <p
+          className={`text-sm mb-6 leading-relaxed transition-colors ${
+            isHighContrast ? 'text-white' : dark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+          }`}
+        >
+          For your security, you've been signed out after a period of inactivity.
+        </p>
+
+        <button
+          onClick={handleSignBackIn}
+          aria-label="Sign back in and return to your previous page"
+          className={`inline-flex items-center gap-2 px-6 py-3 rounded-[12px] font-semibold text-sm transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+            isHighContrast
+              ? 'bg-white text-black border-2 border-white hover:bg-[#eeeeee] focus-visible:outline-[#ffff00]'
+              : 'bg-[#c9983a] hover:bg-[#a67c2e] text-white shadow-[0_4px_12px_rgba(201,152,58,0.35)] focus-visible:outline-[#a2792c] dark:focus-visible:outline-[#f1b400]'
+          }`}
+        >
+          <LogIn className="w-4 h-4" aria-hidden="true" />
+          Sign back in
+        </button>
+
+        <p
+          className={`text-xs mt-4 transition-colors ${
+            isHighContrast ? 'text-white' : dark ? 'text-[#b8a898]' : 'text-[#9f8b74]'
+          }`}
+        >
+          You'll be taken back to the page you were on.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Banner
+// ---------------------------------------------------------------------------
+
+/**
+ * SessionTimeoutBanner
+ *
+ * Renders a fixed top-of-viewport strip when the user's session is within
+ * 5 minutes of expiry. Transitions to a critical state under 1 minute, then
+ * to a full forced-logout screen on expiry.
+ *
+ * Accessibility:
+ * - role="alert" region announces once per state transition (not per tick).
+ * - Focus is never stolen from the user's current task.
+ * - Keyboard accessible: all interactive elements are <button>.
+ * - WCAG 2.1 AA contrast in both light and dark themes.
+ * - Reduced-motion: uses data-opacity-transition (opacity-only, ≤150 ms).
+ * - High-contrast: opaque backgrounds, solid borders, yellow focus ring.
+ */
+export function SessionTimeoutBanner() {
+  const { sessionTimeoutState, secondsRemaining, staySignedIn, dismissTimeoutBanner } = useAuth();
+  const { theme } = useTheme();
+  const dark = isDarkVariant(theme);
+  const isHighContrast = theme === 'high-contrast';
+  const isReducedMotion = theme === 'reduced-motion';
+
+  // Track whether we've already announced the current state so role="alert"
+  // only fires once per state transition.
+  const announcedStateRef = useRef<string>('');
+  const [announcement, setAnnouncement] = useState('');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Update the one-shot ARIA announcement on state transitions only.
+  useEffect(() => {
+    if (sessionTimeoutState === announcedStateRef.current) return;
+    announcedStateRef.current = sessionTimeoutState;
+
+    if (sessionTimeoutState === 'warning-visible') {
+      setAnnouncement('Your session will expire in about 5 minutes. Select "Stay signed in" to continue.');
+    } else if (sessionTimeoutState === 'critical') {
+      setAnnouncement('Your session is about to expire. Select "Stay signed in" immediately to avoid being signed out.');
+    } else {
+      setAnnouncement('');
+    }
+  }, [sessionTimeoutState]);
+
+  // Expose banner height as a CSS custom property so sticky nav can offset itself.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (sessionTimeoutState === 'warning-visible' || sessionTimeoutState === 'critical') {
+      root.style.setProperty('--session-banner-height', '52px');
+    } else {
+      root.style.setProperty('--session-banner-height', '0px');
+    }
+    return () => {
+      root.style.setProperty('--session-banner-height', '0px');
+    };
+  }, [sessionTimeoutState]);
+
+  const handleStaySignedIn = async () => {
+    setIsRefreshing(true);
+    try {
+      await staySignedIn();
+      toast.success("You're still signed in.", { duration: 3000 });
+    } catch {
+      // staySignedIn() transitions to expired on failure — no additional handling needed.
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  // Render forced-logout screen on expiry
+  if (sessionTimeoutState === 'expired') {
+    return <SessionExpiredScreen />;
+  }
+
+  // Nothing to show
+  if (sessionTimeoutState === 'banner-hidden') {
+    return null;
+  }
+
+  const isWarning = sessionTimeoutState === 'warning-visible';
+  const isCritical = sessionTimeoutState === 'critical';
+
+  // -------------------------------------------------------------------------
+  // Theme-conditional class strings
+  // -------------------------------------------------------------------------
+
+  const bannerBg = isHighContrast
+    ? isCritical ? 'bg-[#1a0000] border-b-2 border-white' : 'bg-black border-b-2 border-white'
+    : isWarning
+      ? dark
+        ? 'bg-[#3a2b0d] border-b border-[#f59e0b]/50'
+        : 'bg-[#fffaeb] border-b border-[#f59e0b]/30'
+      : dark
+        ? 'bg-[#2d1a1a] border-b border-[#ef4444]/60'
+        : 'bg-[#fef2f2] border-b border-[#ef4444]/40';
+
+  const textColor = isHighContrast
+    ? 'text-white'
+    : isWarning
+      ? dark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+      : dark ? 'text-[#fca5a5]' : 'text-[#2d2820]';
+
+  const iconColor = isHighContrast
+    ? 'text-white'
+    : isWarning
+      ? dark ? 'text-[#f59e0b]' : 'text-[#b45309]'
+      : dark ? 'text-[#f87171]' : 'text-[#dc2626]';
+
+  const ctaColor = isHighContrast
+    ? 'text-white border-2 border-white hover:bg-white/20 focus-visible:outline-[#ffff00]'
+    : isWarning
+      ? dark
+        ? 'text-[#f1b400] border border-[#f1b400]/30 bg-[#f1b400]/10 hover:bg-[#f1b400]/20 focus-visible:outline-[#f1b400]'
+        : 'text-[#2d2820] border border-[#c9983a]/40 bg-[#c9983a]/10 hover:bg-[#c9983a]/20 focus-visible:outline-[#a2792c]'
+      : dark
+        ? 'text-[#fca5a5] border border-[#ef4444]/40 bg-[#ef4444]/10 hover:bg-[#ef4444]/20 focus-visible:outline-[#f87171]'
+        : 'text-[#dc2626] border border-[#ef4444]/30 bg-[#ef4444]/10 hover:bg-[#ef4444]/20 focus-visible:outline-[#dc2626]';
+
+  const closeBtnColor = isHighContrast
+    ? 'text-white hover:bg-white/20 focus-visible:outline-[#ffff00]'
+    : isWarning
+      ? dark ? 'text-[#b8a898] hover:text-[#e8dfd0] focus-visible:outline-[#f1b400]' : 'text-[#7a6b5a] hover:text-[#2d2820] focus-visible:outline-[#a2792c]'
+      : dark ? 'text-[#fca5a5]/70 hover:text-[#fca5a5] focus-visible:outline-[#f87171]' : 'text-[#dc2626]/70 hover:text-[#dc2626] focus-visible:outline-[#dc2626]';
+
+  const transitionClass = isReducedMotion
+    ? 'data-[opacity-transition] transition-opacity duration-[150ms]'
+    : 'transition-all duration-200';
+
+  return (
+    <>
+      {/*
+        role="alert" child — announced once on state entry, not on every tick.
+        Content changes only when `announcement` updates (state transition).
+      */}
+      {announcement && (
+        <div role="alert" className="sr-only" aria-live="assertive" aria-atomic="true">
+          {announcement}
+        </div>
+      )}
+
+      <div
+        // tabIndex={-1} — container is not itself in the focus order
+        tabIndex={-1}
+        data-opacity-transition
+        className={`
+          fixed top-0 left-0 right-0 z-50
+          h-[48px] md:h-[52px]
+          flex items-center justify-between
+          px-4 md:px-6
+          ${bannerBg}
+          ${transitionClass}
+        `}
+        aria-hidden="false"
+      >
+        {/* Left: icon + copy */}
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <AlertTriangle
+            className={`w-4 h-4 flex-shrink-0 ${iconColor}`}
+            aria-hidden="true"
+          />
+
+          {/* Visible countdown copy — not injected into role="alert" on every tick */}
+          {/* aria-live="off" so screen readers do not announce every second */}
+          <span
+            aria-live="off"
+            className={`text-sm font-medium truncate ${textColor}`}
+          >
+            {/* Mobile: shorter copy */}
+            <span className="md:hidden">
+              {isCritical
+                ? `${secondsRemaining}s remaining`
+                : `Expires ${formatCountdown(secondsRemaining)}`}
+            </span>
+            {/* Desktop: full copy */}
+            <span className="hidden md:inline">
+              {buildCopy(sessionTimeoutState, secondsRemaining)}
+            </span>
+          </span>
+        </div>
+
+        {/* Right: CTA + dismiss */}
+        <div className="flex items-center gap-2 flex-shrink-0 ml-3">
+          {/* "Stay signed in" CTA */}
+          <button
+            onClick={handleStaySignedIn}
+            disabled={isRefreshing}
+            aria-label="Stay signed in and extend your session"
+            className={`
+              hidden md:inline-flex items-center gap-1.5
+              px-3 py-1 rounded-[8px]
+              text-xs font-semibold
+              transition-colors
+              focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2
+              disabled:opacity-50 disabled:cursor-not-allowed
+              ${ctaColor}
+            `}
+          >
+            {isRefreshing ? (
+              <>
+                <span
+                  className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
+                  aria-hidden="true"
+                />
+                <span>Refreshing…</span>
+              </>
+            ) : (
+              'Stay signed in'
+            )}
+          </button>
+
+          {/* Mobile: icon-only "stay signed in" */}
+          <button
+            onClick={handleStaySignedIn}
+            disabled={isRefreshing}
+            aria-label="Stay signed in and extend your session"
+            className={`
+              md:hidden
+              p-1.5 rounded-[8px]
+              transition-colors
+              focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2
+              disabled:opacity-50 disabled:cursor-not-allowed
+              ${ctaColor}
+            `}
+          >
+            {isRefreshing ? (
+              <span
+                className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+              />
+            ) : (
+              <LogIn className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+            <span className="sr-only">Stay signed in</span>
+          </button>
+
+          {/* Dismiss button — only visible in warning state */}
+          {isWarning && (
+            <button
+              onClick={dismissTimeoutBanner}
+              aria-label="Dismiss session warning banner"
+              className={`
+                p-1.5 rounded-[8px]
+                transition-colors
+                focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2
+                ${closeBtnColor}
+              `}
+            >
+              <X className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="sr-only">Dismiss</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Spacer so content below is not obscured by the fixed banner */}
+      <div
+        className="h-[48px] md:h-[52px]"
+        aria-hidden="true"
+      />
+    </>
+  );
+}

--- a/frontend/src/shared/components/index.ts
+++ b/frontend/src/shared/components/index.ts
@@ -6,3 +6,4 @@ export { GlassDropdown } from "./GlassDropdown";
 export { NotificationsDropdown } from "./NotificationsDropdown";
 export { EmptyState } from "./EmptyState";
 export type { EmptyStateProps, EmptyStateVariant } from "./EmptyState";
+export { SessionTimeoutBanner } from "./SessionTimeoutBanner";

--- a/frontend/src/shared/contexts/AuthContext.tsx
+++ b/frontend/src/shared/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useRef, useCallback, ReactNode } from 'react';
 import { getCurrentUser, getAuthToken, setAuthToken, removeAuthToken } from '../api/client';
 import { AUTH_BYPASS_ENABLED } from '../config/devAuth';
 
@@ -13,6 +13,47 @@ export interface User {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Session timeout types
+// ---------------------------------------------------------------------------
+
+export type SessionTimeoutState =
+  | 'banner-hidden'
+  | 'warning-visible'
+  | 'critical'
+  | 'expired';
+
+/** Seconds before expiry at which the warning banner first appears. */
+const WARNING_THRESHOLD_SECS = 5 * 60; // 5 minutes
+/** Seconds before expiry at which the banner escalates to critical. */
+const CRITICAL_THRESHOLD_SECS = 60; // 1 minute
+
+// ---------------------------------------------------------------------------
+// JWT helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode the `exp` claim from a JWT without verifying the signature.
+ * Returns the Unix timestamp (seconds) or null if the token is malformed.
+ */
+function getTokenExpiry(token: string): number | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    // Base64url → base64 → JSON
+    const payload = atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'));
+    const json = JSON.parse(payload);
+    if (typeof json.exp !== 'number') return null;
+    return json.exp;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context shape
+// ---------------------------------------------------------------------------
+
 interface AuthContextType {
   userRole: UserRole;
   userId: string | null;
@@ -21,6 +62,11 @@ interface AuthContextType {
   isLoading: boolean;
   login: (token: string) => Promise<void>;
   logout: () => void;
+  // Session timeout
+  sessionTimeoutState: SessionTimeoutState;
+  secondsRemaining: number;
+  staySignedIn: () => Promise<void>;
+  dismissTimeoutBanner: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -35,11 +81,129 @@ const BYPASS_USER: User = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [userRole, setUserRole] = useState<UserRole>(AUTH_BYPASS_ENABLED ? 'contributor' : null);
   const [userId, setUserId] = useState<string | null>(AUTH_BYPASS_ENABLED ? BYPASS_USER.id : null);
   const [user, setUser] = useState<User | null>(AUTH_BYPASS_ENABLED ? BYPASS_USER : null);
   const [isLoading, setIsLoading] = useState(!AUTH_BYPASS_ENABLED);
+
+  // Session timeout state
+  const [sessionTimeoutState, setSessionTimeoutState] = useState<SessionTimeoutState>('banner-hidden');
+  const [secondsRemaining, setSecondsRemaining] = useState(0);
+
+  // Refs for timers so we can clear them reliably
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const criticalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Track whether the user dismissed the banner during the warning window so we
+  // do not re-show it until the critical window begins.
+  const dismissedDuringWarningRef = useRef(false);
+
+  // ---------------------------------------------------------------------------
+  // Timer management
+  // ---------------------------------------------------------------------------
+
+  const clearSessionTimers = useCallback(() => {
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+    if (criticalTimerRef.current) clearTimeout(criticalTimerRef.current);
+    if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
+    warningTimerRef.current = null;
+    criticalTimerRef.current = null;
+    expiryTimerRef.current = null;
+    countdownIntervalRef.current = null;
+  }, []);
+
+  /**
+   * Start a 1-second countdown interval that keeps `secondsRemaining` in sync
+   * and drives the banner copy.
+   */
+  const startCountdown = useCallback((expiryTimestamp: number) => {
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
+
+    const tick = () => {
+      const nowSecs = Math.floor(Date.now() / 1000);
+      const remaining = Math.max(0, expiryTimestamp - nowSecs);
+      setSecondsRemaining(remaining);
+    };
+
+    tick(); // immediate first tick
+    countdownIntervalRef.current = setInterval(tick, 1000);
+  }, []);
+
+  /**
+   * Given an expiry Unix timestamp, arm the three session-timeout timers.
+   * Safe to call multiple times — clears previous timers first.
+   */
+  const armSessionTimers = useCallback(
+    (expiryTimestamp: number) => {
+      clearSessionTimers();
+      dismissedDuringWarningRef.current = false;
+
+      const nowSecs = Math.floor(Date.now() / 1000);
+      const totalSecs = expiryTimestamp - nowSecs;
+
+      if (totalSecs <= 0) {
+        // Token already expired
+        setSessionTimeoutState('expired');
+        setSecondsRemaining(0);
+        return;
+      }
+
+      // Warning timer (5 min before expiry)
+      const warningDelaySecs = totalSecs - WARNING_THRESHOLD_SECS;
+      if (warningDelaySecs > 0) {
+        warningTimerRef.current = setTimeout(() => {
+          if (!dismissedDuringWarningRef.current) {
+            setSessionTimeoutState('warning-visible');
+          }
+          startCountdown(expiryTimestamp);
+        }, warningDelaySecs * 1000);
+      } else {
+        // Already inside the warning window
+        if (totalSecs > CRITICAL_THRESHOLD_SECS) {
+          setSessionTimeoutState('warning-visible');
+        }
+        startCountdown(expiryTimestamp);
+      }
+
+      // Critical timer (1 min before expiry)
+      const criticalDelaySecs = totalSecs - CRITICAL_THRESHOLD_SECS;
+      if (criticalDelaySecs > 0) {
+        criticalTimerRef.current = setTimeout(() => {
+          setSessionTimeoutState('critical');
+          // Ensure countdown is running if it wasn't already
+          startCountdown(expiryTimestamp);
+        }, criticalDelaySecs * 1000);
+      } else if (totalSecs > 0) {
+        // Already inside the critical window
+        setSessionTimeoutState('critical');
+        startCountdown(expiryTimestamp);
+      }
+
+      // Expiry timer
+      expiryTimerRef.current = setTimeout(() => {
+        clearSessionTimers();
+        setSessionTimeoutState('expired');
+        setSecondsRemaining(0);
+        // Force logout — clear token and user state
+        removeAuthToken();
+        setUser(null);
+        setUserRole(null);
+        setUserId(null);
+      }, totalSecs * 1000);
+    },
+    [clearSessionTimers, startCountdown],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Auth helpers
+  // ---------------------------------------------------------------------------
 
   const checkAuth = async () => {
     // DEV-only: skip the real auth check and load a mock contributor.
@@ -71,6 +235,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           id: userData.id,
           githubLogin: userData.github.login
         });
+
+        // Arm session timeout timers
+        const expiry = getTokenExpiry(token);
+        if (expiry !== null) {
+          armSessionTimers(expiry);
+        }
       } catch (error) {
         // Token is invalid, remove it
         console.error('AuthContext - Auth check failed:', error);
@@ -92,6 +262,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Check for existing token on mount
   useEffect(() => {
     checkAuth();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Keep auth state in sync when token changes (logout in same tab, 401s, etc).
@@ -100,6 +271,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const ce = e as CustomEvent<{ token: string | null }>;
       const token = ce.detail?.token ?? null;
       if (!token) {
+        clearSessionTimers();
+        setSessionTimeoutState('banner-hidden');
         setUser(null);
         setUserRole(null);
         setUserId(null);
@@ -112,6 +285,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const onStorage = (e: StorageEvent) => {
       if (e.key !== 'patchwork_jwt') return;
       if (!e.newValue) {
+        clearSessionTimers();
+        setSessionTimeoutState('banner-hidden');
         setUser(null);
         setUserRole(null);
         setUserId(null);
@@ -126,7 +301,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       window.removeEventListener('patchwork-auth-token', onTokenEvent);
       window.removeEventListener('storage', onStorage);
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clearSessionTimers]);
+
+  // Clean up timers on unmount
+  useEffect(() => {
+    return () => {
+      clearSessionTimers();
+    };
+  }, [clearSessionTimers]);
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
 
   const login = async (token: string) => {
     console.log('AuthContext - login() called with token');
@@ -146,6 +333,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated: true,
         githubLogin: userData.github.login
       });
+
+      // Arm session timeout timers on login
+      const expiry = getTokenExpiry(token);
+      if (expiry !== null) {
+        armSessionTimers(expiry);
+      }
     } catch (error) {
       console.error('AuthContext - Login failed:', error);
       removeAuthToken();
@@ -154,10 +347,55 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = () => {
+    clearSessionTimers();
+    setSessionTimeoutState('banner-hidden');
+    setSecondsRemaining(0);
     removeAuthToken();
     setUser(null);
     setUserRole(null);
     setUserId(null);
+  };
+
+  /**
+   * Refresh the session by re-validating the current token with the API.
+   * On success the countdown timers reset; on failure the session expires.
+   */
+  const staySignedIn = async () => {
+    try {
+      const userData = await getCurrentUser();
+      setUser(userData);
+      setUserRole(userData.role as UserRole);
+      setUserId(userData.id);
+
+      // Re-read token (back-end may have rotated it via a response header)
+      const currentToken = getAuthToken();
+      const expiry = currentToken ? getTokenExpiry(currentToken) : null;
+      if (expiry !== null) {
+        armSessionTimers(expiry);
+      }
+
+      setSessionTimeoutState('banner-hidden');
+    } catch {
+      // Refresh failed — expire session immediately
+      clearSessionTimers();
+      setSessionTimeoutState('expired');
+      setSecondsRemaining(0);
+      removeAuthToken();
+      setUser(null);
+      setUserRole(null);
+      setUserId(null);
+    }
+  };
+
+  /**
+   * Dismiss the warning banner without refreshing the token.
+   * The banner will reappear when the critical threshold is reached.
+   */
+  const dismissTimeoutBanner = () => {
+    if (sessionTimeoutState === 'warning-visible') {
+      dismissedDuringWarningRef.current = true;
+      setSessionTimeoutState('banner-hidden');
+    }
   };
 
   return (
@@ -170,6 +408,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isLoading,
         login,
         logout,
+        sessionTimeoutState,
+        secondsRemaining,
+        staySignedIn,
+        dismissTimeoutBanner,
       }}
     >
       {children}


### PR DESCRIPTION
- Add design/specs/session-timeout-warning-ux.md with full UX spec covering four states (banner-hidden, warning-visible, critical, expired), countdown copy, CTA behaviour, forced-logout screen, accessibility annotations, color/contrast tables, and responsive behaviour at 375px

- Wire session timeout logic into AuthContext.tsx: decode JWT exp, arm warning/critical/expiry timers, 1-second countdown interval, staySignedIn() token refresh, dismissTimeoutBanner(), timer cleanup on logout and unmount

Closes #1516 