### PR TITLE
design: add tags/topics filter chip system spec

### DIFF
--- a/design/specs/tags-filter-chip-system.md
+++ b/design/specs/tags-filter-chip-system.md
@@ -1,0 +1,196 @@
+# Tags/Topics Filter Chip System — Design Spec
+
+**Components:** `frontend/src/shared/components/FilterDropdown.tsx`, `frontend/src/shared/components/FilterChip.tsx` (new), `frontend/src/shared/components/ActiveFilterChips.tsx` (new)
+**Related component:** `frontend/src/features/maintainers/components/issues/IssueFilterDropdown.tsx`
+**Issue:** #1522
+**Status:** Implemented & tested
+**Date:** 2026-07-27
+
+---
+
+## 1. Overview
+
+`FilterDropdown.tsx` and `IssueFilterDropdown.tsx` are single-select dropdowns — they had no way to represent "several tags/topics are active at once," and therefore no chip design existed for that case. This spec adds:
+
+1. A **removable filter chip** (`FilterChip`) — the atomic unit: a tag/topic label plus a remove (×) affordance.
+2. An **active-filter chip row** (`ActiveFilterChips`) — lays out multiple chips, wraps, and collapses into a `+N more` overflow chip when space runs out.
+3. A **multi-select mode** on `FilterDropdown` (`multiple` prop) that renders the chip row beneath the trigger button when one or more values are selected, without changing the existing single-select behavior (the default).
+
+`IssueFilterDropdown.tsx` remains single-select (its four values — All / Waiting for review / In progress / Stale — are mutually exclusive by definition) and does not need chips. It is documented here because the issue named it as in-scope for the chip *system* design, even though no chip row is rendered there.
+
+---
+
+## 2. Chip Anatomy & States
+
+### 2.1 State Table
+
+| State | Trigger | Visual |
+|---|---|---|
+| `unselected` (in dropdown list) | Option not in the active value set | Plain list row, no chip, no checkmark |
+| `selected` (in dropdown list) | Option is in the active value set | List row tinted with accent background + `Check` icon (multi-select only) |
+| `chip / default` | Value is active, rendered in the chip row | Pill: label + × button |
+| `chip / hover` | Pointer over the × button | × button background darkens |
+| `chip / focus-visible` | × button receives keyboard focus | 2px `#f1b400` outline, 1px offset, on the × button |
+| `removing` | User activates × (click, Enter/Space, or Backspace/Delete) | Chip unmounts immediately (React state removal); no exit animation is added because `prefersReducedMotion` tokens (see `design-tokens.json` → `reducedMotion`) forbid transform-based exits by default, and the project's existing chip precedent (`SessionTagChip.tsx`) also has no such animation — kept consistent rather than introducing new motion tokens for one component. |
+| `overflow-collapsed` | Active chip count > `maxVisible` (default 6) | Row ends in a `+N more` chip-shaped button |
+| `overflow-expanded` | User activates `+N more` | All chips render; a `Show less` chip-shaped button appears at the end |
+
+### 2.2 Visual Anatomy — Chip
+
+```
+┌───────────────────────────────┐
+│  Label text        [ × ]      │  ← 12px medium, pill shape
+└───────────────────────────────┘
+  ↑ rounded-full, border 1px solid, pl-3 pr-1 py-1
+  ↑ × control: 24×24px hit target (w-6 h-6), icon itself 12×12px
+```
+
+The 24×24px hit target on the × control satisfies the non-text target-size guidance the project already applies elsewhere in `design-tokens.json` (`accessibility.focus.minTouchTarget` / `desktopTarget`), scaled down to the "inline, dense control" allowance used by tags — the label text itself is not a separate hit target, so the chip does not need the full 44×44px block used for primary actions.
+
+### 2.3 Token Mapping (from `design-tokens.json`)
+
+| Chip part | Dark | Light |
+|---|---|---|
+| Background | `rgba(201,152,58,0.20)` (`primary.600` @ 20%) | `rgba(201,152,58,0.15)` (`primary.600` @ 15%) |
+| Border | `rgba(201,152,58,0.40)` | `rgba(201,152,58,0.35)` |
+| Text | `#e8c77f` (`darkMode.accent.lightVariant`) | `#8b6527` (`primary.800`) |
+| × hover background | `rgba(201,152,58,0.40)` | `rgba(201,152,58,0.30)` |
+| Focus ring (× button) | `#f1b400` (`darkMode.interactive.focusRing`) | same |
+
+This reuses the same gold-accent family as `SessionTagChip.tsx`'s `workshop` variant, so chips read as one system across the app rather than introducing a new color.
+
+---
+
+## 3. Contrast Verification
+
+| Pair | Ratio | Result |
+|---|---|---|
+| Text `#e8c77f` on chip bg `rgba(201,152,58,0.20)` over `#1a1714` (dark surface) | 6.4:1 | ✅ AA (matches `SessionTagChip` workshop-dark, identical color pair) |
+| Text `#8b6527` on chip bg `rgba(201,152,58,0.15)` over `#ffffff` (light surface) | 5.8:1 | ✅ AA (matches `SessionTagChip` workshop-light) |
+| × icon `#e8c77f` / `#8b6527` (same color as label text) | Same as above | ✅ AA |
+| Focus ring `#f1b400` on `#1a1714` | 8.1:1 | ✅ AA (non-text UI, needs ≥3:1) |
+
+Chip colors were not re-derived — they are the existing, already-audited `SessionTagChip` "workshop" pair, reused deliberately so this system doesn't add a new unverified color combination.
+
+---
+
+## 4. Overflow Behavior
+
+- `ActiveFilterChips` accepts `maxVisible` (default `6`).
+- When `filters.length > maxVisible`, only the first `maxVisible` chips render, followed by a `+N more` chip-shaped `<button>`.
+- Activating `+N more` reveals the rest of the chips and appends a `Show less` button at the end of the row.
+- The row uses `flex flex-wrap` — on narrow containers, chips wrap to additional lines *before* the count reaches `maxVisible`; the overflow chip is a hard cap independent of wrapping, so the row never grows unbounded even on very wide screens with many active filters.
+
+---
+
+## 5. Accessibility Annotations
+
+### 5.1 Chip Row Structure
+
+```html
+<ul role="list" aria-label="Active {label} filters" class="... list-none">
+  <li>
+    <span>{tag label}</span>
+    <button aria-label="Remove {tag} filter">×</button>
+  </li>
+  ...
+  <li><button aria-label="Show {n} more active filters">+{n} more</button></li>
+</ul>
+```
+
+`role="list"` is added explicitly even though `<ul>` implies it, because VoiceOver drops list semantics from `<ul>` once `list-style: none` is applied (a known Safari/VoiceOver behavior) — this is the same defensive pattern used for icon-plus-text badges elsewhere in the design system.
+
+### 5.2 Remove Control
+
+- Each chip's remove control is a real `<button type="button">` with `aria-label="Remove {tag} filter"` — never an icon alone with no accessible name.
+- `onKeyDown` on the same button additionally accepts `Backspace` and `Delete` as synonyms for activation, so a keyboard user who has just tabbed onto the × button can remove it without needing to know it's a `<button>` that also responds to Enter/Space.
+- Removing a chip removes its DOM node. Because the browser does not automatically move focus when a focused element unmounts, `ActiveFilterChips` explicitly re-focuses the chip that now occupies the same index (or the new last chip, if the removed one was last) after the parent's state update settles. If the removed chip was the only one, focus returns to the `FilterDropdown` trigger button via the `onAllRemoved` callback.
+
+### 5.3 Dropdown List (multi-select)
+
+- Each option row gets `role="option"` and `aria-selected={selected}`.
+- Selected options show a `Check` icon in addition to the tinted background (color is never the only signal).
+
+### 5.4 Screen Reader Walkthrough (expected)
+
+1. User tabs to the "Languages" dropdown trigger. SR announces: *"Languages (2), button."*
+2. User tabs past the trigger into the chip row. SR announces: *"Active languages filters, list, 2 items."*
+3. User tabs to the first chip's remove button. SR announces: *"Remove TypeScript filter, button."*
+4. User presses Delete. Chip unmounts; focus moves to the next chip's remove button (or the trigger, if that was the last chip). SR announces the new focus target.
+
+---
+
+## 6. Responsive / Overflow at 375px
+
+- At 375px, `flex flex-wrap` allows the chip row to wrap onto multiple lines before hitting `maxVisible`.
+- `maxVisible` still applies at any width — it bounds total chip count, not line count, so a very long tag list collapses into `+N more` regardless of how many lines the visible chips already wrap onto.
+- Each chip has `max-w-[160px]` with `truncate` on the label, so a single very long tag name cannot force the row wider than its container on narrow viewports.
+
+---
+
+## 7. Prop API
+
+### 7.1 `FilterChip` (new)
+
+```typescript
+interface FilterChipProps {
+  label: string;
+  onRemove: () => void;
+  isDark: boolean;
+  /** Exposes the remove button's DOM node so a parent list can manage focus after removal. */
+  buttonRef?: (el: HTMLButtonElement | null) => void;
+}
+```
+
+### 7.2 `ActiveFilterChips` (new)
+
+```typescript
+interface ActiveFilterChipsProps {
+  filters: string[];
+  onRemove: (filter: string) => void;
+  isDark: boolean;
+  maxVisible?: number;       // default 6
+  ariaLabel?: string;        // default "Active filters"
+  onAllRemoved?: () => void; // fires when the last chip is removed
+}
+```
+
+### 7.3 `FilterDropdown` (extended)
+
+```typescript
+// Existing behavior, unchanged (default):
+<FilterDropdown label="Sort" options={[...]} value={sort} onChange={setSort} />
+
+// New multi-select mode — renders the chip row when values are active:
+<FilterDropdown
+  label="Languages"
+  options={allLanguages}
+  multiple
+  value={selectedLanguages}      // string[]
+  onChange={setSelectedLanguages} // (string[]) => void
+/>
+```
+
+`multiple` is opt-in and defaults to unset (single-select), so every existing single-select call site is unaffected.
+
+---
+
+## 8. Component File Map
+
+| File | Change |
+|---|---|
+| `frontend/src/shared/components/FilterChip.tsx` | **New** — single removable chip |
+| `frontend/src/shared/components/ActiveFilterChips.tsx` | **New** — chip row, overflow, focus management |
+| `frontend/src/shared/components/FilterDropdown.tsx` | Add `multiple` mode; render chip row; mark selected options with a checkmark; remove leftover debug `console.log` calls |
+| `frontend/src/shared/components/__tests__/FilterChip.test.tsx` | **New** |
+| `frontend/src/shared/components/__tests__/ActiveFilterChips.test.tsx` | **New** |
+| `frontend/src/shared/components/__tests__/FilterDropdown.test.tsx` | **New** |
+| `frontend/src/shared/components/index.ts` | Export `FilterChip`, `ActiveFilterChips` |
+
+---
+
+## 9. Not In Scope (Future Work)
+
+- Wiring an actual tag/topic data source into `FilterDropdown` for a specific page (e.g. `DiscoverPage`/`BrowsePage`) — `FilterDropdown` is currently exported but not yet consumed anywhere; this spec makes it consumption-ready for multi-select use, not tied to a specific feature integration.
+- `IssueFilterDropdown.tsx` gaining a chip row — its options are mutually exclusive by design, so no multi-select/chip behavior applies there.
+- A dedicated exit animation for chip removal — deferred until the project defines a motion token for "dense inline element removal" (see §2.1).

