### PR TITLE
test: document actual duplicate-registration behavior in grainlify-co…

### DIFF
--- a/contracts/grainlify-core/src/test_contract_registry.rs
+++ b/contracts/grainlify-core/src/test_contract_registry.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{ContractKind, GrainlifyContract, GrainlifyContractClient};
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env, String};
 
     fn setup(env: &Env) -> (GrainlifyContractClient, Address) {
         let id = env.register_contract(None, GrainlifyContract);
@@ -326,5 +326,265 @@ mod tests {
         let _ = client.list_deployed_contracts(&None, &None);
         let addr = make_address(&env);
         let _ = client.get_deployed_contract(&addr);
+    }
+
+    // -----------------------------------------------------------------------
+    // Duplicate-registration semantics (issue documentation tests)
+    //
+    // These tests explicitly establish and document what grainlify-core does
+    // when register_deployed_contract is called twice with the same address.
+    //
+    // Observed behaviour: UPDATE-IN-PLACE
+    //   - The DeployedContractIndex (ordered address list) is NOT extended.
+    //   - The DeployedContractEntry storage slot IS overwritten with the new
+    //     name / kind / version / deployed_at values.
+    //   - deployed_contract_count() returns the same value before and after
+    //     the re-registration call.
+    //
+    // This is in contrast to view-facade::register, which performs an
+    // unconditional push_back and therefore CREATES DUPLICATE entries.
+    //
+    // See docs/registry-duplicate-semantics-comparison.md for the full
+    // side-by-side comparison and the follow-up alignment issue flag.
+    // -----------------------------------------------------------------------
+
+    /// Re-registering the same address does NOT increase the count.
+    ///
+    /// This is the primary behavioural invariant: grainlify-core is
+    /// update-in-place, not duplicate-appending.
+    #[test]
+    fn test_reregister_same_address_count_unchanged() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name1 = make_string(&env, "escrow-v1");
+        let name2 = make_string(&env, "escrow-v2");
+
+        client.register_deployed_contract(&addr, &name1, &ContractKind::BountyEscrow, &1);
+        // Precondition: one entry exists.
+        assert_eq!(
+            client.deployed_contract_count(),
+            1,
+            "count must be 1 after first registration"
+        );
+
+        // Re-register the same address with different metadata.
+        client.register_deployed_contract(&addr, &name2, &ContractKind::ProgramEscrow, &2);
+
+        // DOCUMENTED BEHAVIOUR: count stays at 1 (update-in-place, no duplicate).
+        assert_eq!(
+            client.deployed_contract_count(),
+            1,
+            "count must remain 1 after re-registration of the same address \
+             (grainlify-core uses update-in-place, not duplicate-append)"
+        );
+    }
+
+    /// Re-registering overwrites name, kind and version in the stored entry.
+    ///
+    /// The entry returned by get_deployed_contract reflects the values from
+    /// the most recent register_deployed_contract call.
+    #[test]
+    fn test_reregister_same_address_overwrites_metadata() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name_v1 = make_string(&env, "my-escrow-v1");
+        let name_v2 = make_string(&env, "my-escrow-v2");
+
+        client.register_deployed_contract(&addr, &name_v1, &ContractKind::BountyEscrow, &1);
+        client.register_deployed_contract(&addr, &name_v2, &ContractKind::ProgramEscrow, &99);
+
+        let entry = client
+            .get_deployed_contract(&addr)
+            .expect("entry must exist after re-registration");
+
+        // DOCUMENTED BEHAVIOUR: latest values win.
+        assert_eq!(entry.name, name_v2, "name must reflect the second registration");
+        assert_eq!(
+            entry.kind,
+            ContractKind::ProgramEscrow,
+            "kind must reflect the second registration"
+        );
+        assert_eq!(entry.version, 99, "version must reflect the second registration");
+        assert_eq!(
+            entry.address, addr,
+            "address field in the entry must match the registered address"
+        );
+    }
+
+    /// Re-registering updates deployed_at to the timestamp of the latest call.
+    ///
+    /// The overwrite replaces the entire DeployedContract struct, including
+    /// deployed_at, so the second call's ledger timestamp wins.
+    #[test]
+    fn test_reregister_same_address_updates_deployed_at() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name = make_string(&env, "timed");
+
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &1);
+        let first_deployed_at = client
+            .get_deployed_contract(&addr)
+            .expect("must exist")
+            .deployed_at;
+
+        // Advance ledger time so the two calls have different timestamps.
+        env.ledger().with_mut(|li| {
+            li.timestamp += 100;
+        });
+
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &2);
+        let second_deployed_at = client
+            .get_deployed_contract(&addr)
+            .expect("must exist after re-registration")
+            .deployed_at;
+
+        // DOCUMENTED BEHAVIOUR: deployed_at is refreshed on overwrite.
+        assert!(
+            second_deployed_at > first_deployed_at,
+            "re-registration must update deployed_at (second={} must be > first={})",
+            second_deployed_at,
+            first_deployed_at
+        );
+    }
+
+    /// The index (insertion-order address list) does not gain a second entry
+    /// for the same address. list_deployed_contracts returns the address
+    /// exactly once.
+    #[test]
+    fn test_reregister_same_address_appears_once_in_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name = make_string(&env, "dedup-check");
+
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &1);
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &2);
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &3);
+
+        let list = client.list_deployed_contracts(&None, &None);
+
+        // DOCUMENTED BEHAVIOUR: address appears exactly once in the list.
+        let occurrences = list.iter().filter(|e| e.address == addr).count();
+        assert_eq!(
+            occurrences,
+            1,
+            "address must appear exactly once in list after three re-registrations \
+             (grainlify-core uses update-in-place, not duplicate-append)"
+        );
+    }
+
+    /// Registering N distinct addresses then re-registering each once
+    /// results in exactly N entries — not 2*N.
+    #[test]
+    fn test_reregister_many_addresses_no_count_inflation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        const N: u32 = 5;
+        let mut addrs = soroban_sdk::Vec::new(&env);
+
+        for i in 0..N {
+            let addr = make_address(&env);
+            let name = make_string(&env, "c");
+            addrs.push_back(addr.clone());
+            client.register_deployed_contract(&addr, &name, &ContractKind::Other, &i);
+        }
+
+        assert_eq!(
+            client.deployed_contract_count(),
+            N,
+            "count must equal N after N distinct registrations"
+        );
+
+        // Re-register every address once with a new version.
+        for i in 0..N {
+            let addr = addrs.get(i).unwrap();
+            let name = make_string(&env, "c-updated");
+            client.register_deployed_contract(&addr, &name, &ContractKind::Other, &(i + 100));
+        }
+
+        // DOCUMENTED BEHAVIOUR: count must still be N, not 2*N.
+        assert_eq!(
+            client.deployed_contract_count(),
+            N,
+            "count must remain N after re-registering all N addresses once \
+             (grainlify-core uses update-in-place)"
+        );
+    }
+
+    /// Re-registering an address that was subsequently deregistered results
+    /// in a fresh insertion (count goes up), not an update-in-place of the
+    /// deleted entry.
+    #[test]
+    fn test_register_after_deregister_creates_new_entry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name = make_string(&env, "lifecycle");
+
+        // First registration.
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &1);
+        assert_eq!(client.deployed_contract_count(), 1);
+
+        // Deregister removes the entry entirely.
+        client.deregister_deployed_contract(&addr);
+        assert_eq!(client.deployed_contract_count(), 0);
+        assert!(client.get_deployed_contract(&addr).is_none());
+
+        // Second registration after deregister is treated as a fresh insert.
+        client.register_deployed_contract(&addr, &name, &ContractKind::Other, &2);
+        assert_eq!(
+            client.deployed_contract_count(),
+            1,
+            "re-registering after deregister must create a single fresh entry"
+        );
+        let entry = client.get_deployed_contract(&addr).unwrap();
+        assert_eq!(entry.version, 2, "entry must reflect the post-deregister version");
+    }
+
+    /// Verify that re-registration with a different ContractKind is reflected
+    /// correctly — ensures the kind field is not frozen at first-registration.
+    #[test]
+    fn test_reregister_kind_change_is_visible() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let addr = make_address(&env);
+        let name = make_string(&env, "kind-change");
+
+        for kind in [
+            ContractKind::BountyEscrow,
+            ContractKind::ProgramEscrow,
+            ContractKind::SorobanEscrow,
+            ContractKind::GrainlifyCore,
+            ContractKind::ViewFacade,
+            ContractKind::Other,
+        ] {
+            client.register_deployed_contract(&addr, &name, &kind, &1);
+            let stored = client
+                .get_deployed_contract(&addr)
+                .expect("entry must exist");
+            assert_eq!(
+                stored.kind, kind,
+                "kind must update immediately after re-registration"
+            );
+            // Count must never exceed 1 regardless of how many re-registrations.
+            assert_eq!(client.deployed_contract_count(), 1);
+        }
     }
 }

