### PR TITLE
test: add threshold monitor boundary fuzz coverage

### DIFF
--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -2115,6 +2115,8 @@ mod test_circuit_breaker_enforcement;
 // #[cfg(test)] mod test_dispute_resolution; // pre-existing breakage
 mod fot_routing;
 mod threshold_monitor;
+#[cfg(test)]
+mod threshold_monitor_prop_tests;
 mod token_math;
 mod reputation;
 pub use reputation::{
@@ -9010,4 +9012,3 @@ mod test_event_ordering;
 #[cfg(test)]
 #[path = "release_schedule_host.rs"]
 mod release_schedule_host;
-

--- a/contracts/program-escrow/src/threshold_monitor.rs
+++ b/contracts/program-escrow/src/threshold_monitor.rs
@@ -16,6 +16,8 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 /// Configuration for threshold-based circuit breaking
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThresholdConfig {
+    /// Maximum failed operations permitted in a window.
     pub outflow_volume_threshold: i128,
     /// Maximum amount for a single payout transaction
     pub max_single_payout: i128,

--- a/contracts/program-escrow/src/threshold_monitor_prop_tests.rs
+++ b/contracts/program-escrow/src/threshold_monitor_prop_tests.rs
@@ -1,0 +1,71 @@
+//! Property tests for threshold-monitor window boundaries.
+//!
+//! `proptest` shrinks a failing timestamp/outcome sequence to the smallest
+//! reproducer, which makes boundary regressions straightforward to diagnose.
+
+use proptest::prelude::*;
+use soroban_sdk::Env;
+
+use crate::threshold_monitor::{self, ThresholdConfig};
+
+const WINDOW_SECS: u64 = 10;
+const FAILURE_THRESHOLD: u32 = 3;
+
+fn boundary_offsets() -> impl Strategy<Value = Vec<(bool, u8)>> {
+    prop::collection::vec((any::<bool>(), prop_oneof![Just(9), Just(10), Just(11)]), 0..24)
+}
+
+fn expected_breach(events: &[(bool, u8)]) -> bool {
+    let mut window_start = 0_u64;
+    let mut failures = 0_u32;
+
+    for &(failed, offset) in events {
+        let timestamp = offset as u64;
+        if timestamp >= window_start + WINDOW_SECS {
+            window_start = timestamp;
+            failures = 0;
+        }
+        if failed {
+            failures += 1;
+        }
+    }
+
+    failures >= FAILURE_THRESHOLD
+}
+
+proptest! {
+    /// Events at `end - 1` remain in the old window; events at `end` begin a
+    /// new one. The breaker result must exactly match the current-window model.
+    #[test]
+    fn prop_boundary_sequences_open_only_when_current_window_exceeds_threshold(
+        mut events in boundary_offsets(),
+    ) {
+        events.sort_by_key(|(_, offset)| *offset);
+
+        let env = Env::default();
+        env.ledger().with_mut(|ledger| ledger.timestamp = 0);
+        threshold_monitor::init_threshold_monitor(&env);
+        let mut config = ThresholdConfig::default();
+        config.set_time_window_secs(WINDOW_SECS);
+        config.set_failure_rate_threshold(FAILURE_THRESHOLD);
+        threshold_monitor::set_threshold_config(&env, config).unwrap();
+
+        for &(failed, offset) in &events {
+            env.ledger().with_mut(|ledger| ledger.timestamp = offset as u64);
+            if failed {
+                threshold_monitor::record_operation_failure(&env);
+            } else {
+                threshold_monitor::record_operation_success(&env);
+            }
+        }
+
+        let final_timestamp = events.last().map(|(_, offset)| *offset as u64).unwrap_or(0);
+        env.ledger().with_mut(|ledger| ledger.timestamp = final_timestamp);
+        prop_assert_eq!(
+            threshold_monitor::check_thresholds(&env).is_err(),
+            expected_breach(&events),
+            "boundary sequence did not match the window-membership model: {:?}",
+            events,
+        );
+    }
+}

--- a/docs/program-escrow-threshold-monitor-fuzzing.md
+++ b/docs/program-escrow-threshold-monitor-fuzzing.md
@@ -1,0 +1,13 @@
+# Threshold Monitor Boundary Fuzzing
+
+The threshold monitor starts a new window when `timestamp >= window_start + time_window_secs`.
+Its property test generates ordered success/failure sequences at `end - 1`, `end`, and `end + 1`.
+
+For every sequence, the test compares `check_thresholds` with an independent current-window model.
+It asserts that the breaker opens exactly when the current window contains at least the configured
+number of failures. The test uses `proptest`, so a failing sequence is automatically shrunk to a
+small boundary-focused reproducer.
+
+The generated inputs contain no token amounts and exercise no authorization paths. This keeps the
+security assertion focused on the monitor's window-membership boundary: failures before a rotation
+must not leak into the new window, while failures immediately before it must remain counted.


### PR DESCRIPTION
## Description

Closes #1490.

Adds a separate Proptest module for threshold-monitor window boundaries. Generated success/failure sequences are clustered at `window_end - 1`, `window_end`, and `window_end + 1`, then compared against an independent current-window oracle. Proptest shrinks any failure to a minimal timestamp sequence.

## Changes

- Add property coverage for threshold membership and failure threshold transitions.
- Document the boundary invariant and security rationale.
- Restore the missing `ThresholdConfig` struct declaration in the upstream source, which otherwise prevents the monitor from compiling.

## Verification

```text
$ cargo test -p program-escrow threshold_monitor_prop_tests
/bin/bash: line 1: cargo: command not found
```

The environment has no `cargo` or `rustup`, so the requested test suite could not be run here. `git diff --check` passed.