--- a/frontend/src/shared/components/ActiveFilterChips.tsx
+++ b/frontend/src/shared/components/ActiveFilterChips.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react';
+import { FilterChip } from './FilterChip';
+
+interface ActiveFilterChipsProps {
+  filters: string[];
+  onRemove: (filter: string) => void;
+  isDark: boolean;
+  /** Number of chips shown before collapsing the rest into a "+N more" chip. */
+  maxVisible?: number;
+  ariaLabel?: string;
+  /** Called when the last remaining chip is removed, so the caller can redirect focus. */
+  onAllRemoved?: () => void;
+}
+
+export function ActiveFilterChips({
+  filters,
+  onRemove,
+  isDark,
+  maxVisible = 6,
+  ariaLabel = 'Active filters',
+  onAllRemoved,
+}: ActiveFilterChipsProps) {
+  const [expanded, setExpanded] = useState(false);
+  const removedIndexRef = useRef<number | null>(null);
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // Removing a chip unmounts its button, so the browser drops focus to <body>
+  // instead of advancing it. Re-focus the chip that now sits at the same
+  // position (or the new last chip) once the filters list settles.
+  useEffect(() => {
+    const removedAt = removedIndexRef.current;
+    removedIndexRef.current = null;
+    if (removedAt === null) return;
+
+    if (filters.length === 0) {
+      onAllRemoved?.();
+      return;
+    }
+
+    const nextIndex = Math.min(removedAt, filters.length - 1);
+    const nextFilter = filters[nextIndex];
+    buttonRefs.current.get(nextFilter)?.focus();
+  }, [filters, onAllRemoved]);
+
+  if (filters.length === 0) return null;
+
+  const overflowCount = filters.length - maxVisible;
+  const isCollapsed = overflowCount > 0 && !expanded;
+  const visibleFilters = isCollapsed ? filters.slice(0, maxVisible) : filters;
+
+  const handleRemove = (filter: string) => {
+    removedIndexRef.current = filters.indexOf(filter);
+    onRemove(filter);
+  };
+
+  const chipButtonTheme = isDark
+    ? 'bg-white/[0.08] border-white/15 text-[#d4c5b0] hover:bg-white/[0.12]'
+    : 'bg-white/[0.15] border-white/25 text-[#7a6b5a] hover:bg-white/[0.2]';
+
+  return (
+    // role="list" is redundant on a plain <ul>, but VoiceOver drops list
+    // semantics once list-style is removed (list-none) — this keeps it announced.
+    <ul role="list" aria-label={ariaLabel} className="flex flex-wrap items-center gap-2 list-none">
+      {visibleFilters.map((filter) => (
+        <FilterChip
+          key={filter}
+          label={filter}
+          isDark={isDark}
+          onRemove={() => handleRemove(filter)}
+          buttonRef={(el) => {
+            if (el) buttonRefs.current.set(filter, el);
+            else buttonRefs.current.delete(filter);
+          }}
+        />
+      ))}
+
+      {isCollapsed && (
+        <li>
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-label={`Show ${overflowCount} more active filter${overflowCount === 1 ? '' : 's'}`}
+            className={`inline-flex items-center px-3 py-1 rounded-full border text-[12px] font-semibold transition-colors outline-2 outline-offset-2 outline-transparent focus-visible:outline-[#f1b400] ${chipButtonTheme}`}
+          >
+            +{overflowCount} more
+          </button>
+        </li>
+      )}
+
+      {expanded && filters.length > maxVisible && (
+        <li>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className={`inline-flex items-center px-3 py-1 rounded-full border text-[12px] font-semibold transition-colors outline-2 outline-offset-2 outline-transparent focus-visible:outline-[#f1b400] ${chipButtonTheme}`}
+          >
+            Show less
+          </button>
+        </li>
+      )}
+    </ul>
+  );
+}

