### PR TITLE
fix: bound fot_router.quote() return values to prevent router-manipul…

### DIFF
--- a/contracts/program-escrow/src/errors.rs
+++ b/contracts/program-escrow/src/errors.rs
@@ -688,11 +688,6 @@ pub enum ContractError {
     InvalidRoleProposal = 1207,
     RoleRotationNotAllowed = 1208,
 
-    /// FoT (fee-on-transfer) routing failed.
-    ///
-    /// This error occurs when the fee-on-transfer router cannot process the transfer.
-    FotRoutingFailed = 1209,
-
     /// Role rotation timelock is active.
     ///
     /// This error occurs when role rotation is temporarily disabled
@@ -708,6 +703,14 @@ pub enum ContractError {
     /// This error occurs when the FoT router contract returns an unexpected
     /// result or the routing calculation overflows.
     FotRoutingFailed = 1210,
+
+    /// Fee-on-transfer router quote exceeded the configured maximum multiplier.
+    ///
+    /// This error occurs when `router.quote()` returns a gross amount larger
+    /// than `net_amount * max_fot_multiplier_bps / BASIS_POINTS`, which is
+    /// rejected to prevent a malicious or misconfigured router from draining
+    /// the program's remaining balance.
+    FotRouterQuoteExceeded = 1211,
 
     // =========================================================================
     // Dynamic Pricing Errors (1300-1399)
@@ -955,6 +958,9 @@ impl ContractError {
 
             // FoT Router Errors
             ContractError::FotRoutingFailed => "FoT routing failed",
+            ContractError::FotRouterQuoteExceeded => {
+                "FoT router quote exceeded configured maximum multiplier"
+            }
 
             // Role Management Errors
             ContractError::AdminRotationInProgress => "Admin rotation already in progress",

--- a/contracts/program-escrow/src/fot_routing.rs
+++ b/contracts/program-escrow/src/fot_routing.rs
@@ -1,6 +1,20 @@
 #![allow(dead_code)]
 
-use soroban_sdk::{vec, Address, Env, IntoVal, Symbol, Val};
+use soroban_sdk::{panic_with_error, vec, Address, Env, IntoVal, Symbol, Val};
+
+/// Default maximum gross-to-net multiplier for router quotes.
+///
+/// Expressed in basis points over `BASIS_POINTS` (i.e. `15_000` == 1.5x).
+/// This bounds the acceptable return from `router.quote(token, net_amount)` so
+/// a malicious or misconfigured router cannot drain the program by returning
+/// an implausibly large gross amount.
+pub const DEFAULT_MAX_FOT_MULTIPLIER_BPS: u32 = 15_000;
+
+/// Maximum configurable multiplier, in basis points, allowed via `set_fot_router`.
+///
+/// This caps the bound at 10x the intended net amount. Any higher would let
+/// a compromised admin set a multiplier large enough to defeat the sanity check.
+pub const MAX_FOT_MULTIPLIER_BPS: u32 = 100_000;
 
 /// Apply FoT routing to compute the gross transfer amount.
 ///
@@ -12,12 +26,23 @@ use soroban_sdk::{vec, Address, Env, IntoVal, Symbol, Val};
 /// that returns the gross amount needed to deliver `net_amount` to the
 /// recipient after fee-on-transfer deductions.
 ///
+/// # Upper-bound sanity check
+///
+/// The raw `gross` returned by the router is bounded by
+/// `net_amount * max_fot_multiplier_bps / BASIS_POINTS`. This prevents a
+/// malicious or misconfigured router from returning an arbitrarily large
+/// gross amount, which could otherwise be used to drain the program's
+/// `remaining_balance` under the guise of fee-on-transfer compensation.
+/// If the router quote exceeds the configured bound, the function aborts
+/// with [`crate::errors::ContractError::FotRouterQuoteExceeded`].
+///
 /// Slippage is applied as:
 /// `adjusted = gross * (BASIS_POINTS + slippage_bps) / BASIS_POINTS`
 ///
 /// # Panics
 /// - If the router call fails or returns a non-positive amount
-/// - On arithmetic overflow during slippage adjustment
+/// - If the router quote exceeds the configured maximum multiplier
+/// - On arithmetic overflow during the bound or slippage calculations
 pub fn apply_fot_router(
     env: &Env,
     token_address: &Address,
@@ -46,6 +71,18 @@ pub fn apply_fot_router(
 
     if gross <= 0 {
         panic!("FoT router returned non-positive amount");
+    }
+
+    // Reject implausibly large gross amounts before any further arithmetic.
+    // This guards against a compromised router inflating the gross quote.
+    let max_allowed = net_amount
+        .checked_mul(router.max_fot_multiplier_bps as i128)
+        .expect("FoT routing: bound calculation overflow")
+        .checked_div(crate::BASIS_POINTS)
+        .expect("FoT routing: bound calculation overflow");
+
+    if gross > max_allowed {
+        panic_with_error!(&env, &crate::errors::ContractError::FotRouterQuoteExceeded);
     }
 
     if router.slippage_bps == 0 {

--- a/contracts/program-escrow/src/lib.rs
+++ b/contracts/program-escrow/src/lib.rs
@@ -745,6 +745,12 @@ pub struct FotRouter {
     pub router_contract: Address,
     /// Slippage tolerance in basis points (0 – 500, i.e. 0 – 5 %).
     pub slippage_bps: u32,
+    /// Maximum gross-to-net multiplier for router quotes, in basis points over 10_000.
+    ///
+    /// For example, `15_000` permits a gross quote up to 1.5x the intended net.
+    /// This bound prevents a compromised or misconfigured router from draining
+    /// the program with an implausibly inflated quote.
+    pub max_fot_multiplier_bps: u32,
 }
 
 /// Nullable wrapper for `FotRouter` stored inside `ProgramData`.
@@ -766,6 +772,8 @@ pub struct FotRouterSetEvent {
     pub version: u32,
     pub router_contract: Address,
     pub slippage_bps: u32,
+    /// Configured upper-bound multiplier for gross router quotes, in basis points over 10_000.
+    pub max_fot_multiplier_bps: u32,
     pub set_by: Address,
     pub timestamp: u64,
 }
@@ -777,47 +785,6 @@ pub struct FotRouterClearedEvent {
     pub version: u32,
     pub set_by: Address,
     pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FotRouter {
-    /// Address of the router contract that implements `quote(Address, i128) -> i128`.
-    pub router_contract: Address,
-    /// Slippage tolerance in basis points (1 bp = 0.01%).
-    /// Applied as a buffer on top of the quoted amount.
-    pub slippage_bps: u32,
-}
-
-/// Event emitted when the FoT router configuration is set or updated.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FotRouterSetEvent {
-    pub version: u32,
-    pub router_contract: Address,
-    pub slippage_bps: u32,
-    pub set_by: Address,
-    pub timestamp: u64,
-}
-
-/// Event emitted when the FoT router configuration is cleared.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FotRouterClearedEvent {
-    pub version: u32,
-    pub set_by: Address,
-    pub timestamp: u64,
-}
-
-/// Contract-type-safe optional wrapper around [`FotRouter`].
-///
-/// Nested `Option<FotRouter>` inside another `#[contracttype]` breaks under
-/// Cargo feature unification with `soroban-sdk/testutils` (unit-test builds).
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum OptionalFotRouter {
-    None,
-    Some(FotRouter),
 }
 
 #[contracttype]
@@ -836,11 +803,6 @@ pub struct ProgramData {
     pub reference_hash: Option<soroban_sdk::Bytes>,
     pub archived: bool,
     pub archived_at: Option<u64>,
-    // --- Program identity and history ---
-    pub program_id: String,
-    pub payout_history: soroban_sdk::Vec<PayoutRecord>,
-    pub initial_liquidity: i128,
-    pub reference_hash: Option<soroban_sdk::Bytes>,
     /// Optional per-program circuit breaker failure threshold.
     /// If set, overrides the global default (3) for this program.
     /// Must be between 1 and 100 inclusive when set.
@@ -2114,6 +2076,8 @@ mod reentrancy_tests;
 mod test_circuit_breaker_enforcement;
 // #[cfg(test)] mod test_dispute_resolution; // pre-existing breakage
 mod fot_routing;
+#[cfg(test)]
+mod test_fot_routing;
 mod threshold_monitor;
 mod token_math;
 mod reputation;
@@ -4626,15 +4590,30 @@ impl ProgramEscrowContract {
     /// # Arguments
     /// * `router_contract` - Address of the AMM router contract implementing `quote`.
     /// * `slippage_bps` - Slippage tolerance in basis points (0-500, i.e. 0-5%).
+    /// * `max_fot_multiplier_bps` - Upper-bound multiplier for router quotes,
+    ///   expressed in basis points over 10_000 (e.g. `15_000` = 1.5x the net amount).
+    ///   This sanity cap prevents a malicious or misconfigured router from draining
+    ///   the program with an implausibly inflated `quote`.
     ///
     /// # Panics
     /// * If the contract is not initialized
     /// * If caller is not the admin
     /// * If `slippage_bps` exceeds 500 (5%)
-    pub fn set_fot_router(env: Env, router_contract: Address, slippage_bps: u32) {
+    /// * If `max_fot_multiplier_bps` is outside the allowed range
+    pub fn set_fot_router(
+        env: Env,
+        router_contract: Address,
+        slippage_bps: u32,
+        max_fot_multiplier_bps: u32,
+    ) {
         let admin = Self::require_admin(&env);
         if slippage_bps > 500 {
             panic!("FoT router slippage exceeds maximum (500 bps = 5%)");
+        }
+        if max_fot_multiplier_bps < crate::BASIS_POINTS as u32
+            || max_fot_multiplier_bps > crate::fot_routing::MAX_FOT_MULTIPLIER_BPS
+        {
+            panic!("FoT router max multiplier must be between 10000 and 100000 basis points");
         }
 
         let mut program_data: ProgramData = env
@@ -4646,6 +4625,7 @@ impl ProgramEscrowContract {
         program_data.fot_router = OptionalFotRouter::Some(FotRouter {
             router_contract: router_contract.clone(),
             slippage_bps,
+            max_fot_multiplier_bps,
         });
 
         env.storage().instance().set(&PROGRAM_DATA, &program_data);
@@ -4656,6 +4636,7 @@ impl ProgramEscrowContract {
                 version: EVENT_VERSION_V2,
                 router_contract,
                 slippage_bps,
+                max_fot_multiplier_bps,
                 set_by: admin,
                 timestamp: env.ledger().timestamp(),
             },

--- a/contracts/program-escrow/src/test_fot_routing.rs
+++ b/contracts/program-escrow/src/test_fot_routing.rs
@@ -43,6 +43,24 @@ impl MockFotRouter {
 }
 
 // ===========================================================================
+// Mock Malicious FoT Router Contract
+// ===========================================================================
+
+/// A mock router that simulates a compromised quote source by inflating the
+/// gross amount far above any plausible fee-on-transfer compensation.
+#[contract]
+pub struct InflatedFotRouter;
+
+#[contractimpl]
+impl InflatedFotRouter {
+    pub fn quote(env: Env, _token: Address, amount: i128) -> i128 {
+        // Return 100x the intended net amount; this should be rejected by the
+        // upper-bound check before any tokens are transferred.
+        amount.checked_mul(100).expect("Mock inflated amount overflow")
+    }
+}
+
+// ===========================================================================
 // Mock FoT Token Contract
 // ===========================================================================
 
@@ -122,7 +140,8 @@ fn setup_with_router(
     let program_id = String::from_str(env, "fot-routing-prog");
 
     client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
-    client.set_fot_router(&router_id, &slippage_bps);
+    // Use a 5x upper-bound multiplier so high-FoT router tests (up to 50% fee) pass.
+    client.set_fot_router(&router_id, &slippage_bps, &50_000);
     client.publish_program(&program_id, &admin);
 
     FotRoutingSetup { client, token, router, admin }
@@ -442,7 +461,7 @@ fn test_set_fot_router_emits_event() {
     use soroban_sdk::testutils::Events;
     let events_before = env.events().all().len();
 
-    client.set_fot_router(&router_id, &100);
+    client.set_fot_router(&router_id, &100, &15_000);
 
     let events_after = env.events().all().len();
     assert!(events_after > events_before, "set_fot_router must emit an event");
@@ -463,7 +482,7 @@ fn test_clear_fot_router_emits_event() {
     let program_id = String::from_str(&env, "event-prog-2");
 
     client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
-    client.set_fot_router(&router_id, &100);
+    client.set_fot_router(&router_id, &100, &15_000);
 
     use soroban_sdk::testutils::Events;
     let events_before = env.events().all().len();
@@ -495,7 +514,7 @@ fn test_set_fot_router_rejects_excessive_slippage() {
 
     client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
     // 600 bps = 6% > 5% max
-    client.set_fot_router(&router_id, &600);
+    client.set_fot_router(&router_id, &600, &15_000);
 }
 
 // ===========================================================================
@@ -558,6 +577,8 @@ fn test_fot_router_in_program_data() {
     let fot_router = info.fot_router.unwrap();
     assert_eq!(fot_router.router_contract, setup.router.address);
     assert_eq!(fot_router.slippage_bps, 100);
+    assert_eq!(fot_router.max_fot_multiplier_bps, 50_000,
+        "max_fot_multiplier_bps default used by the helper must be persisted");
 }
 
 // ===========================================================================
@@ -645,7 +666,7 @@ fn test_single_payout_with_protocol_fee_and_routing() {
 
     // Enable a 5% protocol fee
     client.update_fee_config(&100, &0, &500, &0, &admin, &true, &0);
-    client.set_fot_router(&router_id, &0);
+    client.set_fot_router(&router_id, &0, &15_000);
     client.publish_program(&program_id, &admin);
 
     // Fund
@@ -690,7 +711,7 @@ fn test_batch_payout_with_protocol_fee_and_routing() {
 
     client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
     client.update_fee_config(&100, &0, &500, &0, &admin, &true, &0);
-    client.set_fot_router(&router_id, &0);
+    client.set_fot_router(&router_id, &0, &15_000);
     client.publish_program(&program_id, &admin);
 
     token.mint(&client.address, &30_000);
@@ -712,4 +733,41 @@ fn test_batch_payout_with_protocol_fee_and_routing() {
     assert_eq!(token.balance(&r1), 9_500, "r1 gets intended net");
     assert_eq!(token.balance(&r2), 9_500, "r2 gets intended net");
     assert_eq!(client.get_program_info().remaining_balance, 9_000);
+}
+
+// ===========================================================================
+// 23. Malicious router with an inflated quote is rejected
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "FotRouterQuoteExceeded")]
+fn test_malicious_router_inflated_quote_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, DeflatToken);
+    let token = DeflatTokenClient::new(&env, &token_id);
+    token.set_fee_bps(&0);
+
+    let router_id = env.register_contract(None, InflatedFotRouter);
+
+    let admin = Address::generate(&env);
+    let program_id = String::from_str(&env, "malicious-router-prog");
+
+    client.init_program(&program_id, &admin, &token_id, &admin, &None, &None);
+    // Cap the gross quote at 1.5x net. The malicious router returns 100x.
+    client.set_fot_router(&router_id, &0, &15_000);
+    client.publish_program(&program_id, &admin);
+
+    // Fund the program
+    token.mint(&client.address, &10_000);
+    client.lock_program_funds(&10_000);
+
+    let recipient = Address::generate(&env);
+    // This must abort because the router's 100x gross quote exceeds the 1.5x cap.
+    // No tokens should be transferred to the recipient or debited beyond the lock.
+    client.single_payout(&recipient, &100, &None);
 }

--- a/docs/fee-on-transfer-routing.md
+++ b/docs/fee-on-transfer-routing.md
@@ -54,8 +54,8 @@ receives the intended net amount after FoT deductions.
 Only the contract admin may set or clear the router configuration.
 
 ```rust
-// Set router with 1 % slippage tolerance
-contract.set_fot_router(&router_address, &100);
+// Set router with 1 % slippage tolerance and a 1.5x gross upper bound
+contract.set_fot_router(&router_address, &100, &15_000);
 
 // Clear router (restores backward-compatible behavior)
 contract.clear_fot_router();
@@ -93,6 +93,9 @@ The `FotRouter` config is stored as an optional field on `ProgramData`:
 pub struct FotRouter {
     pub router_contract: Address,
     pub slippage_bps: u32,
+    /// Maximum gross-to-net multiplier in basis points over 10_000.
+    /// For example, 15_000 permits a gross quote up to 1.5x the net amount.
+    pub max_fot_multiplier_bps: u32,
 }
 
 pub struct ProgramData {
@@ -116,6 +119,7 @@ pre-routing implementation (backward compatible).
 | Code | Constant | Description |
 |------|----------|-------------|
 | 1300 | `FotRoutingFailed` | Router returned invalid result or call failed |
+| 1211 | `FotRouterQuoteExceeded` | Router gross quote exceeded configured `max_fot_multiplier_bps` |
 
 ## Security Considerations
 
@@ -124,8 +128,12 @@ The router contract is a **trusted component**. A malicious router could:
 - Return inflated gross amounts to drain the escrow contract
 - Return deflated amounts causing payouts to fall short
 
-**Mitigation**: Only the contract admin can set the router. Choose a router
-that is audited and verified.
+**Mitigation**: Only the contract admin can set the router. Additionally,
+`set_fot_router` enforces an admin-configurable `max_fot_multiplier_bps` cap on
+the gross quote returned by `router.quote()`. `apply_fot_router` rejects any
+quote above this bound with `ContractError::FotRouterQuoteExceeded`, preventing
+a malicious router from draining the program. Choose a router that is audited
+and verified, and keep the multiplier as low as the token's fee structure allows.
 
 ### Slippage
 Slippage adds a buffer above the quoted amount. Higher slippage provides more

--- a/docs/program-escrow-fot-router-trust-boundary.md
+++ b/docs/program-escrow-fot-router-trust-boundary.md
@@ -1,0 +1,95 @@
+# Program Escrow FoT Router Trust Boundary
+
+## Overview
+
+The fee-on-transfer (FoT) router is an **external, caller-configured contract** that
+`program-escrow` queries on every payout to translate an intended *net* recipient
+amount into the gross transfer amount required after any fee-on-transfer
+deduction. Because that translation is performed by code outside the escrow
+program, it is a trust boundary that must be explicitly bounded.
+
+A compromised, buggy, or malicious router can return an arbitrarily large gross
+amount. Without an upper-bound check, the escrow contract would debit that
+amount from `remaining_balance` and transfer it out, draining the program for
+far more than the intended payout plus any plausible FoT fee.
+
+## Upper-Bound Sanity Check
+
+`apply_fot_router` enforces the invariant:
+
+```text
+gross_quote <= net_amount * max_fot_multiplier_bps / 10_000
+```
+
+- `net_amount` is the amount the recipient is intended to receive.
+- `max_fot_multiplier_bps` is an admin-configured ceiling expressed in basis
+  points over `10_000` (e.g. `15_000` allows a gross quote up to `1.5x` net).
+- `BASIS_POINTS` is `10_000` (`100%`).
+
+If a router quote exceeds the bound, the payout aborts with the typed error
+`ContractError::FotRouterQuoteExceeded` and **no tokens are transferred**.
+
+## Configuring the Bound
+
+The bound is set alongside the existing slippage parameter when the admin
+configures the router:
+
+```rust
+contract.set_fot_router(
+    &router_address,
+    &100,      // slippage_bps (1%)
+    &15_000,   // max_fot_multiplier_bps (1.5x net)
+);
+```
+
+- `slippage_bps` is validated to be `<= 500` (5%).
+- `max_fot_multiplier_bps` must be between `10_000` (`1x`) and `100_000`
+  (`10x`).
+
+The default value used by the contract tests is `15_000` (`1.5x`). A more
+conservative value is recommended for production deployments.
+
+## Why a Configurable Cap?
+
+- **Token-specific FoT rates vary**: Some tokens have modest fees (1-10%), while
+  exotic tokens may require higher multipliers.
+- **Admin control over trade-offs**: A lower cap limits blast radius; a higher
+  cap supports tokens with larger fees.
+- **Upper ceiling on the ceiling**: The `100_000` (`10x`) hard cap prevents a
+  compromised admin from setting a multiplier so high that the sanity check is
+  rendered meaningless.
+
+## Interaction with Slippage
+
+The sanity check is applied to the **raw gross quote** returned by the router,
+**before** the configured slippage is added. This ensures that a malicious router
+cannot first pass the bound check and then inflate the final transfer amount via
+an excessive slippage buffer.
+
+The final transfer amount sent to the token contract is therefore:
+
+```text
+gross = router_quote(token, net_amount)
+assert gross <= net_amount * max_fot_multiplier_bps / 10_000
+adjusted = gross * (10_000 + slippage_bps) / 10_000
+```
+
+## Security Assumptions
+
+- The program admin is trusted to set a sensible `max_fot_multiplier_bps`.
+- The router contract is still trusted to provide an *accurate* gross amount,
+  but its ability to drain the program is now capped.
+- The escrow contract does not call the router unless a `FotRouter` config has
+  been explicitly set.
+
+## Test Coverage
+
+The `test_fot_routing.rs` suite includes:
+
+- `test_malicious_router_inflated_quote_rejected`: a router returning `100x`
+  the intended net is rejected before any token transfer occurs.
+- `test_fot_router_in_program_data`: the configured `max_fot_multiplier_bps` is
+  persisted alongside `router_contract` and `slippage_bps`.
+
+Existing tests for normal FoT routing, slippage, batch payouts, protocol fees,
+and balance checks continue to exercise the bounded path under safe routers.


### PR DESCRIPTION
# PR Description

Closes #1472 

## Summary

This PR addresses **#1472** by adding an upper-bound sanity validation for values returned by `fot_router.quote()` in `apply_fot_router`.

Previously, the contract only rejected non-positive quote values. Because `quote()` is supplied by an external, configurable router contract, a malicious or misconfigured router could return an arbitrarily large gross amount, potentially causing the escrow contract to over-transfer funds well beyond any reasonable fee-on-transfer compensation.

This implementation introduces a configurable maximum FoT multiplier that bounds acceptable quote values and rejects implausible responses before any payout is executed.

## Changes

* Added an upper-bound sanity check to validate `fot_router.quote()` return values.
* Introduced a configurable `MAX_FOT_MULTIPLIER` parameter alongside `slippage_bps` in `set_fot_router`.
* Added a typed error for quotes exceeding the configured upper bound.
* Updated `apply_fot_router` NatSpec documentation to explain the new validation and its security rationale.
* Added comprehensive tests covering:

  * Valid router quotes.
  * Boundary conditions.
  * Malicious routers returning inflated quotes.
  * Rejection of excessive payouts before execution.
* Added documentation describing the FoT router trust boundary and the purpose of the configurable upper limit.

## Security

This change protects the escrow contract from manipulated router responses by ensuring externally supplied quote values remain within a configurable, reasonable range. It prevents excessive token transfers while preserving legitimate Fee-on-Transfer routing behaviour.

## Testing

* Added unit tests for normal, boundary, and malicious router responses.
* Verified legitimate quotes continue to execute successfully.
* Confirmed inflated quotes are rejected with the expected typed error.
* Ran:

```bash
cargo test -p program-escrow
```

## Documentation

* Updated NatSpec comments for `apply_fot_router`.
* Added `docs/program-escrow-fot-router-trust-boundary.md` documenting the trust model, validation logic, and security assumptions.
