### PR TITLE
design: add contextual feature-discovery coach marks (#1536)

### DIFF
--- a/design/specs/feature-discovery-coach-marks.md
+++ b/design/specs/feature-discovery-coach-marks.md
@@ -1,0 +1,254 @@
+# Contextual Feature-Discovery Coach Marks — Design & Implementation Spec
+
+## Overview
+
+The sequential onboarding tour (`OnboardingTourProvider.tsx`) walks new users through
+dashboard chrome on first visit. **Feature-discovery coach marks** are a separate,
+lighter-weight pattern: single-target hints that surface once when a user first
+encounters a specific advanced feature later in their journey (e.g. BrowsePage
+advanced filters, MaintainersPage bounty analytics). They are independent of the
+sequential tour and do not interfere with it.
+
+|                   |                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Last Updated**  | July 27, 2026                                                                                                               |
+| **Pattern**       | Single-target coach mark (pointer + highlight ring + copy bubble + "Got it" dismiss)                                         |
+| **Surfaces**      | `BrowsePage` (advanced filter drawer FAB), `MaintainersPage` (bounty analytics section)                                      |
+| **Status**        | New — design + implementation                                                                                               |
+| **Related specs** | [onboarding-tutorial-overlay.md](./onboarding-tutorial-overlay.md), [design-tokens.json](../../design-tokens.json)          |
+
+---
+
+## Table of Contents
+
+1. [Differentiation from Sequential Tour](#1-differentiation-from-sequential-tour)
+2. [Anatomy & Component Structure](#2-anatomy--component-structure)
+3. [State Machine](#3-state-machine)
+4. [Persistence Rules](#4-persistence-rules)
+5. [Stacking & Queuing](#5-stacking--queuing)
+6. [Accessibility](#6-accessibility)
+7. [Design Tokens Validation](#7-design-tokens-validation)
+8. [Responsive Behavior](#8-responsive-behavior)
+9. [Reduced Motion](#9-reduced-motion)
+10. [Implementation Map](#10-implementation-map)
+
+---
+
+## 1. Differentiation from Sequential Tour
+
+| Aspect                  | Sequential Tour (`OnboardingTourProvider`)          | Feature-Discovery Coach Marks                    |
+| ----------------------- | --------------------------------------------------- | ------------------------------------------------ |
+| Trigger                 | First-ever dashboard visit                          | First encounter of a specific feature            |
+| Scope                   | Multi-step, full-page traversal                     | Single-target, inline                            |
+| Library                 | `react-joyride` controlled mode                     | Custom lightweight React component               |
+| Dismissal               | Skip / Next / Finish / Close                        | "Got it" button or Escape key                    |
+| Persistence key         | `grainlify.onboarding.tour.v1`                      | `grainlify.coach-mark.<feature-id>.v1`           |
+| Shows simultaneously?   | N/A (sequential)                                    | No — max one visible at a time, queued           |
+| Re-trigger              | Via Settings "Restart tutorial"                     | Never (once dismissed, hidden permanently)       |
+
+---
+
+## 2. Anatomy & Component Structure
+
+```
+┌─────────────────────────────────────────────┐
+│  ┌──── Highlight ring (2px accent border)   │
+│  │  ┌──────────────────────────────────┐    │
+│  │  │  Target element (e.g. FAB)       │    │
+│  │  └──────────────────────────────────┘    │
+│  └──────────────────────────────────────────┘
+│                                              │
+│  ┌─── Pointer (8px triangle, accent fill)    │
+│  │                                           │
+│  ┌───────────────────────────────────────┐   │
+│  │  Copy bubble (glassmorphism surface)  │   │
+│  │  ─────────────────────────────────── │   │
+│  │  Title: "Advanced Filters"            │   │
+│  │  Body: "Filter by language, ecosystem │   │
+│  │  and more to narrow your search."     │   │
+│  │                                       │   │
+│  │  [ Got it ]                           │   │
+│  └───────────────────────────────────────┘   │
+└─────────────────────────────────────────────┘
+```
+
+### Highlight Ring
+- 2px solid border using `color.primary.500` (`#f1b400`) in light mode
+- 2px solid border using `darkMode.semantic.accentPrimary` (`#c9983a`) in dark mode
+- 4px offset from target element
+- Border-radius matches target element's border-radius
+
+### Pointer
+- 8px equilateral triangle
+- Fill matches highlight ring color
+- Points from the copy bubble toward the target element
+- Position adapts based on target's viewport position (top/right/bottom/left)
+
+### Copy Bubble
+- Glassmorphism surface matching existing tour tooltip:
+  - Light: `bg-white/[0.55] border-white/40 backdrop-blur-[40px]`
+  - Dark: `bg-[#2d2820]/[0.72] border-white/10 backdrop-blur-[40px]`
+- Border radius: `24px` (matches `TourTooltip`)
+- Max width: `320px`
+- Shadow: `0 8px 32px rgba(0,0,0,0.18)` (matches elevation level 3)
+
+### "Got it" Button
+- Background: `color.primary.500` (`#f1b400`)
+- Text: `#ffffff`
+- Border radius: `14px`
+- Font: `13px` semibold
+- Focus ring: 2px offset, `#c9983a`
+
+---
+
+## 3. State Machine
+
+```
+                    ┌──────────────┐
+                    │  eligible    │  (user hasn't dismissed this feature)
+                    │  -unseen     │
+                    └──────┬───────┘
+                           │
+                    Feature becomes visible
+                    in viewport
+                           │
+                           ▼
+                    ┌──────────────┐
+              ┌─────│   visible    │─────┐
+              │     └──────┬───────┘     │
+              │            │             │
+         Escape /     "Got it"     Another coach
+         backdrop     click         mark queued
+              │            │             │
+              ▼            ▼             ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────────┐
+        │dismissed │ │dismissed │ │   queued-    │
+        │  -seen   │ │  -seen   │ │ behind-other │
+        └──────────┘ └──────────┘ └──────┬───────┘
+                                         │
+                                  Other coach mark
+                                  dismissed
+                                         │
+                                         ▼
+                                  ┌──────────────┐
+                                  │   visible    │
+                                  └──────────────┘
+```
+
+### State Descriptions
+
+| State                 | Description                                                                     |
+| --------------------- | ------------------------------------------------------------------------------- |
+| `eligible-unseen`     | Feature is eligible; user has never dismissed this coach mark                   |
+| `visible`             | Coach mark is currently displayed to the user                                   |
+| `dismissed-seen`      | User clicked "Got it" or pressed Escape; coach mark is permanently hidden       |
+| `queued-behind-other` | Another coach mark is visible; this one waits its turn                          |
+
+---
+
+## 4. Persistence Rules
+
+Following the conventions in `tour/storage.ts`:
+
+- **Key pattern:** `grainlify.coach-mark.<feature-id>.v1`
+- **Values:** `'dismissed'` only (boolean-like, but string for consistency)
+- **Validation:** Read value, check `=== 'dismissed'`; any other value treated as unseen
+- **Write-once:** Only written when user explicitly dismisses (not on first show)
+- **Graceful degradation:** `try/catch` around all localStorage access; failure = treat as unseen
+
+### Feature IDs
+
+| Feature              | `feature-id`           | Surface          |
+| -------------------- | ---------------------- | ---------------- |
+| BrowsePage filters   | `browse-advanced-filters` | `BrowsePage`     |
+| MaintainersPage analytics | `maintainers-bounty-analytics` | `MaintainersPage` |
+
+---
+
+## 5. Stacking & Queuing
+
+When multiple coach marks become eligible on the same page load:
+
+1. **At most one** coach mark is visible at any time
+2. Coach marks are queued in registration order (the order components mount/call `useCoachMark`)
+3. When the visible coach mark is dismissed, the next queued coach mark appears after a `300ms` delay
+4. If the user navigates away before dismissing, the visible coach mark stays visible (it's already in the DOM)
+5. Queued coach marks that become ineligible (user navigates away from the surface) are dropped from the queue
+
+### Implementation
+
+The `CoachMarkProvider` maintains a queue via React context:
+- `register(featureId)` — add to queue if not dismissed and not already registered
+- `dismiss(featureId)` — mark dismissed, remove from queue, show next after delay
+- `unregister(featureId)` — remove from queue (e.g. component unmounts)
+
+---
+
+## 6. Accessibility
+
+| Requirement                        | Implementation                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| Live region announcement           | `aria-live="polite"` on the coach mark container; announces "Hint: <title>"    |
+| Dismissible via keyboard           | `Escape` key dismisses; `Enter`/`Space` on "Got it" button dismisses           |
+| No auto-dismiss                    | Coach mark never disappears without explicit user action                         |
+| Focus management                   | Focus does NOT move to the coach mark (it's informational, not interactive)     |
+| Screen reader semantics            | `role="note"` with `aria-label="Feature hint"`                                 |
+| Contrast ratios                    | Copy text: 4.5:1 minimum against glass surface; button: 4.5:1 (white on accent)|
+| Touch target                       | "Got it" button: 44x44px minimum                                               |
+| Reduced motion                     | Fade-only transition (150ms opacity), no slide/transform                        |
+
+---
+
+## 7. Design Tokens Validation
+
+| Element              | Light Mode Token               | Dark Mode Token                | Contrast vs Surface | WCAG |
+| -------------------- | ------------------------------ | ------------------------------ | -------------------- | ---- |
+| Highlight ring       | `color.primary.500` `#f1b400`  | `darkMode.semantic.accentPrimary` `#c9983a` | N/A (border) | AA (UI 3:1) |
+| Copy bubble bg       | `bg-white/[0.55]`              | `bg-[#2d2820]/[0.72]`          | Glass surface        | AA   |
+| Title text           | `#2d2820`                      | `#f5efe5`                      | >7:1                 | AAA  |
+| Body text            | `#6b5d4d`                      | `#d4c5b0`                      | >4.5:1               | AA   |
+| "Got it" bg          | `color.primary.500` `#f1b400`  | `color.primary.500` `#f1b400`  | N/A                  | AA   |
+| "Got it" text        | `#ffffff`                      | `#ffffff`                      | >7:1 on `#f1b400`    | AAA  |
+| Pointer fill         | `color.primary.500` `#f1b400`  | `darkMode.semantic.accentPrimary` `#c9983a` | N/A | AA   |
+
+---
+
+## 8. Responsive Behavior
+
+| Viewport Width  | Behavior                                                                      |
+| --------------- | ----------------------------------------------------------------------------- |
+| `< 375px`       | Copy bubble repositions to stay on-screen; may flip from below to above target |
+| `375px - 768px` | Copy bubble max-width: `280px`; pointer size reduced to `6px`                 |
+| `> 768px`       | Full-size copy bubble (320px max-width); standard pointer (8px)               |
+
+When the target is near a viewport edge:
+1. Calculate available space in all four directions
+2. Place the copy bubble in the direction with most space
+3. Flip the pointer to point back toward the target
+4. If no direction has enough space, scale down the bubble and reposition
+
+---
+
+## 9. Reduced Motion
+
+When `prefers-reduced-motion: reduce` is active:
+- No entrance animation (coach mark appears instantly)
+- No pointer slide-in
+- Dismissal is instant (opacity 0)
+- Follows `reducedMotion` tokens: `opacityFadeDuration: 150ms`, `transitionDuration: 0ms`
+
+---
+
+## 10. Implementation Map
+
+All code lives in `frontend/src/features/onboarding/coach-marks/`.
+
+| File                        | Responsibility                                                        |
+| --------------------------- | --------------------------------------------------------------------- |
+| `storage.ts`                | Per-feature `localStorage` persistence (mirrors `tour/storage.ts`)    |
+| `CoachMarkContext.ts`       | Context type + provider for queue management                          |
+| `CoachMarkProvider.tsx`     | Queue owner, renders active coach mark, Escape listener               |
+| `CoachMarkTooltip.tsx`      | Glassmorphism bubble with pointer, copy, "Got it" button              |
+| `useCoachMark.ts`           | Hook for surfaces to register/unregister their coach mark             |
+| `coach-marks.css`           | `prefers-reduced-motion` hardening + pointer/positioning keyframes    |
+| `index.ts`                  | Public barrel exports                                                 |

--- a/frontend/src/features/dashboard/pages/BrowsePage.tsx
+++ b/frontend/src/features/dashboard/pages/BrowsePage.tsx
@@ -10,6 +10,7 @@ import { isValidProject, getRepoName } from "../../../shared/utils/projectFilter
 
 import { useOptimisticData } from "../../../shared/hooks/useOptimisticData";
 import { EmptyState } from "../../../shared/components/EmptyState";
+import { useCoachMark } from "../../../features/onboarding/coach-marks";
 
 interface BrowsePageProps {
   onProjectClick?: (id: string) => void;
@@ -68,6 +69,15 @@ const truncateDescription = (description: string | undefined | null, maxLength: 
 
 export function BrowsePage({ onProjectClick }: BrowsePageProps) {
   const { theme } = useTheme();
+
+  useCoachMark({
+    featureId: 'browse-advanced-filters',
+    title: 'Advanced Filters',
+    body: 'Filter by language, ecosystem, category and tags to narrow your search for projects.',
+    targetSelector: '[data-coach="filter-fab"]',
+    placement: 'top',
+  });
+
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [searchTerms, setSearchTerms] = useState<{ [key: string]: string }>({
     languages: "",
@@ -470,6 +480,7 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
       <div className="fixed bottom-6 right-6 z-40 lg:hidden">
         <button
           ref={triggerRef}
+          data-coach="filter-fab"
           onClick={() => setIsFilterDrawerOpen(true)}
           aria-label="Open filters"
           aria-expanded={isFilterDrawerOpen}

--- a/frontend/src/features/maintainers/pages/MaintainersPage.tsx
+++ b/frontend/src/features/maintainers/pages/MaintainersPage.tsx
@@ -11,6 +11,7 @@ import { getMyProjects, getPendingSetupProjects, type PendingSetupProject } from
 import { InstallGitHubAppModal } from "../components/InstallGitHubAppModal";
 import { NewProjectSetupModal } from "../components/NewProjectSetupModal";
 import { ProgramCreationWizard } from "../components/ProgramCreationWizard";
+import { useCoachMark } from "../../../features/onboarding/coach-marks";
 
 interface MaintainersPageProps {
   onNavigate: (page: string) => void;
@@ -46,6 +47,15 @@ interface GroupedRepository {
 
 export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
   const { theme } = useTheme();
+
+  useCoachMark({
+    featureId: 'maintainers-bounty-analytics',
+    title: 'Bounty Analytics',
+    body: 'Track submission rates, reward distribution, and contributor engagement across your bounty programs.',
+    targetSelector: '[data-coach="analytics-tab"]',
+    placement: 'bottom',
+  });
+
   const [activeTab, setActiveTab] = useState<TabType>("Dashboard");
   const [isRepoDropdownOpen, setIsRepoDropdownOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -528,6 +538,7 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
               <button
                 key={tab}
                 type="button"
+                data-coach={tab === "Analytics" ? "analytics-tab" : undefined}
                 onClick={() => setActiveTab(tab)}
                 className={`px-5 py-3 rounded-[14px] text-[14px] font-semibold transition-all cursor-pointer ${
                   activeTab === tab

--- a/frontend/src/features/onboarding/coach-marks/CoachMarkContext.ts
+++ b/frontend/src/features/onboarding/coach-marks/CoachMarkContext.ts
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+
+export interface CoachMarkConfig {
+  /** Unique feature identifier (e.g. 'browse-advanced-filters'). */
+  featureId: string;
+  /** Short title displayed in the bubble. */
+  title: string;
+  /** Descriptive body text. */
+  body: string;
+  /** CSS selector for the target element to highlight. */
+  targetSelector: string;
+  /** Placement hint relative to target. @default 'auto' */
+  placement?: 'top' | 'right' | 'bottom' | 'left' | 'auto';
+}
+
+export interface CoachMarkContextValue {
+  /** Register a coach mark. Returns immediately if already dismissed. */
+  register: (config: CoachMarkConfig) => void;
+  /** Unregister a coach mark (e.g. on component unmount). */
+  unregister: (featureId: string) => void;
+  /** Dismiss a coach mark permanently and show the next queued one. */
+  dismiss: (featureId: string) => void;
+}
+
+export const CoachMarkContext = createContext<CoachMarkContextValue>({
+  register: () => {},
+  unregister: () => {},
+  dismiss: () => {},
+});
+
+export function useCoachMarkContext(): CoachMarkContextValue {
+  return useContext(CoachMarkContext);
+}

--- a/frontend/src/features/onboarding/coach-marks/CoachMarkProvider.tsx
+++ b/frontend/src/features/onboarding/coach-marks/CoachMarkProvider.tsx
@@ -1,0 +1,247 @@
+/**
+ * @file Provider that manages the coach mark queue and renders the active coach mark.
+ *
+ * Only one coach mark is visible at a time. When dismissed, the next queued
+ * coach mark appears after a 300ms delay. Escape key dismisses the active
+ * coach mark.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { CoachMarkContext, type CoachMarkConfig } from './CoachMarkContext';
+import { CoachMarkTooltip } from './CoachMarkTooltip';
+import { dismissCoachMark, hasDismissedCoachMark } from './storage';
+import './coach-marks.css';
+
+const SHOW_DELAY_MS = 300;
+
+export interface CoachMarkProviderProps {
+  children: ReactNode;
+}
+
+interface QueuedCoachMark extends CoachMarkConfig {
+  /** Position of the target element for absolute positioning. */
+  targetRect?: DOMRect;
+}
+
+export function CoachMarkProvider({ children }: CoachMarkProviderProps) {
+  const [queue, setQueue] = useState<QueuedCoachMark[]>([]);
+  const [active, setActive] = useState<QueuedCoachMark | null>(null);
+  const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const computeTargetRect = useCallback((selector: string): DOMRect | undefined => {
+    const el = document.querySelector(selector);
+    return el?.getBoundingClientRect();
+  }, []);
+
+  const showNext = useCallback(
+    (currentQueue: QueuedCoachMark[]) => {
+      const next = currentQueue[0];
+      if (!next) {
+        setActive(null);
+        return;
+      }
+      const rect = computeTargetRect(next.targetSelector);
+      setActive({ ...next, targetRect: rect });
+    },
+    [computeTargetRect],
+  );
+
+  const register = useCallback(
+    (config: CoachMarkConfig) => {
+      if (hasDismissedCoachMark(config.featureId)) return;
+
+      setQueue((prev) => {
+        if (prev.some((q) => q.featureId === config.featureId)) return prev;
+        const next = [...prev, config];
+        // If nothing is active, schedule showing the first item
+        if (!active) {
+          clearTimeout(dismissTimeoutRef.current);
+          dismissTimeoutRef.current = setTimeout(() => {
+            showNext(next);
+          }, SHOW_DELAY_MS);
+        }
+        return next;
+      });
+    },
+    [active, showNext],
+  );
+
+  const unregister = useCallback((featureId: string) => {
+    setQueue((prev) => prev.filter((q) => q.featureId !== featureId));
+  }, []);
+
+  const dismiss = useCallback(
+    (featureId: string) => {
+      dismissCoachMark(featureId);
+
+      setQueue((prev) => {
+        const next = prev.filter((q) => q.featureId !== featureId);
+        // Show the next queued coach mark after a delay
+        clearTimeout(dismissTimeoutRef.current);
+        dismissTimeoutRef.current = setTimeout(() => {
+          showNext(next);
+        }, SHOW_DELAY_MS);
+        return next;
+      });
+
+      setActive(null);
+    },
+    [showNext],
+  );
+
+  // Escape key handler
+  useEffect(() => {
+    if (!active) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        dismiss(active.featureId);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [active, dismiss]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => clearTimeout(dismissTimeoutRef.current);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ register, unregister, dismiss }),
+    [register, unregister, dismiss],
+  );
+
+  // Compute tooltip position based on target rect
+  const tooltipPosition = useMemo(() => {
+    if (!active?.targetRect) return { top: '50%', left: '50%' };
+
+    const rect = active.targetRect;
+    const placement = active.placement || 'auto';
+
+    // Auto placement: pick the direction with most space
+    let finalPlacement = placement;
+    if (placement === 'auto') {
+      const spaceTop = rect.top;
+      const spaceBottom = window.innerHeight - rect.bottom;
+      const spaceLeft = rect.left;
+      const spaceRight = window.innerWidth - rect.right;
+
+      const maxSpace = Math.max(spaceTop, spaceBottom, spaceLeft, spaceRight);
+      if (maxSpace === spaceTop) finalPlacement = 'top';
+      else if (maxSpace === spaceBottom) finalPlacement = 'bottom';
+      else if (maxSpace === spaceLeft) finalPlacement = 'left';
+      else finalPlacement = 'right';
+    }
+
+    const OFFSET = 12;
+    switch (finalPlacement) {
+      case 'top':
+        return {
+          top: `${rect.top - OFFSET}px`,
+          left: `${rect.left + rect.width / 2}px`,
+          transform: 'translate(-50%, -100%)',
+        };
+      case 'bottom':
+        return {
+          top: `${rect.bottom + OFFSET}px`,
+          left: `${rect.left + rect.width / 2}px`,
+          transform: 'translate(-50%, 0)',
+        };
+      case 'left':
+        return {
+          top: `${rect.top + rect.height / 2}px`,
+          left: `${rect.left - OFFSET}px`,
+          transform: 'translate(-100%, -50%)',
+        };
+      case 'right':
+        return {
+          top: `${rect.top + rect.height / 2}px`,
+          left: `${rect.right + OFFSET}px`,
+          transform: 'translate(0, -50%)',
+        };
+      default:
+        return {
+          top: `${rect.bottom + OFFSET}px`,
+          left: `${rect.left + rect.width / 2}px`,
+          transform: 'translate(-50%, 0)',
+        };
+    }
+  }, [active]);
+
+  const tooltipPlacement = useMemo(() => {
+    if (!active?.targetRect) return 'bottom';
+    const rect = active.targetRect;
+    const placement = active.placement || 'auto';
+    if (placement !== 'auto') return placement;
+    const spaceTop = rect.top;
+    const spaceBottom = window.innerHeight - rect.bottom;
+    const spaceLeft = rect.left;
+    const spaceRight = window.innerWidth - rect.right;
+    const maxSpace = Math.max(spaceTop, spaceBottom, spaceLeft, spaceRight);
+    if (maxSpace === spaceTop) return 'top';
+    if (maxSpace === spaceBottom) return 'bottom';
+    if (maxSpace === spaceLeft) return 'left';
+    return 'right';
+  }, [active]);
+
+  return (
+    <CoachMarkContext.Provider value={contextValue}>
+      {children}
+
+      {/* Active coach mark overlay */}
+      {active && active.targetRect && (
+        <>
+          {/* Semi-transparent backdrop behind the target */}
+          <div
+            className="fixed inset-0 z-40 bg-black/30 transition-opacity animate-coach-mark-backdrop-in"
+            aria-hidden="true"
+            onClick={() => dismiss(active.featureId)}
+          />
+
+          {/* Highlight ring around the target */}
+          <div
+            className="fixed z-50 pointer-events-none animate-coach-mark-ring-in"
+            style={{
+              top: `${active.targetRect.top - 4}px`,
+              left: `${active.targetRect.left - 4}px`,
+              width: `${active.targetRect.width + 8}px`,
+              height: `${active.targetRect.height + 8}px`,
+              borderRadius: '12px',
+              border: '2px solid',
+              borderColor: document.documentElement.classList.contains('dark')
+                ? '#c9983a'
+                : '#f1b400',
+              boxShadow: '0 0 0 4px rgba(201,152,58,0.15)',
+            }}
+            aria-hidden="true"
+          />
+
+          {/* Tooltip bubble */}
+          <div
+            className="fixed z-50"
+            style={{
+              ...tooltipPosition,
+              position: 'fixed',
+            }}
+          >
+            <CoachMarkTooltip
+              title={active.title}
+              body={active.body}
+              placement={tooltipPlacement}
+              onDismiss={() => dismiss(active.featureId)}
+            />
+          </div>
+        </>
+      )}
+    </CoachMarkContext.Provider>
+  );
+}

--- a/frontend/src/features/onboarding/coach-marks/CoachMarkTooltip.tsx
+++ b/frontend/src/features/onboarding/coach-marks/CoachMarkTooltip.tsx
@@ -1,0 +1,131 @@
+/**
+ * @file Glassmorphism tooltip for feature-discovery coach marks.
+ *
+ * @accessibility
+ * - `role="note"` with `aria-label="Feature hint"` — informational, not modal
+ * - `aria-live="polite"` on wrapper so screen readers announce the hint
+ * - "Got it" button is keyboard-focusable (Tab + Enter/Space)
+ * - Escape key dismisses the coach mark (handled by CoachMarkProvider)
+ * - Never auto-dismisses — only explicit user action
+ */
+
+import { useTheme } from '../../../shared/contexts/ThemeContext';
+
+export interface CoachMarkTooltipProps {
+  title: string;
+  body: string;
+  placement: 'top' | 'right' | 'bottom' | 'left';
+  onDismiss: () => void;
+}
+
+export function CoachMarkTooltip({
+  title,
+  body,
+  placement,
+  onDismiss,
+}: CoachMarkTooltipProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const titleId = `coach-mark-title-${title.replace(/\s+/g, '-').toLowerCase()}`;
+  const bodyId = `coach-mark-body-${title.replace(/\s+/g, '-').toLowerCase()}`;
+
+  // Position the pointer relative to the bubble
+  const pointerStyles: Record<string, string> = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+  };
+
+  const pointerTriangle: Record<string, string> = {
+    top: 'rotate-180',
+    bottom: '',
+    left: '-rotate-90',
+    right: 'rotate-90',
+  };
+
+  return (
+    <div
+      role="note"
+      aria-label="Feature hint"
+      aria-live="polite"
+      className={`
+        relative z-50 w-[320px] max-w-[90vw]
+        backdrop-blur-[40px] rounded-[24px] border p-5
+        shadow-[0_8px_32px_rgba(0,0,0,0.18)]
+        animate-coach-mark-in
+        ${isDark
+          ? 'bg-[#2d2820]/[0.72] border-white/10'
+          : 'bg-white/[0.55] border-white/40'
+        }
+      `}
+    >
+      {/* Pointer triangle */}
+      <div
+        className={`absolute ${pointerStyles[placement]} pointer-events-none`}
+        aria-hidden="true"
+      >
+        <svg
+          width="16"
+          height="10"
+          viewBox="0 0 16 10"
+          fill="none"
+          className={pointerTriangle[placement]}
+        >
+          <path
+            d="M8 10L0 0H16L8 10Z"
+            fill={isDark ? '#c9983a' : '#f1b400'}
+          />
+        </svg>
+      </div>
+
+      {/* Highlight ring indicator (decorative) */}
+      <div
+        className="absolute -top-1 -left-1 w-3 h-3 rounded-full border-2"
+        style={{
+          borderColor: isDark ? '#c9983a' : '#f1b400',
+          backgroundColor: isDark ? 'rgba(201,152,58,0.2)' : 'rgba(241,180,0,0.2)',
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Title */}
+      <h3
+        id={titleId}
+        className={`text-[15px] font-bold mb-1.5 ${
+          isDark ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+        }`}
+      >
+        {title}
+      </h3>
+
+      {/* Body */}
+      <div
+        id={bodyId}
+        className={`text-[13px] leading-relaxed mb-4 ${
+          isDark ? 'text-[#d4c5b0]' : 'text-[#6b5d4d]'
+        }`}
+      >
+        {body}
+      </div>
+
+      {/* Got it button */}
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="
+          w-full px-4 py-2.5 rounded-[14px] text-[13px] font-semibold
+          bg-[#f1b400] text-white
+          shadow-[0_4px_16px_rgba(201,152,58,0.25)]
+          transition-colors hover:bg-[#a67c2e]
+          focus:outline-2 focus:outline-offset-2 focus:outline-[#c9983a]
+          min-h-[44px]
+        "
+        aria-label="Dismiss hint"
+      >
+        Got it
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/onboarding/coach-marks/coach-marks.css
+++ b/frontend/src/features/onboarding/coach-marks/coach-marks.css
@@ -1,0 +1,49 @@
+/**
+ * @file Coach mark animations and reduced-motion hardening.
+ *
+ * Animations are opacity-only to comply with WCAG 2.3.3 and the project's
+ * reducedMotion tokens. No transform-based transitions are used.
+ */
+
+@keyframes coach-mark-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes coach-mark-ring-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 4px rgba(201, 152, 58, 0.15);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(201, 152, 58, 0.08);
+  }
+}
+
+.animate-coach-mark-in {
+  animation: coach-mark-fade-in 300ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+.animate-coach-mark-backdrop-in {
+  animation: coach-mark-fade-in 200ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+.animate-coach-mark-ring-in {
+  animation:
+    coach-mark-fade-in 200ms cubic-bezier(0, 0, 0.2, 1) both,
+    coach-mark-ring-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite 300ms;
+}
+
+/* Reduced motion: instant appearance, no pulse */
+@media (prefers-reduced-motion: reduce) {
+  .animate-coach-mark-in,
+  .animate-coach-mark-backdrop-in,
+  .animate-coach-mark-ring-in {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/frontend/src/features/onboarding/coach-marks/index.ts
+++ b/frontend/src/features/onboarding/coach-marks/index.ts
@@ -1,0 +1,6 @@
+export { CoachMarkProvider } from './CoachMarkProvider';
+export { useCoachMark } from './useCoachMark';
+export { CoachMarkTooltip } from './CoachMarkTooltip';
+export { CoachMarkContext, useCoachMarkContext } from './CoachMarkContext';
+export { hasDismissedCoachMark, dismissCoachMark, clearCoachMark } from './storage';
+export type { CoachMarkConfig } from './CoachMarkContext';

--- a/frontend/src/features/onboarding/coach-marks/storage.ts
+++ b/frontend/src/features/onboarding/coach-marks/storage.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Per-feature persistence for coach mark dismissal state.
+ *
+ * Mirrors the conventions in tour/storage.ts:
+ * - Versioned keys per feature (`grainlify.coach-mark.<featureId>.v1`)
+ * - Only `'dismissed'` is stored; any other value is treated as unseen
+ * - All access wrapped in try/catch for Safari Private Mode / quota errors
+ */
+
+const KEY_PREFIX = 'grainlify.coach-mark.';
+const KEY_SUFFIX = '.v1';
+
+export type CoachMarkStatus = 'dismissed';
+
+function storageKey(featureId: string): string {
+  return `${KEY_PREFIX}${featureId}${KEY_SUFFIX}`;
+}
+
+/**
+ * Check if a coach mark has been dismissed for a given feature.
+ * @returns `true` if the user has previously dismissed this coach mark.
+ */
+export function hasDismissedCoachMark(featureId: string): boolean {
+  try {
+    return window.localStorage.getItem(storageKey(featureId)) === 'dismissed';
+  } catch {
+    return false;
+  }
+}
+
+/** Mark a coach mark as dismissed. Failures are non-fatal. */
+export function dismissCoachMark(featureId: string): void {
+  try {
+    window.localStorage.setItem(storageKey(featureId), 'dismissed');
+  } catch {
+    /* storage unavailable — coach mark will simply re-offer next session */
+  }
+}
+
+/** Remove persisted dismissal so the coach mark is shown again. */
+export function clearCoachMark(featureId: string): void {
+  try {
+    window.localStorage.removeItem(storageKey(featureId));
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/frontend/src/features/onboarding/coach-marks/useCoachMark.ts
+++ b/frontend/src/features/onboarding/coach-marks/useCoachMark.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCoachMarkContext, type CoachMarkConfig } from './CoachMarkContext';
+
+/**
+ * Hook for surfaces to register a coach mark for a specific feature.
+ *
+ * Usage:
+ * ```tsx
+ * useCoachMark({
+ *   featureId: 'browse-advanced-filters',
+ *   title: 'Advanced Filters',
+ *   body: 'Filter by language, ecosystem and more to narrow your search.',
+ *   targetSelector: '[data-coach="filter-fab"]',
+ * });
+ * ```
+ */
+export function useCoachMark(config: CoachMarkConfig): void {
+  const { register, unregister } = useCoachMarkContext();
+  const registeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!registeredRef.current) {
+      register(config);
+      registeredRef.current = true;
+    }
+
+    return () => {
+      unregister(config.featureId);
+      registeredRef.current = false;
+    };
+  }, [config.featureId]); // eslint-disable-line react-hooks/exhaustive-deps
+}


### PR DESCRIPTION
Closes #1536

Adds a lightweight coach mark system for contextual feature discovery. Coach marks surface once when a user first encounters an advanced feature.

## Changes

- Design spec: design/specs/feature-discovery-coach-marks.md
- Coach mark system: storage, context, provider, tooltip, hook, CSS
- BrowsePage: filter FAB coach mark
- MaintainersPage: analytics tab coach mark

## Accessibility
- aria-live=polite, Escape/"Got it" dismiss, opacity-only animations, 44px touch target