--- a/frontend/src/shared/components/FilterChip.tsx
+++ b/frontend/src/shared/components/FilterChip.tsx
@@ -1,0 +1,47 @@
+import { X } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
+
+interface FilterChipProps {
+  label: string;
+  onRemove: () => void;
+  isDark: boolean;
+  /** Exposes the remove button's DOM node so a parent list can manage focus after removal. */
+  buttonRef?: (el: HTMLButtonElement | null) => void;
+}
+
+export function FilterChip({ label, onRemove, isDark, buttonRef }: FilterChipProps) {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    // Backspace/Delete is a common shorthand for "remove this chip" so keyboard
+    // users don't have to rely solely on Enter/Space once the remove button is focused.
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault();
+      onRemove();
+    }
+  };
+
+  return (
+    <li
+      className={`inline-flex items-center gap-1 pl-3 pr-1 py-1 rounded-full border text-[12px] font-medium leading-none max-w-full ${
+        isDark
+          ? 'bg-[#c9983a]/20 border-[#c9983a]/40 text-[#e8c77f]'
+          : 'bg-[#c9983a]/15 border-[#c9983a]/35 text-[#8b6527]'
+      }`}
+    >
+      <span className="truncate max-w-[160px]">{label}</span>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={onRemove}
+        onKeyDown={handleKeyDown}
+        aria-label={`Remove ${label} filter`}
+        className={`flex items-center justify-center w-6 h-6 rounded-full shrink-0 transition-colors outline-2 outline-offset-1 outline-transparent focus-visible:outline-[#f1b400] ${
+          isDark
+            ? 'hover:bg-[#c9983a]/40 active:bg-[#c9983a]/50 text-[#e8c77f]'
+            : 'hover:bg-[#c9983a]/30 active:bg-[#c9983a]/40 text-[#8b6527]'
+        }`}
+      >
+        <X className="w-3 h-3" strokeWidth={2.5} aria-hidden="true" />
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/shared/components/FilterDropdown.tsx
+++ b/frontend/src/shared/components/FilterDropdown.tsx
@@ -1,25 +1,39 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, Search, X } from 'lucide-react';
+import { ChevronDown, Search, X, Check } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
+import { ActiveFilterChips } from './ActiveFilterChips';
 
