### PR TITLE
design: MaintainersPage bounty analytics dashboard (#1509)

### DIFF
--- a/frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/PayoutHistoryTable.tsx
@@ -315,16 +315,22 @@ export function PayoutHistoryTable({
         </table>
       </div>
 
-      {/* ── Mobile card list ── */}
+      {/* ── Mobile card list (aria-hidden: the <table> above is the accessible source of truth) ── */}
       {isLoading ? (
         <SkeletonCards />
       ) : pageRecords.length === 0 ? (
-        <div className={`md:hidden flex flex-col items-center py-10 gap-3 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+        <div
+          aria-hidden="true"
+          className={`md:hidden flex flex-col items-center py-10 gap-3 ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}
+        >
           <DollarSign className="w-10 h-10 opacity-30" aria-hidden />
           <p className="text-[13px]">No payouts yet</p>
         </div>
       ) : (
-        <ul className="md:hidden space-y-3 mt-2" aria-label="Payout history">
+        <ul
+          aria-hidden="true"
+          className="md:hidden space-y-3 mt-2"
+        >
           {pageRecords.map((r) => (
             <PayoutCard key={r.id} record={r} isDark={isDark} />
           ))}

--- a/frontend/src/features/maintainers/components/dashboard/__tests__/AnalyticsTab.test.tsx
+++ b/frontend/src/features/maintainers/components/dashboard/__tests__/AnalyticsTab.test.tsx
@@ -174,17 +174,21 @@ describe('PayoutHistoryTable', () => {
 
   it('renders contributor name', () => {
     render(<PayoutHistoryTable records={[paidRecord]} />);
-    expect(screen.getByText('alice')).toBeInTheDocument();
+    // The table is the accessible source of truth; mobile cards are aria-hidden
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('alice')).toBeInTheDocument();
   });
 
   it('renders amount with XLM suffix', () => {
     render(<PayoutHistoryTable records={[paidRecord]} />);
-    expect(screen.getByText('250 XLM')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('250 XLM')).toBeInTheDocument();
   });
 
   it('renders repository name', () => {
     render(<PayoutHistoryTable records={[paidRecord]} />);
-    expect(screen.getByText('StelloPay/frontend')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('StelloPay/frontend')).toBeInTheDocument();
   });
 
   it('renders "Paid" status pill with role=status', () => {
@@ -210,7 +214,9 @@ describe('PayoutHistoryTable', () => {
 
   it('shows empty state when records is empty', () => {
     render(<PayoutHistoryTable records={[]} />);
-    expect(screen.getByText('No payouts yet')).toBeInTheDocument();
+    // Empty state lives inside the table (mobile fallback is aria-hidden)
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('No payouts yet')).toBeInTheDocument();
   });
 
   it('shows skeleton rows when isLoading is true', () => {


### PR DESCRIPTION
## Summary

Closes #1509

Implements the consolidated **Analytics** tab on `MaintainersPage` with a 4-stage conversion funnel, payout history table, and top-contributors leaderboard module — all WCAG 2.1 AA compliant, fully tested, and spec-documented.

---

## Components Added

| File | Description |
|---|---|
| `BountyFunnelChart.tsx` | Recharts `FunnelChart` — Applied, Assigned, Submitted, Paid — with sr-only data-table alternative |
| `PayoutHistoryTable.tsx` | Paginated table (date, contributor, repository, amount, status) + mobile card-list below 768px |
| `TopContributorsModule.tsx` | Ranked top-5 list with gold/silver/bronze badges, trend indicators, "View all" leaderboard link |
| `AnalyticsTab.tsx` | Composes all three modules with a 4-button period filter (7d / 30d / 90d / all) |

## Files Updated

| File | Change |
|---|---|
| `types/index.ts` | Added `TabType`, `AnalyticsPeriod`, `FunnelStage`, `PayoutRecord`, `TopContributor` |
| `MaintainersPage.tsx` | Wired Analytics tab to `AnalyticsTab` component |
| `design/specs/maintainers-bounty-analytics-dashboard.md` | Full spec: contrast ratios, keyboard walkthrough, responsive breakpoints, component map |
| `PayoutHistoryTable.tsx` | Added `aria-hidden` to mobile card-list (table is the semantic source of truth) |
| `AnalyticsTab.test.tsx` | Scoped 4 table tests to `within(table)` — fixes 8 failing tests, 51/51 now pass |

---

## Accessibility (WCAG 2.1 AA)

- **Funnel:** chart wrapped in `aria-hidden`; data exposed via `sr-only` table with `aria-label="Bounty conversion funnel data"`
- **Payout table:** `role="table"`, `scope="col"` headers, each row `tabIndex={0}`, status pills `role="status" aria-label`, pagination `aria-live="polite"`
- **Top contributors:** `<ol aria-label>`, rank badges `aria-label="Rank N"`, trend icons carry descriptive `aria-label`
- **Period filter:** `role="group" aria-label`, each button `aria-pressed` + `aria-label="Filter by ..."`
- **Focus ring:** `focus:ring-2 focus:ring-[#f1b400]` on all interactive elements
- **Mobile:** card-list is `aria-hidden` (visual only); table is the accessible source

## Contrast (dark theme, verified)

| Element | Ratio | Result |
|---|---|---|
| Funnel labels `#f5f5f5` | 18.1:1 | AA |
| Status pill "Paid" `#22c55e` | 5.2:1 | AA |
| Status pill "Pending" `#f59e0b` | 4.7:1 | AA |
| Status pill "Processing" `#3b82f6` | 4.6:1 | AA |
| Status pill "Failed" `#ef4444` | 4.6:1 | AA |
| Amount gold `#c9983a` | 4.7:1 | AA |

## Responsive Breakpoints

- **>= 1024px:** funnel + contributors side-by-side (3fr / 2fr), full-width table below
- **768px to 1023px:** funnel full-width, contributors below, then table
- **< 768px:** all stacked; table hidden, card-list shown (`hidden md:block` / `md:hidden`)

## Keyboard Walkthrough

1. Tab to Analytics tab, Enter activates
2. Tab to period filter buttons, Space selects
3. Tab enters funnel sr-only table (screen reader reads each cell)
4. Tab through Top Contributors list items (each `li` has `tabIndex={0}`)
5. Tab to "View all" link, Enter navigates to leaderboard
6. Tab through Payout History table rows (each `tr` has `tabIndex={0}`)
7. Tab to Previous / Next pagination buttons

## Test Results

```
Test Files  1 passed (1)
     Tests  51 passed (51)
```
