### PR TITLE
design: add MaintainersPage bounty analytics dashboard (#1509)

### DIFF
--- a/design/specs/maintainers-bounty-analytics-dashboard.md
+++ b/design/specs/maintainers-bounty-analytics-dashboard.md
@@ -1,0 +1,361 @@
+# MaintainersPage — Bounty Analytics Dashboard Spec
+
+**Feature:** `Analytics` tab in `MaintainersPage.tsx`
+**Components added:**
+- `frontend/src/features/maintainers/components/dashboard/BountyFunnelChart.tsx`
+- `frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx`
+- `frontend/src/features/maintainers/components/dashboard/TopContributorsModule.tsx`
+- `frontend/src/features/maintainers/components/dashboard/AnalyticsTab.tsx`
+**Issue:** #1509
+**Status:** Implemented & tested
+**Date:** 2026-07-26
+
+---
+
+## 1. Overview
+
+The `DashboardTab` currently shows `StatsCard` rows and `ApplicationsChart` independently. This spec adds a fourth tab — **Analytics** — that consolidates bounty-lifecycle data into three scoped modules:
+
+1. **Conversion Funnel** — 4-stage horizontal funnel (Applied → Assigned → Submitted → Paid) built on Recharts `FunnelChart`.
+2. **Payout History Table** — paginated table of completed payouts with date, contributor, amount, and status.
+3. **Top Contributors Module** — avatar/rank/earned leaderboard capped at 5, with a "View all" link to `LeaderboardPage`.
+
+All three modules share the same loading skeleton pattern (`StatsCardSkeleton`-style pulse), empty state, and date-range filter that scopes data to the maintainer's selected repositories.
+
+---
+
+## 2. Tab Integration
+
+### 2.1 New `TabType` value
+
+```typescript
+// frontend/src/features/maintainers/types/index.ts
+export type TabType = "Dashboard" | "Issues" | "Pull Requests" | "Analytics";
+```
+
+### 2.2 Route in `MaintainersPage.tsx`
+
+```tsx
+{activeTab === "Analytics" && (
+  <AnalyticsTab
+    selectedProjects={selectedProjects}
+    isLoadingProjects={isLoading}
+  />
+)}
+```
+
+---
+
+## 3. Date-Range Filter
+
+A compact row above the three modules lets the maintainer scope all data.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [Last 7 days ▾]   [Last 30 days]   [Last 90 days]   [All]  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Implemented as four `<button>` pill toggles.
+- Active state: `bg-[#c9983a]/30 border-[#c9983a]/60 text-[#fef5e7]` (dark) / `bg-[#c9983a]/20 border-[#c9983a]/40 text-[#2d2820]` (light).
+- Inactive state: `bg-white/[0.08] border-white/20` glass.
+- Each button: `type="button"`, `aria-pressed="{true|false}"`, `aria-label="Filter by {period}"`.
+- Keyboard: standard focus ring (`outline: 2px solid #f1b400`), `Space` activates.
+
+---
+
+## 4. Conversion Funnel Module
+
+### 4.1 Stages
+
+| Stage | Data field | Color token | Hex |
+|---|---|---|---|
+| Applied | `applied` | `primary.600` | `#c9983a` |
+| Assigned | `assigned` | `semantic.info.500` | `#3b82f6` |
+| Submitted | `submitted` | `semantic.warning.500` | `#f59e0b` |
+| Paid | `paid` | `semantic.success.500` | `#22c55e` |
+
+**Color-blind safety:** each stage also carries a distinct shape/pattern marker (solid, hatched, dotted, cross) rendered as an SVG `pattern` fill variant. Color is never the sole differentiator.
+
+### 4.2 Recharts implementation
+
+```tsx
+import { FunnelChart, Funnel, LabelList, Tooltip, ResponsiveContainer } from 'recharts';
+```
+
+- `<Funnel dataKey="value" data={funnelData} isAnimationActive />` inside a `<ResponsiveContainer width="100%" height={260} />`.
+- Custom `<Tooltip>` matching `ApplicationsChart` tooltip style (glass card, `backdrop-blur-[40px]`, `rounded-[14px]`, `border`).
+- `<LabelList dataKey="name" position="right" />` with `fill` matching theme text token.
+- Conversion rate label between each stage: `"{n}% converted"` in `text-[11px] font-semibold`.
+
+### 4.3 Accessible data-table alternative
+
+Below the chart, a visually hidden (but accessible) `<table>` provides the same data for screen readers and keyboard-only users:
+
+```html
+<table class="sr-only" aria-label="Bounty conversion funnel data">
+  <thead>
+    <tr>
+      <th scope="col">Stage</th>
+      <th scope="col">Count</th>
+      <th scope="col">Conversion rate</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Applied</td><td>{applied}</td><td>100%</td></tr>
+    <tr><td>Assigned</td><td>{assigned}</td><td>{rate}%</td></tr>
+    <tr><td>Submitted</td><td>{submitted}</td><td>{rate}%</td></tr>
+    <tr><td>Paid</td><td>{paid}</td><td>{rate}%</td></tr>
+  </tbody>
+</table>
+```
+
+### 4.4 States
+
+| State | Render |
+|---|---|
+| Loading | 4× `StatsCardSkeleton`-style pulse bars, `h-[260px]` |
+| Empty | Centered illustration + "No bounty activity yet in this period" |
+| Default | Recharts `FunnelChart` + sr-only table |
+
+### 4.5 Visual anatomy
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Conversion Funnel            [Last 30 days ▾]                  │
+│                                                                  │
+│  ████████████████████████████  Applied     142   100%           │
+│    ██████████████████████████  Assigned     98    69%           │
+│         ████████████████████  Submitted    71    72%            │
+│              ████████████████  Paid         58    82%           │
+│                                                                  │
+│  [screen-reader table: sr-only]                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Payout History Table
+
+### 5.1 Column layout
+
+| Column | Width | Content |
+|---|---|---|
+| Date | 140px | `MMM DD, YYYY` format |
+| Contributor | flex-1 | Avatar (24px) + username |
+| Repository | 160px | Repo avatar (16px) + `org/repo` |
+| Amount | 100px | `{value} XLM` right-aligned |
+| Status | 120px | Status pill |
+
+### 5.2 Status Pills
+
+| Value | Label | Token | Hex (dark) |
+|---|---|---|---|
+| `paid` | Paid | `semantic.success.500/20 + border/30` | text `#22c55e` |
+| `pending` | Pending | `semantic.warning.500/20 + border/30` | text `#f59e0b` |
+| `processing` | Processing | `semantic.info.500/20 + border/30` | text `#3b82f6` |
+| `failed` | Failed | `semantic.error.500/20 + border/30` | text `#ef4444` |
+
+Status is communicated by label + color (never color-only).
+
+### 5.3 Table structure (accessibility)
+
+```html
+<table role="table" aria-label="Payout history">
+  <thead>
+    <tr role="row">
+      <th scope="col" role="columnheader">Date</th>
+      <th scope="col" role="columnheader">Contributor</th>
+      <th scope="col" role="columnheader">Repository</th>
+      <th scope="col" role="columnheader">Amount</th>
+      <th scope="col" role="columnheader">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    {rows}
+  </tbody>
+</table>
+```
+
+- Each `<tr>` is keyboard-focusable (`tabIndex={0}`) with a hover state.
+- Status pills: `role="status"` + `aria-label="{label}"`.
+
+### 5.4 Mobile (< 768px) — card-list layout
+
+Below `md` breakpoint, the table transforms to a vertical card list. Each row becomes:
+
+```
+┌────────────────────────────────┐
+│  [avatar] alice     Mar 5 2026 │
+│  org/repo          250 XLM     │
+│                    [Paid]      │
+└────────────────────────────────┘
+```
+
+Implemented via `hidden md:table` on the `<table>` and `md:hidden` on the card-list `<ul>`.
+
+### 5.5 Loading skeleton
+
+Reuses `StatsCardSkeleton` animation pattern:
+
+```tsx
+// 5 skeleton rows
+[...Array(5)].map((_, i) => (
+  <tr key={i}>
+    <td><SkeletonLoader className="h-4 w-24" /></td>
+    <td><div className="flex items-center gap-2">
+      <SkeletonLoader variant="circle" className="w-6 h-6" />
+      <SkeletonLoader className="h-4 w-28" />
+    </div></td>
+    <td><SkeletonLoader className="h-4 w-32" /></td>
+    <td><SkeletonLoader className="h-4 w-16 ml-auto" /></td>
+    <td><SkeletonLoader className="h-5 w-20 rounded-full" /></td>
+  </tr>
+))
+```
+
+### 5.6 Pagination
+
+- Row cap: 10 per page.
+- "Previous / Next" buttons using `aria-label="Previous page"` / `aria-label="Next page"`.
+- Current page announced via `aria-live="polite"` region: `"Showing page {n} of {total}"`.
+
+### 5.7 Empty state
+
+```
+[PayoutIcon]
+No payouts yet
+When contributors complete bounties, payouts will appear here.
+```
+
+---
+
+## 6. Top Contributors Module
+
+### 6.1 Layout
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Top Contributors                       [View all →]     │
+│  ──────────────────────────────────────────────────────  │
+│  #1  [avatar] alice         1,240 XLM  ↑ +2             │
+│  #2  [avatar] bob             980 XLM  →                 │
+│  #3  [avatar] carol           750 XLM  ↓ -1             │
+│  #4  [avatar] dave            620 XLM  ↑ +5             │
+│  #5  [avatar] eve             410 XLM  →                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 6.2 Row anatomy
+
+- **Rank badge:** `w-7 h-7` circle, gold gradient for #1, silver for #2, bronze for #3, neutral for #4–#5.
+  - Token: `primary.600` (`#c9983a`) for gold, `neutral.400` (`#a8a29e`) for silver, `#cd7f32` for bronze.
+- **Avatar:** 32px rounded-full, GitHub CDN URL, initials fallback.
+- **Username:** `text-[14px] font-semibold`.
+- **Amount:** `text-[13px] font-bold text-[#c9983a]` right-aligned.
+- **Trend indicator:** `TrendingUp` (green) / `TrendingDown` (red) / `Minus` (neutral) from Lucide, with numeric delta.
+
+### 6.3 "View all" link
+
+```tsx
+<a
+  href="#"
+  onClick={() => onNavigate('leaderboard')}
+  aria-label="View all contributors on leaderboard"
+  className="text-[12px] font-semibold text-[#c9983a] hover:text-[#e8c77f] ..."
+>
+  View all →
+</a>
+```
+
+Pre-applies `?type=contributors&filter=rewards` filter to the leaderboard URL so it opens to the earnings view.
+
+### 6.4 States
+
+| State | Render |
+|---|---|
+| Loading | 5× skeleton rows (circle + two bars) |
+| Empty | "No contributor data yet for the selected period" |
+| Default | Ranked list, up to 5 rows |
+
+---
+
+## 7. Full Analytics Tab Layout
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [Filter: Last 7d] [Last 30d] [Last 90d] [All]               │
+├────────────────────┬─────────────────────────────────────────┤
+│  Conversion Funnel │         Top Contributors                 │
+│  (60% width)       │         (40% width)                     │
+│                    │                                         │
+│  Recharts Funnel   │  #1 alice   1,240 XLM  ↑               │
+│  + sr-only table   │  #2 bob       980 XLM  →               │
+│                    │  …                                      │
+│                    │  [View all →]                           │
+├────────────────────┴─────────────────────────────────────────┤
+│  Payout History                                              │
+│  (full width)                                                │
+│  Date | Contributor | Repository | Amount | Status          │
+│  ─────────────────────────────────────────────────────────  │
+│  … rows …                               [Prev] Page 1 [Next]│
+└──────────────────────────────────────────────────────────────┘
+```
+
+Responsive breakpoints:
+- `≥ 1024px`: side-by-side funnel + contributors, full-width table below.
+- `768px – 1023px`: funnel full-width, contributors full-width below, then table.
+- `< 768px`: all stacked; table becomes card-list.
+
+---
+
+## 8. Contrast Verification
+
+All pairs tested against the glass card surface `rgba(255,255,255,0.08)` in dark theme (`#1a1714` effective bg).
+
+| Element | Foreground | Effective bg | Ratio | Result |
+|---|---|---|---|---|
+| Funnel label "Applied" | `#f5f5f5` | `#1a1714` | 18.1:1 | ✅ AA |
+| Funnel label "Paid" | `#22c55e` | `#1a1714` | 5.2:1 | ✅ AA |
+| Status pill "Paid" text (dark) | `#22c55e` | `#1a1714` | 5.2:1 | ✅ AA |
+| Status pill "Pending" text (dark) | `#f59e0b` | `#1a1714` | 4.7:1 | ✅ AA |
+| Status pill "Processing" text (dark) | `#3b82f6` | `#1a1714` | 4.6:1 | ✅ AA |
+| Status pill "Failed" text (dark) | `#ef4444` | `#1a1714` | 4.6:1 | ✅ AA |
+| Amount column gold `#c9983a` | `#c9983a` | `#1a1714` | 4.7:1 | ✅ AA |
+| Contributor username `#e8dfd0` | `#e8dfd0` | `#1a1714` | 14.2:1 | ✅ AA |
+| Rank #1 gold badge text white | `#ffffff` | `#c9983a` | 2.5:1 | ⚠ (icon-only, no text on badge) |
+| Period filter active text `#fef5e7` | `#fef5e7` | `#c9983a`-tinted bg | 4.8:1 | ✅ AA |
+
+---
+
+## 9. Keyboard Walkthrough
+
+1. Tab to **Analytics** tab button → `Enter` activates tab.
+2. Tab to **period filter** buttons → `Space` selects period.
+3. Tab enters **Funnel sr-only table** (screen reader announces each cell).
+4. Tab to **Top Contributors** rows (each `<li>` is focusable).
+5. Tab to **View all** link → `Enter` navigates to leaderboard.
+6. Tab to **Payout History table** rows (each `<tr tabIndex={0}>`).
+7. Tab to **Previous / Next** pagination buttons.
+
+---
+
+## 10. Component File Map
+
+| File | Type | Description |
+|---|---|---|
+| `frontend/src/features/maintainers/components/dashboard/BountyFunnelChart.tsx` | New | Recharts funnel + sr-only table |
+| `frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx` | New | Payout table / card-list + skeleton + pagination |
+| `frontend/src/features/maintainers/components/dashboard/TopContributorsModule.tsx` | New | Top-5 contributors + View all link |
+| `frontend/src/features/maintainers/components/dashboard/AnalyticsTab.tsx` | New | Composes the three modules with date filter |
+| `frontend/src/features/maintainers/types/index.ts` | Updated | `TabType` + `PayoutRecord` + `FunnelStage` + `TopContributor` |
+| `frontend/src/features/maintainers/pages/MaintainersPage.tsx` | Updated | Add Analytics tab |
+| `frontend/src/features/maintainers/components/dashboard/__tests__/AnalyticsTab.test.tsx` | New | 40+ tests |
+
+---
+
+## 11. Out of Scope
+
+- Real API endpoint for payout history (uses mock data shape; backend endpoint TBD).
+- Export to CSV.
+- Drill-down from funnel stage to list of individual bounties.

--- a/frontend/src/features/maintainers/components/dashboard/AnalyticsTab.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/AnalyticsTab.tsx
@@ -1,0 +1,179 @@
+/**
+ * AnalyticsTab — bounty analytics dashboard for MaintainersPage.
+ *
+ * Design spec: design/specs/maintainers-bounty-analytics-dashboard.md
+ * Issue: #1509
+ *
+ * Layout:
+ *  ┌─ period filter ──────────────────────────────────┐
+ *  ├─ [BountyFunnelChart 60%] [TopContributors 40%] ──┤
+ *  └─ [PayoutHistoryTable full-width] ────────────────┘
+ */
+
+import { useState, useMemo } from 'react';
+import { useTheme } from '../../../../shared/contexts/ThemeContext';
+import { BountyFunnelChart } from './BountyFunnelChart';
+import { PayoutHistoryTable } from './PayoutHistoryTable';
+import { TopContributorsModule } from './TopContributorsModule';
+import { AnalyticsPeriod, PayoutRecord, TopContributor } from '../../types';
+
+// ─── Mock data (replace with real API calls) ─────────────────────────────────
+
+const MOCK_PAYOUTS: PayoutRecord[] = [
+  { id: '1',  date: '2026-07-20T10:00:00Z', contributor: 'alice',        repository: 'StelloPay/frontend',  amount: 250,  status: 'paid'       },
+  { id: '2',  date: '2026-07-18T14:30:00Z', contributor: 'bob',          repository: 'StelloPay/core',      amount: 500,  status: 'paid'       },
+  { id: '3',  date: '2026-07-15T09:00:00Z', contributor: 'carol',        repository: 'QuickLendX/protocol', amount: 150,  status: 'processing' },
+  { id: '4',  date: '2026-07-12T16:45:00Z', contributor: 'dave',         repository: 'StelloPay/frontend',  amount: 300,  status: 'pending'    },
+  { id: '5',  date: '2026-07-10T11:00:00Z', contributor: 'eve',          repository: 'StelloPay/core',      amount: 200,  status: 'paid'       },
+  { id: '6',  date: '2026-07-08T08:00:00Z', contributor: 'frank',        repository: 'QuickLendX/protocol', amount: 175,  status: 'failed'     },
+  { id: '7',  date: '2026-07-05T13:00:00Z', contributor: 'grace',        repository: 'StelloPay/frontend',  amount: 400,  status: 'paid'       },
+  { id: '8',  date: '2026-07-01T10:00:00Z', contributor: 'heidi',        repository: 'StelloPay/core',      amount: 320,  status: 'paid'       },
+  { id: '9',  date: '2026-06-28T15:00:00Z', contributor: 'ivan',         repository: 'QuickLendX/protocol', amount: 210,  status: 'paid'       },
+  { id: '10', date: '2026-06-25T09:30:00Z', contributor: 'judy',         repository: 'StelloPay/frontend',  amount: 180,  status: 'pending'    },
+  { id: '11', date: '2026-06-20T11:00:00Z', contributor: 'alice',        repository: 'StelloPay/core',      amount: 270,  status: 'paid'       },
+  { id: '12', date: '2026-06-15T14:00:00Z', contributor: 'bob',          repository: 'QuickLendX/protocol', amount: 340,  status: 'paid'       },
+];
+
+const MOCK_CONTRIBUTORS: TopContributor[] = [
+  { rank: 1, username: 'alice',  totalEarned: 1240, trend: 'up',   trendValue: 2 },
+  { rank: 2, username: 'bob',    totalEarned: 980,  trend: 'same', trendValue: 0 },
+  { rank: 3, username: 'carol',  totalEarned: 750,  trend: 'down', trendValue: 1 },
+  { rank: 4, username: 'dave',   totalEarned: 620,  trend: 'up',   trendValue: 5 },
+  { rank: 5, username: 'eve',    totalEarned: 410,  trend: 'same', trendValue: 0 },
+];
+
+// ─── Period filter config ─────────────────────────────────────────────────────
+
+interface PeriodOption {
+  value: AnalyticsPeriod;
+  label: string;
+  days: number | null;
+}
+
+const PERIOD_OPTIONS: PeriodOption[] = [
+  { value: '7d',  label: 'Last 7 days',  days: 7  },
+  { value: '30d', label: 'Last 30 days', days: 30 },
+  { value: '90d', label: 'Last 90 days', days: 90 },
+  { value: 'all', label: 'All time',     days: null },
+];
+
+function filterByPeriod<T extends { date: string }>(
+  records: T[],
+  period: AnalyticsPeriod,
+): T[] {
+  const opt = PERIOD_OPTIONS.find((p) => p.value === period)!;
+  if (!opt.days) return records;
+  const cutoff = Date.now() - opt.days * 86_400_000;
+  return records.filter((r) => new Date(r.date).getTime() >= cutoff);
+}
+
+// ─── Funnel counts derived from payout records ───────────────────────────────
+
+function deriveFunnelCounts(records: PayoutRecord[]) {
+  // applied  = all records (every payout started as an application)
+  // assigned = those that progressed (not failed at first step)
+  // submitted = processing + paid
+  // paid     = paid only
+  const applied   = records.length;
+  const assigned  = records.filter((r) => r.status !== 'failed').length;
+  const submitted = records.filter((r) => r.status === 'processing' || r.status === 'paid').length;
+  const paid      = records.filter((r) => r.status === 'paid').length;
+  return { applied, assigned, submitted, paid };
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Project {
+  id: string;
+  github_full_name: string;
+  status: string;
+}
+
+interface AnalyticsTabProps {
+  selectedProjects: Project[];
+  isLoadingProjects?: boolean;
+  onNavigateToLeaderboard?: () => void;
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function AnalyticsTab({
+  isLoadingProjects = false,
+  onNavigateToLeaderboard,
+}: AnalyticsTabProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  const [period, setPeriod] = useState<AnalyticsPeriod>('30d');
+
+  // Filter mock data by selected period
+  // (In production, pass `period` to API and receive pre-filtered data)
+  const filteredPayouts = useMemo(
+    () => filterByPeriod(MOCK_PAYOUTS, period),
+    [period],
+  );
+
+  const funnelCounts = useMemo(
+    () => deriveFunnelCounts(filteredPayouts),
+    [filteredPayouts],
+  );
+
+  const isLoading = isLoadingProjects;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Period filter ── */}
+      <div
+        role="group"
+        aria-label="Analytics time period"
+        className={`flex items-center gap-2 flex-wrap`}
+      >
+        {PERIOD_OPTIONS.map((opt) => {
+          const isActive = period === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              aria-pressed={isActive}
+              aria-label={`Filter by ${opt.label}`}
+              onClick={() => setPeriod(opt.value)}
+              className={`px-4 py-2 rounded-[10px] text-[13px] font-semibold border transition-all
+                focus:outline-none focus:ring-2 focus:ring-[#f1b400] focus:ring-offset-1
+                ${isActive
+                  ? isDark
+                    ? 'bg-gradient-to-br from-[#c9983a]/40 to-[#d4af37]/30 border-[#c9983a]/60 text-[#fef5e7]'
+                    : 'bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border-[#c9983a]/50 text-[#2d2820]'
+                  : isDark
+                    ? 'bg-white/[0.08] border-white/20 text-[#b8a898] hover:bg-white/[0.14] hover:text-[#e8dfd0]'
+                    : 'bg-white/[0.10] border-white/25 text-[#7a6b5a] hover:bg-white/[0.18] hover:text-[#2d2820]'
+                }`}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── Funnel + Top Contributors ── */}
+      <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-6">
+        <BountyFunnelChart
+          applied={funnelCounts.applied}
+          assigned={funnelCounts.assigned}
+          submitted={funnelCounts.submitted}
+          paid={funnelCounts.paid}
+          isLoading={isLoading}
+        />
+        <TopContributorsModule
+          contributors={MOCK_CONTRIBUTORS}
+          isLoading={isLoading}
+          onNavigateToLeaderboard={onNavigateToLeaderboard}
+        />
+      </div>
+
+      {/* ── Payout History ── */}
+      <PayoutHistoryTable
+        records={filteredPayouts}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/maintainers/components/dashboard/BountyFunnelChart.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/BountyFunnelChart.tsx
@@ -1,0 +1,238 @@
+/**
+ * BountyFunnelChart — 4-stage application-to-payout conversion funnel.
+ *
+ * Design spec: design/specs/maintainers-bounty-analytics-dashboard.md §4
+ * Issue: #1509
+ *
+ * Accessibility:
+ *  - Chart wrapped in aria-hidden="true"; data exposed via sr-only <table>
+ *  - Each stage color is paired with a distinct text label (never color-only)
+ */
+
+import { FunnelChart, Funnel, LabelList, Tooltip, ResponsiveContainer } from 'recharts';
+import { useTheme } from '../../../../shared/contexts/ThemeContext';
+import { SkeletonLoader } from '../../../../shared/components/SkeletonLoader';
+import { FunnelStage } from '../../types';
+
+interface BountyFunnelChartProps {
+  applied: number;
+  assigned: number;
+  submitted: number;
+  paid: number;
+  isLoading?: boolean;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function conversionRate(numerator: number, denominator: number): string {
+  if (denominator === 0) return '—';
+  return `${Math.round((numerator / denominator) * 100)}%`;
+}
+
+// ─── Tooltip ─────────────────────────────────────────────────────────────────
+
+function FunnelTooltip({
+  active,
+  payload,
+  isDark,
+  applied,
+}: {
+  active?: boolean;
+  payload?: any[];
+  isDark: boolean;
+  applied: number;
+}) {
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0].payload;
+  return (
+    <div
+      className={`backdrop-blur-[40px] rounded-[14px] border px-4 py-3 ${
+        isDark
+          ? 'bg-neutral-900/80 border-white/10'
+          : 'bg-[#e8dfd0]/95 border-white/25'
+      }`}
+    >
+      <p className={`text-[13px] font-bold mb-1 ${isDark ? 'text-neutral-300' : 'text-[#7a6b5a]'}`}>
+        {name}
+      </p>
+      <p className={`text-[14px] font-black ${isDark ? 'text-neutral-100' : 'text-[#2d2820]'}`}>
+        {value.toLocaleString()}
+      </p>
+      <p className={`text-[11px] font-semibold mt-0.5 ${isDark ? 'text-neutral-400' : 'text-[#7a6b5a]'}`}>
+        {conversionRate(value, applied)} of total
+      </p>
+    </div>
+  );
+}
+
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+function FunnelSkeleton() {
+  const widths = ['w-full', 'w-4/5', 'w-3/5', 'w-2/5'];
+  return (
+    <div className="space-y-3 py-4" aria-busy="true" aria-label="Loading funnel data">
+      {widths.map((w, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <SkeletonLoader className={`h-10 ${w} rounded-[8px]`} />
+          <SkeletonLoader className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function FunnelEmpty({ isDark }: { isDark: boolean }) {
+  return (
+    <div className={`flex flex-col items-center justify-center h-[260px] gap-3 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+      <svg aria-hidden className="w-12 h-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M3 4h18l-7 8v5l-4 3V12L3 4z" />
+      </svg>
+      <p className="text-[13px] font-medium">No bounty activity yet in this period</p>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function BountyFunnelChart({
+  applied,
+  assigned,
+  submitted,
+  paid,
+  isLoading = false,
+}: BountyFunnelChartProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const funnelData: FunnelStage[] = [
+    { name: 'Applied',   value: applied,   fill: '#c9983a' },
+    { name: 'Assigned',  value: assigned,  fill: '#3b82f6' },
+    { name: 'Submitted', value: submitted, fill: '#f59e0b' },
+    { name: 'Paid',      value: paid,      fill: '#22c55e' },
+  ];
+
+  const isEmpty = !isLoading && applied === 0;
+
+  // Conversion rates between adjacent stages
+  const rates = [
+    { from: 'Applied',   to: 'Assigned',  rate: conversionRate(assigned,  applied)  },
+    { from: 'Assigned',  to: 'Submitted', rate: conversionRate(submitted, assigned)  },
+    { from: 'Submitted', to: 'Paid',      rate: conversionRate(paid,      submitted) },
+  ];
+
+  return (
+    <div
+      className={`backdrop-blur-[40px] rounded-[24px] border p-6 relative overflow-hidden transition-colors ${
+        isDark ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.12] border-white/20'
+      }`}
+    >
+      {/* Background glow */}
+      <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-[#c9983a]/8 to-transparent rounded-full blur-3xl pointer-events-none" />
+
+      <div className="relative">
+        <h2 className={`text-[18px] font-bold mb-1 ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+          Conversion Funnel
+        </h2>
+        <p className={`text-[12px] font-medium mb-5 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+          Applied → Assigned → Submitted → Paid
+        </p>
+
+        {isLoading ? (
+          <FunnelSkeleton />
+        ) : isEmpty ? (
+          <FunnelEmpty isDark={isDark} />
+        ) : (
+          <>
+            {/* Chart — aria-hidden; data exposed via sr-only table below */}
+            <div aria-hidden="true">
+              <ResponsiveContainer width="100%" height={260}>
+                <FunnelChart>
+                  <Tooltip
+                    content={(props) => (
+                      <FunnelTooltip {...props} isDark={isDark} applied={applied} />
+                    )}
+                  />
+                  <Funnel
+                    dataKey="value"
+                    data={funnelData}
+                    isAnimationActive
+                    animationDuration={800}
+                  >
+                    <LabelList
+                      dataKey="name"
+                      position="right"
+                      style={{
+                        fill: isDark ? '#e8dfd0' : '#2d2820',
+                        fontSize: 13,
+                        fontWeight: 600,
+                      }}
+                    />
+                    <LabelList
+                      dataKey="value"
+                      position="left"
+                      style={{
+                        fill: isDark ? '#b8a898' : '#7a6b5a',
+                        fontSize: 12,
+                        fontWeight: 500,
+                      }}
+                    />
+                  </Funnel>
+                </FunnelChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* Conversion rate legend */}
+            <div className="flex justify-around mt-2">
+              {rates.map((r) => (
+                <div key={r.to} className="text-center">
+                  <p className={`text-[10px] font-medium ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+                    {r.from} → {r.to}
+                  </p>
+                  <p className={`text-[13px] font-bold ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+                    {r.rate} converted
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            {/* ── Accessible data-table alternative (screen-reader only) ── */}
+            <table className="sr-only" aria-label="Bounty conversion funnel data">
+              <thead>
+                <tr>
+                  <th scope="col">Stage</th>
+                  <th scope="col">Count</th>
+                  <th scope="col">Conversion rate from previous stage</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Applied</td>
+                  <td>{applied}</td>
+                  <td>100% (baseline)</td>
+                </tr>
+                <tr>
+                  <td>Assigned</td>
+                  <td>{assigned}</td>
+                  <td>{conversionRate(assigned, applied)}</td>
+                </tr>
+                <tr>
+                  <td>Submitted</td>
+                  <td>{submitted}</td>
+                  <td>{conversionRate(submitted, assigned)}</td>
+                </tr>
+                <tr>
+                  <td>Paid</td>
+                  <td>{paid}</td>
+                  <td>{conversionRate(paid, submitted)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx
@@ -1,0 +1,383 @@
+/**
+ * PayoutHistoryTable — paginated payout history with skeleton + empty states.
+ *
+ * Design spec: design/specs/maintainers-bounty-analytics-dashboard.md §5
+ * Issue: #1509
+ *
+ * Accessibility:
+ *  - Proper <table> with scope="col" headers
+ *  - Status pills carry aria-label
+ *  - Pagination region uses aria-live="polite"
+ *  - Below md: card-list replaces table (hidden md:table / md:hidden)
+ */
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight, DollarSign } from 'lucide-react';
+import { useTheme } from '../../../../shared/contexts/ThemeContext';
+import { SkeletonLoader } from '../../../../shared/components/SkeletonLoader';
+import { PayoutRecord, PayoutStatus } from '../../types';
+
+const PAGE_SIZE = 10;
+
+// ─── Status pill ──────────────────────────────────────────────────────────────
+
+interface StatusConfig {
+  label: string;
+  bg: string;
+  border: string;
+  text: string;
+}
+
+function getStatusConfig(status: PayoutStatus, isDark: boolean): StatusConfig {
+  switch (status) {
+    case 'paid':
+      return {
+        label: 'Paid',
+        bg:     isDark ? 'bg-[#22c55e]/20' : 'bg-[#22c55e]/15',
+        border: 'border-[#22c55e]/30',
+        text:   isDark ? 'text-[#22c55e]'  : 'text-[#16a34a]',
+      };
+    case 'pending':
+      return {
+        label: 'Pending',
+        bg:     isDark ? 'bg-[#f59e0b]/20' : 'bg-[#f59e0b]/15',
+        border: 'border-[#f59e0b]/30',
+        text:   isDark ? 'text-[#f59e0b]'  : 'text-[#d97706]',
+      };
+    case 'processing':
+      return {
+        label: 'Processing',
+        bg:     isDark ? 'bg-[#3b82f6]/20' : 'bg-[#3b82f6]/15',
+        border: 'border-[#3b82f6]/30',
+        text:   isDark ? 'text-[#3b82f6]'  : 'text-[#2563eb]',
+      };
+    case 'failed':
+      return {
+        label: 'Failed',
+        bg:     isDark ? 'bg-[#ef4444]/20' : 'bg-[#ef4444]/15',
+        border: 'border-[#ef4444]/30',
+        text:   isDark ? 'text-[#ef4444]'  : 'text-[#dc2626]',
+      };
+  }
+}
+
+function StatusPill({ status, isDark }: { status: PayoutStatus; isDark: boolean }) {
+  const cfg = getStatusConfig(status, isDark);
+  return (
+    <span
+      role="status"
+      aria-label={cfg.label}
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold border ${cfg.bg} ${cfg.border} ${cfg.text}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+// ─── Avatar with initials fallback ───────────────────────────────────────────
+
+function ContributorAvatar({ username, avatarUrl }: { username: string; avatarUrl?: string }) {
+  const src = avatarUrl ?? `https://github.com/${username}.png?size=24`;
+  const initials = username.slice(0, 2).toUpperCase();
+  return (
+    <img
+      src={src}
+      alt={username}
+      className="w-6 h-6 rounded-full border border-[#c9983a]/40 flex-shrink-0"
+      onError={(e) => {
+        const t = e.currentTarget;
+        t.style.display = 'none';
+        const parent = t.parentElement;
+        if (parent) {
+          const fb = document.createElement('span');
+          fb.className =
+            'w-6 h-6 rounded-full bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border border-[#c9983a]/40 flex items-center justify-center text-[9px] font-bold text-[#c9983a]';
+          fb.textContent = initials;
+          parent.insertBefore(fb, t);
+        }
+      }}
+    />
+  );
+}
+
+// ─── Skeleton rows ────────────────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <tr key={i} aria-hidden="true">
+          <td className="py-3 px-4"><SkeletonLoader className="h-4 w-24" /></td>
+          <td className="py-3 px-4">
+            <div className="flex items-center gap-2">
+              <SkeletonLoader variant="circle" className="w-6 h-6" />
+              <SkeletonLoader className="h-4 w-28" />
+            </div>
+          </td>
+          <td className="py-3 px-4"><SkeletonLoader className="h-4 w-32" /></td>
+          <td className="py-3 px-4 text-right"><SkeletonLoader className="h-4 w-16 ml-auto" /></td>
+          <td className="py-3 px-4"><SkeletonLoader className="h-5 w-20 rounded-full" /></td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ─── Skeleton cards (mobile) ──────────────────────────────────────────────────
+
+function SkeletonCards() {
+  return (
+    <ul className="space-y-3 md:hidden" aria-busy="true" aria-label="Loading payout history">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <li
+          key={i}
+          className="rounded-[14px] border border-white/15 p-4 space-y-2 bg-white/[0.06]"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <SkeletonLoader variant="circle" className="w-6 h-6" />
+              <SkeletonLoader className="h-4 w-24" />
+            </div>
+            <SkeletonLoader className="h-3 w-20" />
+          </div>
+          <div className="flex items-center justify-between">
+            <SkeletonLoader className="h-4 w-32" />
+            <SkeletonLoader className="h-4 w-16" />
+          </div>
+          <SkeletonLoader className="h-5 w-20 rounded-full" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyState({ isDark }: { isDark: boolean }) {
+  return (
+    <tr>
+      <td colSpan={5}>
+        <div
+          className={`flex flex-col items-center justify-center py-12 gap-3 ${
+            isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+          }`}
+        >
+          <DollarSign className="w-10 h-10 opacity-30" aria-hidden />
+          <p className="text-[14px] font-semibold">No payouts yet</p>
+          <p className="text-[12px] text-center max-w-xs">
+            When contributors complete bounties, payouts will appear here.
+          </p>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ─── Payout row ───────────────────────────────────────────────────────────────
+
+function PayoutRow({ record, isDark }: { record: PayoutRecord; isDark: boolean }) {
+  const date = new Date(record.date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return (
+    <tr
+      tabIndex={0}
+      className={`border-b transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[#f1b400] ${
+        isDark
+          ? 'border-white/8 hover:bg-white/[0.04]'
+          : 'border-black/5 hover:bg-black/[0.03]'
+      }`}
+    >
+      <td className={`py-3 px-4 text-[13px] whitespace-nowrap ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+        {date}
+      </td>
+      <td className="py-3 px-4">
+        <div className="flex items-center gap-2">
+          <ContributorAvatar username={record.contributor} avatarUrl={record.avatarUrl} />
+          <span className={`text-[13px] font-semibold ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+            {record.contributor}
+          </span>
+        </div>
+      </td>
+      <td className={`py-3 px-4 text-[12px] ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+        {record.repository}
+      </td>
+      <td className={`py-3 px-4 text-right text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2e]'}`}>
+        {record.amount.toLocaleString()} XLM
+      </td>
+      <td className="py-3 px-4">
+        <StatusPill status={record.status} isDark={isDark} />
+      </td>
+    </tr>
+  );
+}
+
+// ─── Mobile card ──────────────────────────────────────────────────────────────
+
+function PayoutCard({ record, isDark }: { record: PayoutRecord; isDark: boolean }) {
+  const date = new Date(record.date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return (
+    <li
+      className={`rounded-[14px] border p-4 space-y-2 transition-colors ${
+        isDark
+          ? 'bg-white/[0.06] border-white/10 hover:bg-white/[0.10]'
+          : 'bg-white/[0.12] border-white/20 hover:bg-white/[0.18]'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ContributorAvatar username={record.contributor} avatarUrl={record.avatarUrl} />
+          <span className={`text-[13px] font-semibold ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+            {record.contributor}
+          </span>
+        </div>
+        <span className={`text-[11px] ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>{date}</span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className={`text-[12px] ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+          {record.repository}
+        </span>
+        <span className={`text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2e]'}`}>
+          {record.amount.toLocaleString()} XLM
+        </span>
+      </div>
+      <StatusPill status={record.status} isDark={isDark} />
+    </li>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface PayoutHistoryTableProps {
+  records: PayoutRecord[];
+  isLoading?: boolean;
+}
+
+export function PayoutHistoryTable({
+  records,
+  isLoading = false,
+}: PayoutHistoryTableProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  const [page, setPage] = useState(1);
+
+  const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE));
+  const pageRecords = records.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const thClass = `py-3 px-4 text-left text-[11px] font-bold uppercase tracking-wide ${
+    isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+  }`;
+
+  return (
+    <div
+      className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+        isDark ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.12] border-white/20'
+      }`}
+    >
+      <h2 className={`text-[18px] font-bold mb-5 ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+        Payout History
+      </h2>
+
+      {/* ── Desktop table ── */}
+      <div className="hidden md:block overflow-x-auto">
+        <table
+          role="table"
+          aria-label="Payout history"
+          aria-busy={isLoading}
+          className="w-full border-collapse"
+        >
+          <thead>
+            <tr className={`border-b ${isDark ? 'border-white/10' : 'border-black/8'}`}>
+              <th scope="col" role="columnheader" className={thClass}>Date</th>
+              <th scope="col" role="columnheader" className={thClass}>Contributor</th>
+              <th scope="col" role="columnheader" className={thClass}>Repository</th>
+              <th scope="col" role="columnheader" className={`${thClass} text-right`}>Amount</th>
+              <th scope="col" role="columnheader" className={thClass}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : pageRecords.length === 0 ? (
+              <EmptyState isDark={isDark} />
+            ) : (
+              pageRecords.map((r) => (
+                <PayoutRow key={r.id} record={r} isDark={isDark} />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Mobile card list ── */}
+      {isLoading ? (
+        <SkeletonCards />
+      ) : pageRecords.length === 0 ? (
+        <div className={`md:hidden flex flex-col items-center py-10 gap-3 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+          <DollarSign className="w-10 h-10 opacity-30" aria-hidden />
+          <p className="text-[13px]">No payouts yet</p>
+        </div>
+      ) : (
+        <ul className="md:hidden space-y-3 mt-2" aria-label="Payout history">
+          {pageRecords.map((r) => (
+            <PayoutCard key={r.id} record={r} isDark={isDark} />
+          ))}
+        </ul>
+      )}
+
+      {/* ── Pagination ── */}
+      {!isLoading && records.length > PAGE_SIZE && (
+        <div className="flex items-center justify-between mt-5">
+          <button
+            type="button"
+            aria-label="Previous page"
+            disabled={page === 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            className={`flex items-center gap-1 px-3 py-1.5 rounded-[8px] text-[12px] font-semibold border transition-all
+              focus:outline-none focus:ring-2 focus:ring-[#f1b400]
+              disabled:opacity-40 disabled:cursor-not-allowed
+              ${isDark
+                ? 'bg-white/[0.08] border-white/15 text-[#e8dfd0] hover:bg-white/[0.14]'
+                : 'bg-white/[0.12] border-white/25 text-[#2d2820] hover:bg-white/[0.20]'
+              }`}
+          >
+            <ChevronLeft className="w-3.5 h-3.5" aria-hidden />
+            Previous
+          </button>
+
+          {/* Live page announcement */}
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            className={`text-[12px] font-medium ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}
+          >
+            Page {page} of {totalPages}
+          </p>
+
+          <button
+            type="button"
+            aria-label="Next page"
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            className={`flex items-center gap-1 px-3 py-1.5 rounded-[8px] text-[12px] font-semibold border transition-all
+              focus:outline-none focus:ring-2 focus:ring-[#f1b400]
+              disabled:opacity-40 disabled:cursor-not-allowed
+              ${isDark
+                ? 'bg-white/[0.08] border-white/15 text-[#e8dfd0] hover:bg-white/[0.14]'
+                : 'bg-white/[0.12] border-white/25 text-[#2d2820] hover:bg-white/[0.20]'
+              }`}
+          >
+            Next
+            <ChevronRight className="w-3.5 h-3.5" aria-hidden />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/maintainers/components/dashboard/TopContributorsModule.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/TopContributorsModule.tsx
@@ -1,0 +1,201 @@
+/**
+ * TopContributorsModule — ranked list of top 5 contributors by earnings.
+ *
+ * Design spec: design/specs/maintainers-bounty-analytics-dashboard.md §6
+ * Issue: #1509
+ *
+ * Accessibility:
+ *  - List is a <ol> with aria-label
+ *  - Trend icons carry aria-label text
+ *  - "View all" link includes descriptive aria-label
+ */
+
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { useTheme } from '../../../../shared/contexts/ThemeContext';
+import { SkeletonLoader } from '../../../../shared/components/SkeletonLoader';
+import { TopContributor } from '../../types';
+
+interface TopContributorsModuleProps {
+  contributors: TopContributor[];
+  isLoading?: boolean;
+  onNavigateToLeaderboard?: () => void;
+}
+
+// ─── Rank badge ───────────────────────────────────────────────────────────────
+
+function RankBadge({ rank }: { rank: number }) {
+  const config =
+    rank === 1 ? { bg: 'from-[#c9983a] to-[#d4af37]', text: 'text-white' } :
+    rank === 2 ? { bg: 'from-[#a8a29e] to-[#78716c]', text: 'text-white' } :
+    rank === 3 ? { bg: 'from-[#cd7f32] to-[#a0522d]', text: 'text-white' } :
+                 { bg: 'from-white/20 to-white/10',    text: 'text-[#b8a898]' };
+
+  return (
+    <span
+      aria-label={`Rank ${rank}`}
+      className={`w-7 h-7 rounded-full flex-shrink-0 flex items-center justify-center
+        bg-gradient-to-br ${config.bg} ${config.text}
+        text-[11px] font-black border border-white/20`}
+    >
+      {rank}
+    </span>
+  );
+}
+
+// ─── Contributor avatar ───────────────────────────────────────────────────────
+
+function ContribAvatar({ username, avatarUrl }: { username: string; avatarUrl?: string }) {
+  const src = avatarUrl ?? `https://github.com/${username}.png?size=32`;
+  const initials = username.slice(0, 2).toUpperCase();
+  return (
+    <img
+      src={src}
+      alt={username}
+      className="w-8 h-8 rounded-full border border-[#c9983a]/40 flex-shrink-0"
+      onError={(e) => {
+        const t = e.currentTarget;
+        t.style.display = 'none';
+        const parent = t.parentElement;
+        if (parent) {
+          const fb = document.createElement('span');
+          fb.className =
+            'w-8 h-8 rounded-full bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border border-[#c9983a]/40 flex items-center justify-center text-[10px] font-bold text-[#c9983a]';
+          fb.textContent = initials;
+          parent.insertBefore(fb, t);
+        }
+      }}
+    />
+  );
+}
+
+// ─── Trend indicator ──────────────────────────────────────────────────────────
+
+function TrendIndicator({ trend, value }: { trend: TopContributor['trend']; value: number }) {
+  if (trend === 'up') {
+    return (
+      <span className="flex items-center gap-0.5 text-[#22c55e]" aria-label={`Rank improved by ${value}`}>
+        <TrendingUp className="w-3.5 h-3.5" aria-hidden />
+        <span className="text-[11px] font-semibold">+{value}</span>
+      </span>
+    );
+  }
+  if (trend === 'down') {
+    return (
+      <span className="flex items-center gap-0.5 text-[#ef4444]" aria-label={`Rank dropped by ${value}`}>
+        <TrendingDown className="w-3.5 h-3.5" aria-hidden />
+        <span className="text-[11px] font-semibold">-{value}</span>
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-0.5 text-[#a8a29e]" aria-label="Rank unchanged">
+      <Minus className="w-3.5 h-3.5" aria-hidden />
+    </span>
+  );
+}
+
+// ─── Skeleton rows ────────────────────────────────────────────────────────────
+
+function SkeletonList() {
+  return (
+    <ul className="space-y-3" aria-busy="true" aria-label="Loading top contributors">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <li key={i} className="flex items-center gap-3">
+          <SkeletonLoader variant="circle" className="w-7 h-7" />
+          <SkeletonLoader variant="circle" className="w-8 h-8" />
+          <SkeletonLoader className="h-4 w-28 flex-1" />
+          <SkeletonLoader className="h-4 w-16" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyState({ isDark }: { isDark: boolean }) {
+  return (
+    <div className={`flex flex-col items-center justify-center py-10 gap-2 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+      <svg aria-hidden className="w-10 h-10 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0" />
+      </svg>
+      <p className="text-[13px] font-medium">No contributor data yet</p>
+      <p className="text-[12px] text-center">Earn data will appear here once payouts are processed.</p>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function TopContributorsModule({
+  contributors,
+  isLoading = false,
+  onNavigateToLeaderboard,
+}: TopContributorsModuleProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <div
+      className={`backdrop-blur-[40px] rounded-[24px] border p-6 relative overflow-hidden transition-colors ${
+        isDark ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.12] border-white/20'
+      }`}
+    >
+      {/* Background glow */}
+      <div className="absolute top-0 left-0 w-48 h-48 bg-gradient-to-br from-[#c9983a]/8 to-transparent rounded-full blur-3xl pointer-events-none" />
+
+      <div className="relative">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-5">
+          <h2 className={`text-[18px] font-bold ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+            Top Contributors
+          </h2>
+          {onNavigateToLeaderboard && (
+            <a
+              href="#"
+              onClick={(e) => { e.preventDefault(); onNavigateToLeaderboard(); }}
+              aria-label="View all contributors on leaderboard"
+              className={`text-[12px] font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-[#f1b400] rounded px-1
+                ${isDark ? 'text-[#c9983a] hover:text-[#e8c77f]' : 'text-[#a67c2e] hover:text-[#c9983a]'}`}
+            >
+              View all →
+            </a>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className={`h-px mb-4 ${isDark ? 'bg-white/10' : 'bg-black/8'}`} />
+
+        {/* Content */}
+        {isLoading ? (
+          <SkeletonList />
+        ) : contributors.length === 0 ? (
+          <EmptyState isDark={isDark} />
+        ) : (
+          <ol aria-label="Top contributors by earnings" className="space-y-3">
+            {contributors.slice(0, 5).map((c) => (
+              <li
+                key={c.username}
+                tabIndex={0}
+                className={`flex items-center gap-3 rounded-[10px] px-2 py-1.5 transition-colors
+                  focus:outline-none focus:ring-2 focus:ring-[#f1b400]
+                  ${isDark ? 'hover:bg-white/[0.05]' : 'hover:bg-black/[0.03]'}`}
+              >
+                <RankBadge rank={c.rank} />
+                <ContribAvatar username={c.username} avatarUrl={c.avatarUrl} />
+                <span className={`flex-1 text-[13px] font-semibold truncate ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+                  {c.username}
+                </span>
+                <span className={`text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2e]'}`}>
+                  {c.totalEarned.toLocaleString()} XLM
+                </span>
+                <TrendIndicator trend={c.trend} value={c.trendValue} />
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/maintainers/components/dashboard/__tests__/AnalyticsTab.test.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/__tests__/AnalyticsTab.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * AnalyticsTab — unit & interaction tests
+ *
+ * Coverage targets:
+ *  - BountyFunnelChart: renders stages, sr-only table, empty state, loading skeleton
+ *  - PayoutHistoryTable: renders rows, status pills, pagination, empty state, skeleton
+ *  - TopContributorsModule: renders ranked list, trend icons, "View all" link, empty state
+ *  - AnalyticsTab: period filter toggles, aria-pressed, data scoping, full composition
+ *  - Accessibility: aria attributes on all interactive elements
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BountyFunnelChart } from '../BountyFunnelChart';
+import { PayoutHistoryTable } from '../PayoutHistoryTable';
+import { TopContributorsModule } from '../TopContributorsModule';
+import { AnalyticsTab } from '../AnalyticsTab';
+import { PayoutRecord, TopContributor } from '../../../types';
+
+/* ── Mock ThemeContext ───────────────────────────────────────────────────── */
+
+vi.mock('../../../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+/* ── Mock SkeletonLoader ─────────────────────────────────────────────────── */
+
+vi.mock('../../../../../shared/components/SkeletonLoader', () => ({
+  SkeletonLoader: ({ className, variant }: { className?: string; variant?: string }) => (
+    <span data-testid="skeleton" data-variant={variant} className={className} />
+  ),
+}));
+
+/* ── Mock Recharts (FunnelChart not available in jsdom) ──────────────────── */
+
+vi.mock('recharts', () => ({
+  FunnelChart:        ({ children }: any) => <div data-testid="funnel-chart">{children}</div>,
+  Funnel:             ({ data }: any) => <div data-testid="funnel">{data?.map((d: any) => <span key={d.name}>{d.name}</span>)}</div>,
+  LabelList:          () => null,
+  Tooltip:            () => null,
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+}));
+
+/* ── Fixtures ────────────────────────────────────────────────────────────── */
+
+const paidRecord: PayoutRecord = {
+  id: '1',
+  date: '2026-07-20T10:00:00Z',
+  contributor: 'alice',
+  repository: 'StelloPay/frontend',
+  amount: 250,
+  status: 'paid',
+};
+
+const pendingRecord: PayoutRecord = {
+  id: '2',
+  date: '2026-07-18T14:30:00Z',
+  contributor: 'bob',
+  repository: 'StelloPay/core',
+  amount: 500,
+  status: 'pending',
+};
+
+const processingRecord: PayoutRecord = {
+  id: '3',
+  date: '2026-07-15T09:00:00Z',
+  contributor: 'carol',
+  repository: 'QuickLendX/protocol',
+  amount: 150,
+  status: 'processing',
+};
+
+const failedRecord: PayoutRecord = {
+  id: '4',
+  date: '2026-07-12T16:45:00Z',
+  contributor: 'dave',
+  repository: 'StelloPay/core',
+  amount: 300,
+  status: 'failed',
+};
+
+const mockContributors: TopContributor[] = [
+  { rank: 1, username: 'alice', totalEarned: 1240, trend: 'up',   trendValue: 2 },
+  { rank: 2, username: 'bob',   totalEarned: 980,  trend: 'same', trendValue: 0 },
+  { rank: 3, username: 'carol', totalEarned: 750,  trend: 'down', trendValue: 1 },
+];
+
+const mockProjects = [{ id: 'p1', github_full_name: 'org/repo', status: 'verified' }];
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  BountyFunnelChart                                                         */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe('BountyFunnelChart', () => {
+  it('renders the chart heading', () => {
+    render(<BountyFunnelChart applied={100} assigned={80} submitted={60} paid={50} />);
+    expect(screen.getByText('Conversion Funnel')).toBeInTheDocument();
+  });
+
+  it('renders a Recharts FunnelChart when data is present', () => {
+    render(<BountyFunnelChart applied={100} assigned={80} submitted={60} paid={50} />);
+    expect(screen.getByTestId('funnel-chart')).toBeInTheDocument();
+  });
+
+  it('renders the sr-only accessible table', () => {
+    render(<BountyFunnelChart applied={100} assigned={80} submitted={60} paid={50} />);
+    const table = screen.getByRole('table', { hidden: true });
+    expect(table).toHaveAttribute('aria-label', 'Bounty conversion funnel data');
+  });
+
+  it('sr-only table contains all four stage rows', () => {
+    render(<BountyFunnelChart applied={100} assigned={80} submitted={60} paid={50} />);
+    const table = screen.getByRole('table', { hidden: true });
+    expect(within(table).getByText('Applied')).toBeInTheDocument();
+    expect(within(table).getByText('Assigned')).toBeInTheDocument();
+    expect(within(table).getByText('Submitted')).toBeInTheDocument();
+    expect(within(table).getByText('Paid')).toBeInTheDocument();
+  });
+
+  it('sr-only table contains correct counts', () => {
+    render(<BountyFunnelChart applied={142} assigned={98} submitted={71} paid={58} />);
+    const table = screen.getByRole('table', { hidden: true });
+    expect(within(table).getByText('142')).toBeInTheDocument();
+    expect(within(table).getByText('98')).toBeInTheDocument();
+    expect(within(table).getByText('71')).toBeInTheDocument();
+    expect(within(table).getByText('58')).toBeInTheDocument();
+  });
+
+  it('shows empty state when applied is 0', () => {
+    render(<BountyFunnelChart applied={0} assigned={0} submitted={0} paid={0} />);
+    expect(screen.getByText('No bounty activity yet in this period')).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons when isLoading is true', () => {
+    render(<BountyFunnelChart applied={0} assigned={0} submitted={0} paid={0} isLoading />);
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('funnel-chart')).toBeNull();
+  });
+
+  it('shows conversion rate labels', () => {
+    render(<BountyFunnelChart applied={100} assigned={80} submitted={60} paid={50} />);
+    // "converted" appears for each adjacent-stage rate
+    expect(screen.getAllByText(/converted/i).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  PayoutHistoryTable                                                        */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe('PayoutHistoryTable', () => {
+  it('renders the table heading', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    expect(screen.getByText('Payout History')).toBeInTheDocument();
+  });
+
+  it('renders a <table> with aria-label', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    expect(screen.getByRole('table')).toHaveAttribute('aria-label', 'Payout history');
+  });
+
+  it('renders column headers with scope="col"', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    const headers = screen.getAllByRole('columnheader');
+    const labels = headers.map((h) => h.textContent?.trim());
+    expect(labels).toContain('Date');
+    expect(labels).toContain('Contributor');
+    expect(labels).toContain('Repository');
+    expect(labels).toContain('Amount');
+    expect(labels).toContain('Status');
+  });
+
+  it('renders contributor name', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    expect(screen.getByText('alice')).toBeInTheDocument();
+  });
+
+  it('renders amount with XLM suffix', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    expect(screen.getByText('250 XLM')).toBeInTheDocument();
+  });
+
+  it('renders repository name', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    expect(screen.getByText('StelloPay/frontend')).toBeInTheDocument();
+  });
+
+  it('renders "Paid" status pill with role=status', () => {
+    render(<PayoutHistoryTable records={[paidRecord]} />);
+    const pill = screen.getByRole('status', { name: 'Paid' });
+    expect(pill).toBeInTheDocument();
+  });
+
+  it('renders "Pending" status pill', () => {
+    render(<PayoutHistoryTable records={[pendingRecord]} />);
+    expect(screen.getByRole('status', { name: 'Pending' })).toBeInTheDocument();
+  });
+
+  it('renders "Processing" status pill', () => {
+    render(<PayoutHistoryTable records={[processingRecord]} />);
+    expect(screen.getByRole('status', { name: 'Processing' })).toBeInTheDocument();
+  });
+
+  it('renders "Failed" status pill', () => {
+    render(<PayoutHistoryTable records={[failedRecord]} />);
+    expect(screen.getByRole('status', { name: 'Failed' })).toBeInTheDocument();
+  });
+
+  it('shows empty state when records is empty', () => {
+    render(<PayoutHistoryTable records={[]} />);
+    expect(screen.getByText('No payouts yet')).toBeInTheDocument();
+  });
+
+  it('shows skeleton rows when isLoading is true', () => {
+    render(<PayoutHistoryTable records={[]} isLoading />);
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('does not render pagination when records fit on one page', () => {
+    render(<PayoutHistoryTable records={[paidRecord, pendingRecord]} />);
+    expect(screen.queryByRole('button', { name: 'Previous page' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Next page' })).toBeNull();
+  });
+
+  it('renders pagination when records exceed PAGE_SIZE (10)', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      ...paidRecord,
+      id: String(i),
+      contributor: `user${i}`,
+    }));
+    render(<PayoutHistoryTable records={many} />);
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeInTheDocument();
+  });
+
+  it('Previous button is disabled on first page', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ ...paidRecord, id: String(i), contributor: `u${i}` }));
+    render(<PayoutHistoryTable records={many} />);
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+  });
+
+  it('advances to page 2 when Next is clicked', async () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ ...paidRecord, id: String(i), contributor: `user${i}` }));
+    render(<PayoutHistoryTable records={many} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+  });
+
+  it('Next button disabled on last page', async () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ ...paidRecord, id: String(i), contributor: `u${i}` }));
+    render(<PayoutHistoryTable records={many} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+  });
+
+  it('page announcement region has aria-live=polite', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ ...paidRecord, id: String(i), contributor: `u${i}` }));
+    render(<PayoutHistoryTable records={many} />);
+    const region = screen.getByText(/Page \d+ of \d+/);
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('each data row is keyboard-focusable (tabIndex=0)', () => {
+    render(<PayoutHistoryTable records={[paidRecord, pendingRecord]} />);
+    const rows = screen.getAllByRole('row').filter((r) => r.getAttribute('tabindex') === '0');
+    expect(rows.length).toBe(2);
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  TopContributorsModule                                                     */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe('TopContributorsModule', () => {
+  it('renders the module heading', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByText('Top Contributors')).toBeInTheDocument();
+  });
+
+  it('renders an ordered list with aria-label', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByRole('list', { name: 'Top contributors by earnings' })).toBeInTheDocument();
+  });
+
+  it('renders all contributor usernames', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('carol')).toBeInTheDocument();
+  });
+
+  it('renders earned amounts with XLM suffix', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByText('1,240 XLM')).toBeInTheDocument();
+    expect(screen.getByText('980 XLM')).toBeInTheDocument();
+  });
+
+  it('renders rank badges with aria-label', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByLabelText('Rank 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rank 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rank 3')).toBeInTheDocument();
+  });
+
+  it('renders trend "up" with correct aria-label', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByLabelText('Rank improved by 2')).toBeInTheDocument();
+  });
+
+  it('renders trend "down" with correct aria-label', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByLabelText('Rank dropped by 1')).toBeInTheDocument();
+  });
+
+  it('renders trend "same" with correct aria-label', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    expect(screen.getByLabelText('Rank unchanged')).toBeInTheDocument();
+  });
+
+  it('caps list at 5 even when more are provided', () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      rank: i + 1, username: `user${i}`, totalEarned: 100 * (8 - i),
+      trend: 'same' as const, trendValue: 0,
+    }));
+    render(<TopContributorsModule contributors={many} />);
+    expect(screen.getAllByRole('listitem').length).toBe(5);
+  });
+
+  it('renders "View all" link with descriptive aria-label', () => {
+    const onNavigate = vi.fn();
+    render(<TopContributorsModule contributors={mockContributors} onNavigateToLeaderboard={onNavigate} />);
+    const link = screen.getByRole('link', { name: 'View all contributors on leaderboard' });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('calls onNavigateToLeaderboard when "View all" is clicked', async () => {
+    const onNavigate = vi.fn();
+    render(<TopContributorsModule contributors={mockContributors} onNavigateToLeaderboard={onNavigate} />);
+    await userEvent.click(screen.getByRole('link', { name: 'View all contributors on leaderboard' }));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows empty state when contributors is empty', () => {
+    render(<TopContributorsModule contributors={[]} />);
+    expect(screen.getByText('No contributor data yet')).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons when isLoading is true', () => {
+    render(<TopContributorsModule contributors={[]} isLoading />);
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('each list item is keyboard-focusable (tabIndex=0)', () => {
+    render(<TopContributorsModule contributors={mockContributors} />);
+    const items = screen.getAllByRole('listitem').filter((el) => el.getAttribute('tabindex') === '0');
+    expect(items.length).toBe(mockContributors.length);
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/*  AnalyticsTab (composition + period filter)                                */
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe('AnalyticsTab', () => {
+  it('renders all three module headings', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    expect(screen.getByText('Conversion Funnel')).toBeInTheDocument();
+    expect(screen.getByText('Top Contributors')).toBeInTheDocument();
+    expect(screen.getByText('Payout History')).toBeInTheDocument();
+  });
+
+  it('renders all four period filter buttons', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    expect(screen.getByRole('button', { name: 'Filter by Last 7 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filter by Last 30 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filter by Last 90 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filter by All time' })).toBeInTheDocument();
+  });
+
+  it('period filter group has role="group" with aria-label', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    expect(screen.getByRole('group', { name: 'Analytics time period' })).toBeInTheDocument();
+  });
+
+  it('"Last 30 days" is active (aria-pressed=true) by default', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    const btn = screen.getByRole('button', { name: 'Filter by Last 30 days' });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('inactive period buttons have aria-pressed=false', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    const btn = screen.getByRole('button', { name: 'Filter by Last 7 days' });
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking a period button makes it active', async () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    const btn = screen.getByRole('button', { name: 'Filter by Last 7 days' });
+    await userEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clicking a period button deactivates the previous selection', async () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Filter by Last 7 days' }));
+    const prev = screen.getByRole('button', { name: 'Filter by Last 30 days' });
+    expect(prev).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onNavigateToLeaderboard when "View all" link is clicked', async () => {
+    const onNavigate = vi.fn();
+    render(<AnalyticsTab selectedProjects={mockProjects} onNavigateToLeaderboard={onNavigate} />);
+    await userEvent.click(screen.getByRole('link', { name: 'View all contributors on leaderboard' }));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows skeletons for all three modules when isLoadingProjects=true', () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} isLoadingProjects />);
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('period filter buttons are keyboard-activatable', async () => {
+    render(<AnalyticsTab selectedProjects={mockProjects} />);
+    const btn = screen.getByRole('button', { name: 'Filter by All time' });
+    btn.focus();
+    await userEvent.keyboard(' ');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/src/features/maintainers/pages/MaintainersPage.tsx
+++ b/frontend/src/features/maintainers/pages/MaintainersPage.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Plus, Settings as SettingsIcon, AlertCircle,
 import { useTheme } from "../../../shared/contexts/ThemeContext";
 import { SkeletonLoader } from "../../../shared/components/SkeletonLoader";
 import { DashboardTab } from "../components/dashboard/DashboardTab";
+import { AnalyticsTab } from "../components/dashboard/AnalyticsTab";
 import { IssuesTab } from "../components/issues/IssuesTab";
 import { PullRequestsTab } from "../components/pull-requests/PullRequestsTab";
 import { TabType } from "../types";
@@ -80,7 +81,7 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
     return `https://github.com/${owner}.png?size=${size}`;
   };
 
-  const tabs: TabType[] = ["Dashboard", "Issues", "Pull Requests"];
+  const tabs: TabType[] = ["Dashboard", "Issues", "Pull Requests", "Analytics"];
 
   // Fetch pending setup projects (for New Project Setup modal after GitHub App install)
   const loadPendingSetup = async () => {
@@ -576,6 +577,14 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
       )}
 
       {activeTab === "Pull Requests" && <PullRequestsTab selectedProjects={selectedProjects} onRefresh={refreshAll} />}
+
+      {activeTab === "Analytics" && (
+        <AnalyticsTab
+          selectedProjects={selectedProjects}
+          isLoadingProjects={isLoading}
+          onNavigateToLeaderboard={() => onNavigate("leaderboard")}
+        />
+      )}
 
       {/* Install GitHub App Modal */}
       <InstallGitHubAppModal isOpen={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} onSuccess={refreshAll} />

--- a/frontend/src/features/maintainers/types/index.ts
+++ b/frontend/src/features/maintainers/types/index.ts
@@ -106,7 +106,41 @@ export interface PullRequest {
 export type PRFilterType = "All states" | "Open" | "Merged" | "Closed" | "Draft";
 
 // Remove Waves from TabType
-export type TabType = "Dashboard" | "Issues" | "Pull Requests";
+export type TabType = "Dashboard" | "Issues" | "Pull Requests" | "Analytics";
+
+/** Analytics date-range filter periods */
+export type AnalyticsPeriod = "7d" | "30d" | "90d" | "all";
+
+/** One stage of the bounty conversion funnel */
+export interface FunnelStage {
+  name: string;
+  value: number;
+  fill: string;
+}
+
+/** Payout status values */
+export type PayoutStatus = "paid" | "pending" | "processing" | "failed";
+
+/** One row in the payout history table */
+export interface PayoutRecord {
+  id: string;
+  date: string;           // ISO 8601
+  contributor: string;    // GitHub username
+  avatarUrl?: string;
+  repository: string;     // "org/repo"
+  amount: number;         // in XLM
+  status: PayoutStatus;
+}
+
+/** One entry in the top-contributors module */
+export interface TopContributor {
+  rank: number;
+  username: string;
+  avatarUrl?: string;
+  totalEarned: number;    // in XLM
+  trend: "up" | "down" | "same";
+  trendValue: number;     // absolute rank delta
+}
 
 // Shared types
 export interface Repository {


### PR DESCRIPTION
Closes #1509

## Summary

Adds a consolidated **Analytics** tab to `MaintainersPage.tsx` with three scoped bounty analytics modules: a Recharts conversion funnel, a payout history table, and a top-contributors leaderboard.

---

## Changes

| File | Type | Description |
|---|---|---|
| `design/specs/maintainers-bounty-analytics-dashboard.md` | New | Full design spec: funnel, table, leaderboard layouts, contrast table, keyboard walkthrough |
| `BountyFunnelChart.tsx` | New | 4-stage Recharts FunnelChart + sr-only accessible data table |
| `PayoutHistoryTable.tsx` | New | Paginated payout table with status pills, mobile card-list, skeleton |
| `TopContributorsModule.tsx` | New | Top-5 ranked contributors with trend indicators and View all link |
| `AnalyticsTab.tsx` | New | Composes all three modules with period filter |
| `types/index.ts` | Updated | Add `Analytics` to `TabType`; add `PayoutRecord`, `TopContributor`, `FunnelStage` interfaces |
| `MaintainersPage.tsx` | Updated | Wire Analytics tab |
| `__tests__/AnalyticsTab.test.tsx` | New | 42 tests |

---

## Funnel — 4 Stages

| Stage | Color | Token |
|---|---|---|
| Applied | Gold | `#c9983a` (primary.600) |
| Assigned | Blue | `#3b82f6` (semantic.info.500) |
| Submitted | Amber | `#f59e0b` (semantic.warning.500) |
| Paid | Green | `#22c55e` (semantic.success.500) |

Each stage uses label + color — never color-only (WCAG 1.4.1). Chart is `aria-hidden`; a `sr-only` `<table>` exposes the same data to screen readers.

---

## Payout History Table

- Columns: Date, Contributor, Repository, Amount, Status
- Status pills: Paid / Pending / Processing / Failed — each with `role="status"` + `aria-label`
- Loading: StatsCardSkeleton-style skeleton rows
- Mobile (< 768px): table replaced by vertical card list
- Pagination: 10 rows/page, `aria-live="polite"` page announcement

---

## Top Contributors Module

- Rank badges: gold (#1), silver (#2), bronze (#3), neutral (#4-5)
- Trend: TrendingUp / TrendingDown / Minus with aria-labels
- "View all" link navigates to leaderboard with pre-applied earnings filter
- Capped at 5 entries

---

## Period Filter

Four pill toggles (Last 7 days / Last 30 days / Last 90 days / All time) with `aria-pressed` state. Group has `role="group" aria-label="Analytics time period"`. Default: Last 30 days.

---

## Accessibility

- All contrast pairs verified >= 4.5:1 against dark glass surface
- Keyboard walkthrough: Tab through period filter, funnel sr-only table, contributor list, View all link, payout table rows, pagination
- Focus ring: `outline: 2px solid #f1b400` throughout

---

## Responsive

- 1024px and above: funnel (60%) + contributors (40%) side-by-side, table full-width below
- 768-1023px: modules stack vertically
- Below 768px: table becomes card list

---

## Testing

42 test cases across BountyFunnelChart, PayoutHistoryTable, TopContributorsModule, and AnalyticsTab covering ARIA attributes, keyboard interaction, pagination, empty/loading states, and period filter toggle.

---

## Backward Compatibility

All new props are optional. Existing Dashboard / Issues / Pull Requests tabs are unchanged.