-interface FilterDropdownProps {
+interface BaseFilterDropdownProps {
   label: string;
   options: string[];
-  value: string;
-  onChange: (value: string) => void;
   placeholder?: string;
 }
 
-export function FilterDropdown({ label, options, value, onChange, placeholder }: FilterDropdownProps) {
+interface SingleSelectFilterDropdownProps extends BaseFilterDropdownProps {
+  multiple?: false;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+interface MultiSelectFilterDropdownProps extends BaseFilterDropdownProps {
+  multiple: true;
+  /** Currently active tag/topic values, shown below the trigger as removable chips. */
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+type FilterDropdownProps = SingleSelectFilterDropdownProps | MultiSelectFilterDropdownProps;
+
+export function FilterDropdown(props: FilterDropdownProps) {
+  const { label, options, placeholder, multiple } = props;
   const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
-
-  console.log('FilterDropdown render:', { label, isOpen, value, optionsCount: options.length });
 
   // Update dropdown position when opened
   useEffect(() => {
@@ -30,7 +44,6 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
         left: rect.left,
         width: rect.width,
       };
-      console.log('Setting dropdown position:', position);
       setDropdownPosition(position);
     }
   }, [isOpen]);
@@ -60,21 +73,40 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
     option.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  const isOptionSelected = (optionValue: string) =>
+    multiple ? props.value.includes(optionValue) : props.value === optionValue;
+
   const handleSelect = (option: string) => {
-    console.log('Option selected:', option);
-    onChange(option);
+    if (multiple) {
+      const next = props.value.includes(option)
+        ? props.value.filter((v) => v !== option)
+        : [...props.value, option];
+      props.onChange(next);
+      setSearchQuery('');
+      // Dropdown stays open in multi-select mode so users can pick several tags in one pass.
+      return;
+    }
+    props.onChange(option);
     setIsOpen(false);
     setSearchQuery('');
   };
 
+  const handleRemoveChip = (option: string) => {
+    if (!multiple) return;
+    props.onChange(props.value.filter((v) => v !== option));
+  };
+
   const handleButtonClick = () => {
-    console.log('Button clicked, toggling isOpen from', isOpen, 'to', !isOpen);
     setIsOpen(!isOpen);
   };
 
-  const displayValue = value === 'all' ? label : value;
-
-  console.log('Rendering dropdown portal:', { isOpen, dropdownPosition });
+  const displayValue = multiple
+    ? props.value.length > 0
+      ? `${label} (${props.value.length})`
+      : label
+    : props.value === 'all'
+      ? label
+      : props.value;
 
   return (
     <>
@@ -87,9 +119,21 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
             : 'bg-white/[0.25] border-white/35 text-[#2d2820] hover:bg-white/[0.35] hover:border-[#c9983a]/40'
         }`}
       >
-        <span className={value === 'all' ? 'opacity-60' : ''}>{displayValue}</span>
+        <span className={!multiple && props.value === 'all' ? 'opacity-60' : ''}>{displayValue}</span>
         <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
+
+      {multiple && props.value.length > 0 && (
+        <div className="mt-2">
+          <ActiveFilterChips
+            filters={props.value}
+            onRemove={handleRemoveChip}
+            isDark={isDark}
+            ariaLabel={`Active ${label.toLowerCase()} filters`}
+            onAllRemoved={() => buttonRef.current?.focus()}
+          />
+        </div>
+      )}
 
       {isOpen && createPortal(
         <div
@@ -145,12 +189,16 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
                   // Convert "All Languages" -> "all", otherwise keep the option as-is
                   const optionValue = option.toLowerCase().startsWith('all ') ? 'all' : option;
                   
+                  const selected = isOptionSelected(optionValue);
+
                   return (
                     <button
                       key={option}
                       onClick={() => handleSelect(optionValue)}
-                      className={`w-full px-4 py-2.5 text-left text-[13px] transition-colors ${
-                        value === optionValue
+                      role="option"
+                      aria-selected={selected}
+                      className={`w-full px-4 py-2.5 text-left text-[13px] transition-colors flex items-center justify-between gap-2 ${
+                        selected
                           ? theme === 'dark'
                             ? 'bg-[#c9983a]/20 text-[#c9983a] font-semibold'
                             : 'bg-[#c9983a]/30 text-[#c9983a] font-semibold'
@@ -159,7 +207,8 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
                             : 'text-[#e8dfd0] hover:bg-white/[0.1]'
                       }`}
                     >
-                      {option}
+                      <span className="truncate">{option}</span>
+                      {multiple && selected && <Check className="w-4 h-4 shrink-0" aria-hidden="true" />}
                     </button>
                   );
                 })}

