### PR TITLE
perf: replace quadratic duplicate-id check in batch_initialize_programs (#1474)

### DIFF
--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -150,6 +150,8 @@ mod errors;
 pub use errors::BatchPayoutError;
 use errors::ContractError;
 
+mod gas_optimization;
+
 mod metadata;
 pub use metadata::{
     CompressedCustomField, CompressedProgramMetadata, MetadataFieldKey,
@@ -2748,11 +2750,14 @@ impl ProgramEscrowContract {
         if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
             return Err(BatchError::InvalidBatchSizeProgram);
         }
-        for i in 0..batch_size {
-            for j in (i + 1)..batch_size {
-                if items.get(i).unwrap().program_id == items.get(j).unwrap().program_id {
-                    return Err(BatchError::DuplicateProgramId);
-                }
+        {
+            let mut program_ids: soroban_sdk::Vec<String> = soroban_sdk::Vec::new(&env);
+            for i in 0..batch_size {
+                program_ids.push_back(items.get(i).unwrap().program_id.clone());
+            }
+            let deduped = gas_optimization::deduplicate_program_ids(&env, &program_ids);
+            if deduped.len() < program_ids.len() {
+                return Err(BatchError::DuplicateProgramId);
             }
         }
         for i in 0..batch_size {

--- a/contracts/program-escrow/src/test_batch_operations.rs
+++ b/contracts/program-escrow/src/test_batch_operations.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{testutils::Address as _, testutils::Events, token, vec, Addres
 
 use crate::{
     BatchError, BatchPayoutReplayedEvent, LockItem, ProgramData, ProgramEscrowContract,
-    ProgramEscrowContractClient, ReleaseItem,
+    ProgramEscrowContractClient, ProgramInitItem, ReleaseItem,
 };
 
 pub struct Ctx<'a> {
@@ -937,4 +937,130 @@ fn test_batch_payout_by_over_max_returns_batch_too_large() {
         "expected BatchError::BatchTooLarge, got: {:?}",
         result
     );
+}
+
+// ============================================================================
+// batch_initialize_programs duplicate-id detection tests (issue #1474)
+// ============================================================================
+
+/// Adjacent duplicate program_ids are rejected.
+#[test]
+fn test_batch_init_duplicate_adjacent_ids_rejected() {
+    let ctx = setup();
+    let items = vec![
+        &ctx.env,
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "PROG_A"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "PROG_A"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+    ];
+    let res = ctx.client.try_batch_initialize_programs(&items);
+    assert!(matches!(res, Err(Ok(BatchError::DuplicateProgramId))));
+}
+
+/// Non-adjacent duplicate program_ids at start and end are rejected.
+#[test]
+fn test_batch_init_duplicate_non_adjacent_ids_rejected() {
+    let ctx = setup();
+    let items = vec![
+        &ctx.env,
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "PROG_A"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "PROG_B"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "PROG_A"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+    ];
+    let res = ctx.client.try_batch_initialize_programs(&items);
+    assert!(matches!(res, Err(Ok(BatchError::DuplicateProgramId))));
+}
+
+/// Duplicate buried in the middle of a larger batch is rejected.
+#[test]
+fn test_batch_init_duplicate_middle_of_batch_rejected() {
+    let ctx = setup();
+    let items = vec![
+        &ctx.env,
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "P1"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "P2"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "P3"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "P2"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+    ];
+    let res = ctx.client.try_batch_initialize_programs(&items);
+    assert!(matches!(res, Err(Ok(BatchError::DuplicateProgramId))));
+}
+
+/// All-unique program_ids in a batch of 5 succeeds.
+#[test]
+fn test_batch_init_all_unique_ids_succeeds() {
+    let ctx = setup();
+    let ids = ["A", "B", "C", "D", "E"];
+    let items: soroban_sdk::Vec<ProgramInitItem> = ids.iter().fold(soroban_sdk::Vec::new(&ctx.env), |mut v, id| {
+        v.push_back(ProgramInitItem {
+            program_id: String::from_str(&ctx.env, id),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        });
+        v
+    });
+    let result = ctx.client.try_batch_initialize_programs(&items);
+    assert!(result.is_ok(), "All-unique batch should succeed");
+}
+
+/// Single-element batch (no duplicates possible) succeeds.
+#[test]
+fn test_batch_init_single_element_succeeds() {
+    let ctx = setup();
+    let items = vec![
+        &ctx.env,
+        ProgramInitItem {
+            program_id: String::from_str(&ctx.env, "ONLY"),
+            authorized_payout_key: ctx.admin.clone(),
+            token_address: ctx.token_id.clone(),
+            reference_hash: None,
+        },
+    ];
+    let result = ctx.client.try_batch_initialize_programs(&items);
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
Closes #1474

## Changes

Replaces the O(n²) nested-loop duplicate `program_id` check in `batch_initialize_programs` with a sort-then-adjacent-compare approach by reusing the existing `deduplicate_program_ids` function from `gas_optimization.rs`.

### What changed
- **`contracts/program-escrow/src/lib.rs`**: Added `mod gas_optimization;` declaration and replaced the nested `for i / for j` loop with a call to `gas_optimization::deduplicate_program_ids()`. If the deduplicated list is shorter than the original, duplicates exist and `BatchError::DuplicateProgramId` is returned.
- **`contracts/program-escrow/src/test_batch_operations.rs`**: Added 5 new tests confirming duplicates are caught in any position:
  - Adjacent duplicates
  - Non-adjacent duplicates (first and last)
  - Duplicates buried in the middle of a larger batch
  - All-unique batch succeeds
  - Single-element batch succeeds

### Behavior preserved
- Exact same `BatchError::DuplicateProgramId` rejection on duplicates
- No change to function signature or return type
- No change to other batch operations