### PR TITLE
test: add privacy-leak regression coverage for anonymous-lock query paths

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -2717,6 +2717,10 @@ impl BountyEscrowContract {
     }
 
     /// Return the escrow data for a given bounty_id. Returns an error if not found.
+    ///
+    /// Anonymization-aware: only reads `DataKey::Escrow`, never `DataKey::EscrowAnon`,
+    /// so a bounty locked via `lock_funds_anonymous` returns `BountyNotFound` here rather
+    /// than any depositor-bearing record. See `docs/anonymous-lock-privacy.md`.
     pub fn get_escrow_info(env: Env, bounty_id: u64) -> Result<Escrow, Error> {
         env.storage()
             .persistent()
@@ -5799,6 +5803,10 @@ impl BountyEscrowContract {
 
     /// Get the metadata for a bounty. Returns a default (all-zero) record if
     /// no metadata has been written yet.
+    ///
+    /// Anonymization-aware: `EscrowMetadata` has no depositor-identifying field,
+    /// so this is safe to call for anonymously-locked bounties before resolution.
+    /// See `docs/anonymous-lock-privacy.md`.
     pub fn get_metadata(env: Env, bounty_id: u64) -> EscrowMetadata {
         env.storage()
             .persistent()
@@ -9294,6 +9302,10 @@ mod test_e2e_upgrade_with_pause;
 #[cfg(test)]
 mod test_status_transitions;
 // #[cfg(test)] mod test_upgrade_scenarios;
+
+/// Privacy-leak regression tests for anonymous-lock query paths (issue #1466).
+#[cfg(test)]
+mod test_anonymization;
 
 #[cfg(test)]
 #[path = "tests/conversion_tests.rs"]

--- a/contracts/bounty_escrow/contracts/escrow/src/test_anonymization.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_anonymization.rs
@@ -1,0 +1,146 @@
+//! Regression tests for privacy leaks on the *read* paths of anonymous escrows.
+//!
+//! `lock_funds_anonymous` is meant to shield the depositor's identity until
+//! `refund_resolved` is driven by the configured `AnonymousResolver`. These tests
+//! guard the query surface (`get_escrow_info`, `get_metadata`, and the raw
+//! storage layout) against ever exposing that identity before resolution.
+//!
+//! This suite deliberately does not touch `set_anonymous_resolver` /
+//! `refund_resolved` correctness itself (tracked separately) — it only asserts
+//! that the *query* paths stay blind to the depositor pre-resolution, and that
+//! the resolver-driven path is the sole way identity becomes visible.
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, token, BytesN, Env};
+
+fn create_token<'a>(e: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
+    let contract = e.register_stellar_asset_contract_v2(admin.clone());
+    token::StellarAssetClient::new(e, &contract.address())
+}
+
+/// Spins up an initialized contract plus a funded depositor ready to call
+/// `lock_funds_anonymous`.
+fn setup(env: &Env) -> (BountyEscrowContractClient<'_>, Address, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let depositor = Address::generate(env);
+    let recipient = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_client = create_token(env, &token_admin);
+    let token_admin_address = token_client.address.clone();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(env, &contract_id);
+    client.init(&admin, &token_admin_address);
+    token_client.mint(&depositor, &10_000_000);
+
+    (client, admin, depositor, recipient)
+}
+
+/// `get_escrow_info` must never return the depositor for an anonymously-locked
+/// bounty prior to resolution: the anon record lives under `DataKey::EscrowAnon`,
+/// which `get_escrow_info` does not consult, so the call must fail closed
+/// (`BountyNotFound`) rather than fall back to any address-bearing record.
+#[test]
+fn test_get_escrow_info_does_not_leak_depositor_for_anonymous_lock() {
+    let env = Env::default();
+    let (client, _admin, depositor, _recipient) = setup(&env);
+
+    let bounty_id = 1u64;
+    let commitment = BytesN::from_array(&env, &[7u8; 32]);
+    let deadline = env.ledger().timestamp() + 1_000;
+    client.lock_funds_anonymous(&depositor, &commitment, &bounty_id, &1_000i128, &deadline);
+
+    let result = client.try_get_escrow_info(&bounty_id);
+    assert!(
+        result.is_err(),
+        "get_escrow_info must not resolve an anonymous bounty before refund_resolved"
+    );
+}
+
+/// `get_metadata` carries no depositor-identifying field at all; confirm it
+/// keeps returning the plain default record for an anonymously-locked bounty
+/// that never had `update_metadata` called on it, i.e. no identity data is
+/// implicitly attached to metadata storage during an anonymous lock.
+#[test]
+fn test_get_metadata_has_no_identity_for_anonymous_lock() {
+    let env = Env::default();
+    let (client, _admin, depositor, _recipient) = setup(&env);
+
+    let bounty_id = 2u64;
+    let commitment = BytesN::from_array(&env, &[9u8; 32]);
+    let deadline = env.ledger().timestamp() + 1_000;
+    client.lock_funds_anonymous(&depositor, &commitment, &bounty_id, &1_000i128, &deadline);
+
+    let meta = client.get_metadata(&bounty_id);
+    assert_eq!(meta.repo_id, 0);
+    assert_eq!(meta.issue_id, 0);
+    assert_eq!(meta.bounty_type, soroban_sdk::String::from_str(&env, ""));
+    assert_eq!(meta.reference_hash, None);
+}
+
+/// Storage-layout guard: `lock_funds_anonymous` must persist only the
+/// `EscrowAnon` variant (32-byte commitment) and must never also create a
+/// `DataKey::Escrow` entry (which stores a plain `Address`) or add the
+/// depositor to `DataKey::DepositorIndex` — the index that a future
+/// `query_escrows_by_depositor` implementation would read. Either would leak
+/// the depositor through a path this suite doesn't otherwise exercise.
+#[test]
+fn test_anonymous_lock_writes_only_commitment_no_address_indexes() {
+    let env = Env::default();
+    let (client, _admin, depositor, _recipient) = setup(&env);
+
+    let bounty_id = 3u64;
+    let commitment = BytesN::from_array(&env, &[3u8; 32]);
+    let deadline = env.ledger().timestamp() + 1_000;
+    client.lock_funds_anonymous(&depositor, &commitment, &bounty_id, &1_000i128, &deadline);
+
+    env.as_contract(&client.address, || {
+        assert!(
+            !env.storage().persistent().has(&DataKey::Escrow(bounty_id)),
+            "anonymous lock must not create an address-bearing Escrow record"
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .has(&DataKey::EscrowAnon(bounty_id)),
+            "anonymous lock must create the commitment-only EscrowAnon record"
+        );
+        let depositor_index: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DepositorIndex(depositor.clone()))
+            .unwrap_or(Vec::new(&env));
+        assert!(
+            !depositor_index.contains(&bounty_id),
+            "anonymous lock must not link the depositor to the bounty via DepositorIndex"
+        );
+    });
+}
+
+/// End-to-end: identity stays hidden from `get_escrow_info` through the whole
+/// pre-resolution lifetime, and only the resolver-driven `refund_resolved`
+/// call (post-deadline) can move funds to a chosen recipient. That recipient
+/// is the intended point where identity becomes visible — not any query call.
+#[test]
+fn test_identity_hidden_until_resolver_driven_refund() {
+    let env = Env::default();
+    let (client, admin, depositor, recipient) = setup(&env);
+
+    let bounty_id = 4u64;
+    let commitment = BytesN::from_array(&env, &[5u8; 32]);
+    let deadline = env.ledger().timestamp() + 1_000;
+    client.lock_funds_anonymous(&depositor, &commitment, &bounty_id, &1_000i128, &deadline);
+
+    // Pre-resolution: still hidden.
+    assert!(client.try_get_escrow_info(&bounty_id).is_err());
+
+    // Resolver is configured by the admin, then drives the refund.
+    client.set_anonymous_resolver(&Some(admin.clone()));
+    env.ledger().set_timestamp(deadline + 1);
+    client.refund_resolved(&bounty_id, &recipient);
+
+    // Identity became visible only through the recipient of this call, not
+    // through get_escrow_info, which still has nothing to return for this id.
+    assert!(client.try_get_escrow_info(&bounty_id).is_err());
+}