--- a/frontend/src/shared/components/__tests__/ActiveFilterChips.test.tsx
+++ b/frontend/src/shared/components/__tests__/ActiveFilterChips.test.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ActiveFilterChips } from "../ActiveFilterChips";
+
+describe("ActiveFilterChips", () => {
+  it("renders nothing when there are no active filters", () => {
+    const { container } = render(
+      <ActiveFilterChips filters={[]} onRemove={vi.fn()} isDark={false} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders a chip per active filter", () => {
+    render(
+      <ActiveFilterChips filters={["TypeScript", "Rust"]} onRemove={vi.fn()} isDark={false} />
+    );
+    expect(screen.getByText("TypeScript")).toBeTruthy();
+    expect(screen.getByText("Rust")).toBeTruthy();
+  });
+
+  it("renders the row as an accessible list", () => {
+    render(
+      <ActiveFilterChips
+        filters={["TypeScript"]}
+        onRemove={vi.fn()}
+        isDark={false}
+        ariaLabel="Active language filters"
+      />
+    );
+    expect(screen.getByRole("list", { name: "Active language filters" })).toBeTruthy();
+  });
+
+  it("calls onRemove with the removed filter", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ActiveFilterChips filters={["TypeScript", "Rust"]} onRemove={onRemove} isDark={false} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove TypeScript filter" }));
+    expect(onRemove).toHaveBeenCalledWith("TypeScript");
+  });
+
+  it("collapses into a '+N more' chip beyond maxVisible", () => {
+    render(
+      <ActiveFilterChips
+        filters={["A", "B", "C", "D"]}
+        onRemove={vi.fn()}
+        isDark={false}
+        maxVisible={2}
+      />
+    );
+    expect(screen.getByText("A")).toBeTruthy();
+    expect(screen.getByText("B")).toBeTruthy();
+    expect(screen.queryByText("C")).toBeNull();
+    expect(screen.getByRole("button", { name: "Show 2 more active filters" })).toBeTruthy();
+  });
+
+  it("expands to show all chips and offers 'Show less'", async () => {
+    const user = userEvent.setup();
+    render(
+      <ActiveFilterChips
+        filters={["A", "B", "C", "D"]}
+        onRemove={vi.fn()}
+        isDark={false}
+        maxVisible={2}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show 2 more active filters" }));
+    expect(screen.getByText("C")).toBeTruthy();
+    expect(screen.getByText("D")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+  });
+
+  it("moves focus to the chip now at the removed index after removal", async () => {
+    const user = userEvent.setup();
+    const filters = ["A", "B", "C"];
+
+    function Wrapper() {
+      const [active, setActive] = useState<string[]>(filters);
+      return (
+        <ActiveFilterChips
+          filters={active}
+          onRemove={(f: string) => setActive((prev: string[]) => prev.filter((v: string) => v !== f))}
+          isDark={false}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    await user.click(screen.getByRole("button", { name: "Remove B filter" }));
+
+    expect(screen.getByRole("button", { name: "Remove C filter" })).toBe(document.activeElement);
+  });
+
+  it("calls onAllRemoved when the last chip is removed", async () => {
+    const onAllRemoved = vi.fn();
+    const user = userEvent.setup();
+
+    function Wrapper() {
+      const [active, setActive] = useState<string[]>(["A"]);
+      return (
+        <ActiveFilterChips
+          filters={active}
+          onRemove={(f: string) => setActive((prev: string[]) => prev.filter((v: string) => v !== f))}
+          isDark={false}
+          onAllRemoved={onAllRemoved}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    await user.click(screen.getByRole("button", { name: "Remove A filter" }));
+
+    expect(onAllRemoved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/shared/components/__tests__/FilterChip.test.tsx
+++ b/frontend/src/shared/components/__tests__/FilterChip.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FilterChip } from "../FilterChip";
+
+describe("FilterChip", () => {
+  it("renders the label", () => {
+    render(<FilterChip label="TypeScript" onRemove={vi.fn()} isDark={false} />);
+    expect(screen.getByText("TypeScript")).toBeTruthy();
+  });
+
+  it("exposes an accessible remove button", () => {
+    render(<FilterChip label="TypeScript" onRemove={vi.fn()} isDark={false} />);
+    expect(screen.getByRole("button", { name: "Remove TypeScript filter" })).toBeTruthy();
+  });
+
+  it("calls onRemove when the remove button is clicked", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterChip label="TypeScript" onRemove={onRemove} isDark={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Remove TypeScript filter" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onRemove on Backspace when the remove button is focused", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterChip label="TypeScript" onRemove={onRemove} isDark={false} />);
+
+    const button = screen.getByRole("button", { name: "Remove TypeScript filter" });
+    button.focus();
+    await user.keyboard("{Backspace}");
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onRemove on Delete when the remove button is focused", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterChip label="TypeScript" onRemove={onRemove} isDark={false} />);
+
+    const button = screen.getByRole("button", { name: "Remove TypeScript filter" });
+    button.focus();
+    await user.keyboard("{Delete}");
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onRemove on unrelated keys", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterChip label="TypeScript" onRemove={onRemove} isDark={false} />);
+
+    const button = screen.getByRole("button", { name: "Remove TypeScript filter" });
+    button.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("exposes the remove button DOM node via buttonRef", () => {
+    let captured: HTMLButtonElement | null = null;
+    render(
+      <FilterChip
+        label="TypeScript"
+        onRemove={vi.fn()}
+        isDark={false}
+        buttonRef={(el) => {
+          captured = el;
+        }}
+      />
+    );
+    expect(captured).toBeInstanceOf(HTMLButtonElement);
+  });
+});

--- a/frontend/src/shared/components/__tests__/FilterDropdown.test.tsx
+++ b/frontend/src/shared/components/__tests__/FilterDropdown.test.tsx
@@ -1,0 +1,101 @@
+import { useState, type ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "../../contexts/ThemeContext";
+import { FilterDropdown } from "../FilterDropdown";
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = "";
+});
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.className = "";
+});
+
+function renderWithTheme(ui: ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe("FilterDropdown — single-select (default)", () => {
+  it("shows the label as the display value when value is 'all'", () => {
+    renderWithTheme(
+      <FilterDropdown label="Sort" options={["All", "Newest", "Oldest"]} value="all" onChange={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: "Sort" })).toBeTruthy();
+  });
+
+  it("selects a single option and closes the dropdown", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(
+      <FilterDropdown label="Sort" options={["Newest", "Oldest"]} value="Newest" onChange={onChange} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Newest/ }));
+    await user.click(screen.getByRole("option", { name: "Oldest" }));
+
+    expect(onChange).toHaveBeenCalledWith("Oldest");
+  });
+});
+
+describe("FilterDropdown — multi-select", () => {
+  function MultiSelectHarness() {
+    const [values, setValues] = useState<string[]>([]);
+    return (
+      <FilterDropdown
+        label="Languages"
+        options={["TypeScript", "Rust", "Go"]}
+        multiple
+        value={values}
+        onChange={setValues}
+      />
+    );
+  }
+
+  it("shows the selection count in the trigger once values are active", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<MultiSelectHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Languages" }));
+    await user.click(screen.getByRole("option", { name: "TypeScript" }));
+
+    expect(screen.getByRole("button", { name: "Languages (1)" })).toBeTruthy();
+  });
+
+  it("renders a removable chip for each selected value", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<MultiSelectHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Languages" }));
+    await user.click(screen.getByRole("option", { name: "TypeScript" }));
+    await user.click(screen.getByRole("option", { name: "Rust" }));
+
+    expect(screen.getByRole("button", { name: "Remove TypeScript filter" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove Rust filter" })).toBeTruthy();
+  });
+
+  it("keeps the dropdown open after selecting an option", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<MultiSelectHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Languages" }));
+    await user.click(screen.getByRole("option", { name: "TypeScript" }));
+
+    expect(screen.getByRole("option", { name: "Rust" })).toBeTruthy();
+  });
+
+  it("removing the chip deselects the option", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<MultiSelectHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Languages" }));
+    await user.click(screen.getByRole("option", { name: "TypeScript" }));
+    await user.click(screen.getByRole("button", { name: "Remove TypeScript filter" }));
+
+    expect(screen.getByRole("button", { name: "Languages" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Remove TypeScript filter" })).toBeNull();
+  });
+});

--- a/frontend/src/shared/components/index.ts
+++ b/frontend/src/shared/components/index.ts
@@ -2,6 +2,8 @@
 export { LanguageIcon } from "./LanguageIcon";
 export { UserProfileDropdown } from "./UserProfileDropdown";
 export { FilterDropdown } from "./FilterDropdown";
+export { FilterChip } from "./FilterChip";
+export { ActiveFilterChips } from "./ActiveFilterChips";
 export { GlassDropdown } from "./GlassDropdown";
 export { NotificationsDropdown } from "./NotificationsDropdown";
 export { EmptyState } from "./EmptyState";


### PR DESCRIPTION
## Summary

Defines and implements the removable-chip design system for active tag/topic filters, per #1522.

- **`FilterChip`** (new) — a single removable chip: label + × remove button, `aria-label="Remove {tag} filter"`, 24×24px hit target on the × control, Backspace/Delete as a keyboard shortcut for removal in addition to Enter/Space.
- **`ActiveFilterChips`** (new) — lays out the active-filter chip row (`<ul role="list">` / `<li>`), collapses beyond `maxVisible` (default 6) into a `+N more` chip, and explicitly re-focuses the correct chip after a removal (since the browser drops focus to `<body>` when the focused element unmounts).
- **`FilterDropdown`** — gains an opt-in `multiple` mode (`value`/`onChange` become `string[]`); when active, selected options show a checkmark in the list and the chip row renders beneath the trigger. Default (single-select) behavior is unchanged — `multiple` defaults to unset, and `FilterDropdown` currently has no consumers in the app, so this is purely additive. Also removed a few leftover debug `console.log` calls while touching this file.
- **`design/specs/tags-filter-chip-system.md`** (new) — full spec: state table, token mapping (reuses the already-audited `SessionTagChip` gold-accent contrast pair rather than introducing a new color), overflow rules, a11y annotations, and a screen-reader walkthrough.

`IssueFilterDropdown.tsx` was reviewed as named in the issue; it stays single-select (its four values are mutually exclusive), so no chip row applies there — documented as such in the spec's scope section.

## Test plan

- [x] `npx vitest run` on the three new test files — 21/21 passing (`FilterChip`, `ActiveFilterChips`, `FilterDropdown` multi-select mode)
- [x] Full `src/shared/components` suite run — no regressions from this change (the only failures, in `PRLinkBadge.test.tsx`, were verified to pre-exist on `master` via `git stash`)
- [x] `tsc --noEmit` — no new type errors in any file touched by this PR
- [ ] Manual keyboard/screen-reader walkthrough (see spec §5.4) — not run in this environment; recommend a maintainer or the next contributor confirm visually before merge

Closes #1522