--- a/docs/registry-duplicate-semantics-comparison.md
+++ b/docs/registry-duplicate-semantics-comparison.md
@@ -1,0 +1,220 @@
+# Registry Duplicate-Registration Semantics: grainlify-core vs view-facade
+
+> **Status**: Documentation only — no behaviour changes in this document.  
+> **Follow-up**: See [Inconsistency Flag](#inconsistency-flag--follow-up-alignment-issue) at the bottom.
+
+---
+
+## Background
+
+The Grainlify protocol contains two independently implemented contract registries:
+
+| Contract | File | Entry-point |
+|---|---|---|
+| `grainlify-core` | `contracts/grainlify-core/src/lib.rs` | `register_deployed_contract` |
+| `view-facade` | `contracts/view-facade/src/lib.rs` | `register` |
+
+Both registries accept an `(address, kind, version)` tuple and store it in
+instance storage. They diverge in what happens when the **same address is
+submitted a second time** (duplicate registration).
+
+This document establishes the **observed, test-verified** behaviour of each
+registry so that consumers, integrators, and future maintainers understand the
+contracts without having to re-read and re-derive the behaviour from source.
+
+---
+
+## Side-by-Side Comparison
+
+| Aspect | `grainlify-core` | `view-facade` |
+|---|---|---|
+| **Duplicate strategy** | **Update-in-place** | **Duplicate-append** |
+| **Index grows on re-registration?** | ❌ No | ✅ Yes |
+| **Entry data overwritten?** | ✅ Yes (name, kind, version, deployed_at) | ✅ Yes (new entry pushed; old entry stays) |
+| **`count()` after re-registration** | Unchanged (same as before) | Incremented by 1 |
+| **Address appears in list N times after N calls?** | No — exactly once always | Yes — N times |
+| **`get_*(address)` after re-registration** | Returns latest metadata | Returns **first** match (oldest metadata) |
+| **Storage key for entry** | `DeployedContractEntry(Address)` — keyed by address | `Registry` Vec — appended to sequentially |
+| **Storage key for index** | `DeployedContractIndex` Vec — not extended on duplicate | `Registry` Vec — always extended |
+| **Cap enforcement on re-registration** | Cap check skipped for existing address | Cap check applies regardless |
+| **Admin auth required** | ✅ Yes | ✅ Yes |
+| **Read-only mode guard** | ✅ Yes | N/A (no read-only mode in view-facade) |
+| **Module-level doc claim** | Not documented in module doc | Claims update-in-place ("updated, not duplicated") |
+| **Function-level doc note** | No note (behaviour implied by code) | `# Note` warns duplicates ARE created |
+| **Test-verified?** | ✅ Yes — see `test_contract_registry.rs` | ⚠️ Partial — existing tests do not explicitly assert duplicate counts |
+
+---
+
+## Detailed Behaviour: grainlify-core
+
+### Source location
+`contracts/grainlify-core/src/lib.rs` — function `register_deployed_contract`
+
+### Logic (simplified)
+
+```rust
+let existed = env.storage().instance()
+    .has(&DataKey::DeployedContractEntry(address.clone()));
+
+if !existed {
+    // Only push to the ordered index on first registration.
+    if index.len() >= MAX_DEPLOYED_CONTRACTS {
+        panic!("Registry full");
+    }
+    index.push_back(address.clone());
+}
+
+// Always write the entry — overwrites on re-registration.
+let entry = DeployedContract { address, name, kind, version, deployed_at: now };
+env.storage().instance()
+    .set(&DataKey::DeployedContractEntry(address), &entry);
+env.storage().instance()
+    .set(&DataKey::DeployedContractIndex, &index);
+```
+
+### Consequences
+
+- `DeployedContractEntry(addr)` is keyed per-address — only one slot exists per address.
+- `DeployedContractIndex` is the ordered list of addresses; it is only extended for genuinely new addresses.
+- `deployed_contract_count()` reads `DeployedContractIndex.len()` — unchanged by re-registration.
+- `get_deployed_contract(addr)` always returns the latest values after any number of re-registrations.
+- `list_deployed_contracts()` iterates the index, so each address appears exactly once.
+
+### Verified tests (contracts/grainlify-core/src/test_contract_registry.rs)
+
+| Test | What it proves |
+|---|---|
+| `test_reregister_same_address_count_unchanged` | count does not increase on re-registration |
+| `test_reregister_same_address_overwrites_metadata` | name/kind/version reflect the latest call |
+| `test_reregister_same_address_updates_deployed_at` | deployed_at is refreshed |
+| `test_reregister_same_address_appears_once_in_list` | address appears exactly once in list |
+| `test_reregister_many_addresses_no_count_inflation` | N re-registrations never inflate count beyond N |
+| `test_register_after_deregister_creates_new_entry` | deregister + re-register = fresh entry, count = 1 |
+| `test_reregister_kind_change_is_visible` | every ContractKind change is immediately reflected |
+
+---
+
+## Detailed Behaviour: view-facade
+
+### Source location
+`contracts/view-facade/src/lib.rs` — function `register`
+
+### Logic (simplified)
+
+```rust
+let mut registry: Vec<RegisteredContract> = env.storage().instance()
+    .get(&DataKey::Registry)
+    .unwrap_or(Vec::new(&env));
+
+// Cap check applies to every call, including re-registration.
+if registry.len() >= MAX_REGISTRY_SIZE {
+    return Err(FacadeError::RegistryFull);
+}
+
+// Unconditional push — no duplicate guard.
+registry.push_back(RegisteredContract { address, kind, version });
+
+env.storage().instance().set(&DataKey::Registry, &registry);
+```
+
+### Consequences
+
+- `Registry` is a flat `Vec<RegisteredContract>` — there is no secondary index keyed by address.
+- Every call appends a new element regardless of whether the address already exists.
+- `contract_count()` returns `Registry.len()`, which **increments** on every `register` call.
+- `get_contract(addr)` performs an `O(n)` linear scan and returns the **first** (oldest) match.
+  After N re-registrations there are N entries for the same address; `get_contract` returns
+  the one pushed earliest.
+- `list_contracts()` / `list_contracts_all()` return all entries including duplicates.
+
+### Documentation inconsistency within the file
+
+The **module-level doc** (top of `lib.rs`) states:
+
+> "When `register` is called with an address that is already in the registry,
+> the existing entry is **updated** (not duplicated) with the new `kind` and
+> `version` values."
+
+The **function-level `# Note`** (on `register` itself) contradicts this:
+
+> "Registering the same address multiple times will create duplicate entries.
+> Callers should call `get_contract` first to check for an existing entry, or
+> `deregister` before re-registering with updated metadata."
+
+**The code matches the `# Note`** — duplicates are created. The module-level
+description is incorrect.
+
+---
+
+## Inconsistency Flag — Follow-up Alignment Issue
+
+> ⚠️ **This section flags a candidate for a follow-up issue.**
+>
+> This document's scope is limited to establishing and documenting current
+> behaviour. **No behaviour changes are made here.**
+
+### Summary of inconsistencies discovered
+
+1. **view-facade module doc vs code**: The module-level doc claims update-in-place;
+   the code creates duplicates. The function-level `# Note` is accurate.
+
+2. **grainlify-core vs view-facade runtime behaviour**: The two registries behave
+   opposite to each other under duplicate registration. Consumers that interact
+   with both registries may write code that assumes a shared contract and receive
+   surprising results.
+
+3. **Absence of deduplication test coverage in view-facade**: The existing
+   `contracts/view-facade/src/test.rs` does not include a test that asserts
+   duplicate counts after two `register` calls with the same address. The
+   duplicate-creating behaviour is therefore undocumented at the test level.
+
+### Proposed follow-up issue
+
+**Title**: Align duplicate-registration semantics between grainlify-core and
+view-facade (or document the divergence as intentional)
+
+**Scope**:
+- Decide canonical duplicate policy: update-in-place vs duplicate-append
+- If update-in-place is chosen: patch `view-facade::register` to check for
+  existing entries before pushing, and correct the module doc
+- If duplicate-append is chosen: update `grainlify-core` to match and correct
+  both sets of doc comments
+- If intentionally divergent: update both module docs to explicitly state the
+  chosen policy and the rationale for the difference
+- Add explicit duplicate-registration tests to `view-facade/src/test.rs`
+  mirroring those added to `test_contract_registry.rs`
+
+---
+
+## Storage Architecture Comparison
+
+```
+grainlify-core
+───────────────────────────────────────────────────────────────
+  Instance storage:
+    DeployedContractIndex  →  Vec<Address>          (ordered; no duplicates)
+    DeployedContractEntry(addr)  →  DeployedContract  (one slot per address)
+
+  Re-registration:  overwrites DeployedContractEntry; index unchanged
+  Lookup:           O(1) via DeployedContractEntry(addr)
+  List:             iterates DeployedContractIndex, fetches each entry
+
+view-facade
+───────────────────────────────────────────────────────────────
+  Instance storage:
+    Registry  →  Vec<RegisteredContract>  (flat list; may contain duplicates)
+
+  Re-registration:  appends new element to Registry
+  Lookup:           O(n) linear scan; returns first (oldest) match
+  List:             returns Registry slice directly (may include duplicates)
+```
+
+---
+
+## References
+
+- `contracts/grainlify-core/src/lib.rs` — `register_deployed_contract`, `deregister_deployed_contract`
+- `contracts/grainlify-core/src/test_contract_registry.rs` — full test suite including new duplicate-semantics tests
+- `contracts/view-facade/src/lib.rs` — `register`, `deregister`, `get_contract`, `list_contracts`
+- `contracts/view-facade/src/test.rs` — existing view-facade tests
+- `contracts/view-facade/DUPLICATE_REGISTRATION_POLICY.md` — prior policy discussion


### PR DESCRIPTION
…re's contract registry

- Add 7 tests to test_contract_registry.rs establishing that register_deployed_contract uses update-in-place semantics:
  * test_reregister_same_address_count_unchanged
  * test_reregister_same_address_overwrites_metadata
  * test_reregister_same_address_updates_deployed_at
  * test_reregister_same_address_appears_once_in_list
  * test_reregister_many_addresses_no_count_inflation
  * test_register_after_deregister_creates_new_entry
  * test_reregister_kind_change_is_visible

- Add docs/registry-duplicate-semantics-comparison.md with a side-by-side comparison table of grainlify-core (update-in-place) vs view-facade (duplicate-append) duplicate-registration behavior.

- Flag discovered inconsistencies for a follow-up alignment issue:
  1. view-facade module-level doc claims update-in-place but code creates duplicates (function-level # Note is accurate).
  2. The two registries behave opposite to each other at runtime.
  3. view-facade lacks explicit duplicate-count tests.

No behavior changes. Scope limited to establishing and documenting current behavior as required by issue #1497.

Closes #1497