--- a/contracts/bounty_escrow/docs/anonymous-lock-privacy.md
+++ b/contracts/bounty_escrow/docs/anonymous-lock-privacy.md
@@ -1,0 +1,42 @@
+# Anonymous-lock privacy: query-path audit
+
+`lock_funds_anonymous` shields a depositor's identity: it stores only a
+32-byte `depositor_commitment` under `DataKey::EscrowAnon(bounty_id)` and never
+persists the depositor's `Address` on-chain. Identity is meant to stay hidden
+until the configured `AnonymousResolver` calls `refund_resolved`.
+
+This document tracks which **read/query** functions on `BountyEscrowContract`
+are anonymization-aware (safe to call on an anonymously-locked bounty before
+resolution) and which are not. Regression coverage lives in
+`src/test_anonymization.rs`.
+
+## Anonymization-aware (safe pre-resolution)
+
+| Function | Why it's safe |
+|---|---|
+| `get_escrow_info` | Only reads `DataKey::Escrow`. An anonymous lock never writes that key (it writes `DataKey::EscrowAnon` instead), so this returns `Error::BountyNotFound` for an anonymous bounty rather than any address-bearing record. |
+| `get_metadata` | `EscrowMetadata` has no depositor field at all (`repo_id`, `issue_id`, `bounty_type`, `risk_flags`, `notification_prefs`, `reference_hash`). There is nothing in this record that could carry depositor identity, regardless of lock mode. |
+| Raw storage layout | `lock_funds_anonymous` does not add the depositor to `DataKey::DepositorIndex(Address)` — the per-depositor index populated by `lock_funds` / `batch_lock_funds` / recurring locks. This index only ever links a depositor to their *non-anonymous* bounties. |
+
+## Not implemented (out of scope for this audit)
+
+| Function | Status |
+|---|---|
+| `query_escrows_by_depositor` | **Not currently implemented** on `BountyEscrowContract`. The `DataKey::DepositorIndex` storage it would read exists and is written by the non-anonymous lock paths, but no public contract method exposes a lookup over it yet. Several test files in this crate (`test_query_filters.rs`, `test_compatibility.rs`, `test_analytics_monitoring.rs`) reference a method of this name; none of them are wired into `lib.rs`'s `mod` list, so they do not currently compile or run. When this query is implemented, it **must not** read from a data source that includes anonymous bounty ids — the invariant enforced by `test_anonymous_lock_writes_only_commitment_no_address_indexes` (that `lock_funds_anonymous` never touches `DepositorIndex`) is what keeps a future implementation of this query honest, and should be preserved. |
+
+## Resolution path (the only intended identity-reveal point)
+
+Identity for an anonymous escrow becomes observable only through
+`refund_resolved(bounty_id, recipient)`, callable exclusively by the address
+set via `set_anonymous_resolver` (admin-only). The `recipient` supplied there
+is the sole point at which a real address gets associated with the bounty.
+This is exercised end-to-end by
+`test_identity_hidden_until_resolver_driven_refund`.
+
+## Coordination note
+
+This audit is scoped to the *read* paths only (issue #1466). It intentionally
+does not re-verify `set_anonymous_resolver` / `refund_resolved` write-path
+correctness — at the time of writing both are implemented (see
+`src/lib.rs`) and covered by their own tests; that logic is tracked and
+reviewed separately to avoid duplicating effort.


### PR DESCRIPTION
## Summary
- `get_escrow_info` only reads `DataKey::Escrow`, never `DataKey::EscrowAnon`, so it already fails closed (`BountyNotFound`) for anonymously-locked bounties instead of returning any depositor-bearing record.
- `get_metadata` / `EscrowMetadata` carry no depositor field at all, so there's nothing to leak there regardless of lock mode.
- `lock_funds_anonymous` never writes `DataKey::DepositorIndex`, so a depositor can't be linked to an anonymous bounty via that index either.
- Added `contracts/bounty_escrow/contracts/escrow/src/test_anonymization.rs` with regression tests locking in all three properties, plus an end-to-end test showing identity only becomes visible via the resolver-driven `refund_resolved` recipient, never through a query call.
- Added `contracts/bounty_escrow/docs/anonymous-lock-privacy.md` documenting which query functions are anonymization-aware.
- Noted (but did not implement) that `query_escrows_by_depositor` referenced by several pre-existing test files (`test_query_filters.rs`, `test_compatibility.rs`, `test_analytics_monitoring.rs`) isn't actually implemented on `BountyEscrowContract` — those files aren't wired into `lib.rs`'s `mod` list and don't currently compile/run, so they're out of scope here.
- Does not touch `set_anonymous_resolver` / `refund_resolved` write-path logic itself — both already exist and are covered separately, per the issue's ask to coordinate with, not duplicate, that work.

## Test plan
- [ ] `cargo test -p bounty-escrow` (could not be run in the environment this PR was prepared in — no MSVC Build Tools / GNU linker available, only the `wasm32v1-none`/`x86_64-pc-windows-msvc` Rust targets; please run in CI or a machine with a working toolchain)
- [ ] Confirm `test_anonymization` module compiles and all four new tests pass
- [ ] Spot-check that `get_escrow_info` / `get_metadata` doc comments read correctly

Closes #1466