### PR TITLE
feat(grainlify): expand-payout-fee-disclosure-copy

### DIFF
--- a/design/specs/wallet-balance-gas-fee-disclosure.md
+++ b/design/specs/wallet-balance-gas-fee-disclosure.md
@@ -20,7 +20,7 @@ Adds a **WalletBalanceFeeDisplay** component inside `WalletConnectionModal.tsx` 
 │  [Stellar logo]  1,245.80 XLM                       │
 │                   ≈ $312.45 USD                     │
 │                                                     │
-│  Est. fee  ℹ     0.00001 XLM  (≈ $0.0000025)      │
+│  Est. network fee  ℹ     0.00001 XLM  (≈ $0.0000025)      │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -31,7 +31,7 @@ Adds a **WalletBalanceFeeDisplay** component inside `WalletConnectionModal.tsx` 
 | Token icon | Stellar (XLM) logo, 24×24 | `rounded-full`, `border border-white/10` |
 | Balance amount | Formatted number + ticker | `text-[16px] font-semibold` |
 | USD equivalent | "≈ $X.XX USD" | `text-[13px] text-[#b8a898]` (dark) / `text-[#7a6b5a]` (light) |
-| Fee label | "Est. fee" + info icon | `text-[13px]` + `Info` icon 14×14 |
+| Fee label | "Est. network fee" + info icon | `text-[13px]` + `Info` icon 14×14 |
 | Fee amount | Formatted fee + USD | `text-[13px] font-mono` |
 
 ---
@@ -41,13 +41,14 @@ Adds a **WalletBalanceFeeDisplay** component inside `WalletConnectionModal.tsx` 
 ### 1. Default (balance loaded, fee available)
 
 - Token icon, balance, USD equivalent, and fee line all visible
-- Tooltip on info icon explains: _"Estimated network fee based on current Stellar base fee. Actual fee may vary."_
+- Tooltip on info icon explains: _"Estimated Stellar network fee for signing transactions, including payouts…"_ (see `walletFeeDisclosureCopy.ts`)
 
 ### 2. Insufficient balance
 
 - Balance text turns `text-[#ef4444]` (dark) / `text-[#dc2626]` (light) — maps to `color.semantic.error.600`
 - Warning icon (`AlertTriangle`) appears inline after balance amount
-- Fee line remains visible but fee amount is dimmed (`opacity-60`)
+- Alert banner (`role="alert"`) explains insufficient XLM for typical network fees
+- Fee line remains visible but fee row uses reduced opacity (`opacity-60`)
 - `aria-invalid="true"` on the balance region
 
 ### 3. Loading
@@ -61,13 +62,22 @@ Adds a **WalletBalanceFeeDisplay** component inside `WalletConnectionModal.tsx` 
 - A subtle amber banner appears: _"Balance may be outdated. Pull to refresh."_
 - Banner uses `bg-[#f59e0b]/[0.08] text-[#f59e0b]` (semantic.warning)
 - Balance and fee values remain visible but prefixed with a `Clock` icon (12×12)
-- Tooltip on `Clock` icon: _"Last updated X ago"_
+- When `lastUpdated` is provided, the clock exposes `aria-label` / `title` with _"Last updated Xm ago"_
 
 ### 5. Fee unavailable
 
-- Fee line shows: _"Fee unavailable"_ in `text-[#8a7e70]` (muted)
-- Info icon replaced with `AlertCircle` icon
+- Fee line shows: _"Fee unavailable"_ in muted italic text
+- `AlertCircle` icon with `aria-label` describing that the wallet will show the exact fee at confirmation
 - Balance section unaffected
+
+### 6. Partial quote data (edge)
+
+| Condition | UI behavior |
+|---|---|
+| `usdEquivalent === null` | Balance row shows _"USD equivalent unavailable"_ |
+| `estimatedFee` set, `feeUsdEquivalent === null` | Native fee + ticker only; no `(≈ $…)` suffix |
+| `feeUsdEquivalent < 0.01` | USD suffix renders as _"< $0.01"_ |
+| `balance` with thousands separators | Insufficient check strips commas before numeric compare |
 
 ---
 
@@ -142,6 +152,9 @@ interface WalletBalanceFeeDisplayProps {
 | File | Purpose |
 |---|---|
 | `frontend/src/features/auth/components/WalletBalanceFeeDisplay.tsx` | New component |
+| `frontend/src/features/auth/components/walletFeeDisclosureCopy.ts` | Centralized disclosure strings + format helpers |
+| `frontend/src/features/auth/components/__tests__/WalletBalanceFeeDisplay.test.tsx` | Component regression tests |
+| `frontend/src/features/auth/components/__tests__/walletFeeDisclosureCopy.test.ts` | Copy + formatter unit tests |
 | `frontend/src/features/auth/components/WalletConnectionModal.tsx` | Integration point |
 | `design/specs/wallet-balance-gas-fee-disclosure.md` | This spec |
 

--- a/frontend/src/features/auth/components/WalletBalanceFeeDisplay.tsx
+++ b/frontend/src/features/auth/components/WalletBalanceFeeDisplay.tsx
@@ -2,6 +2,12 @@ import { useState, useRef, useEffect } from 'react';
 import { Info, AlertTriangle, Clock, AlertCircle } from 'lucide-react';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
+import {
+  WALLET_FEE_DISCLOSURE_COPY,
+  formatTimeAgo,
+  formatWalletUsd,
+  staleBalanceAriaLabel,
+} from './walletFeeDisclosureCopy';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,26 +32,17 @@ export interface WalletBalanceFeeDisplayProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function formatUsd(value: number): string {
-  if (value < 0.01) return '< $0.01';
-  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-}
-
-function timeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours}h ago`;
-}
-
-// ---------------------------------------------------------------------------
 // Tooltip
 // ---------------------------------------------------------------------------
-function InfoTooltip({ content, isDark }: { content: string; isDark: boolean }) {
+function InfoTooltip({
+  content,
+  isDark,
+  ariaLabel = 'More information',
+}: {
+  content: string;
+  isDark: boolean;
+  ariaLabel?: string;
+}) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const tooltipId = useRef(`tooltip-${Math.random().toString(36).slice(2, 8)}`).current;
@@ -77,7 +74,7 @@ function InfoTooltip({ content, isDark }: { content: string; isDark: boolean }) 
         className={`inline-flex items-center justify-center w-[18px] h-[18px] rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#c9983a]/50 ${
           isDark ? 'text-[#8a7e70] hover:text-[#b8a898]' : 'text-[#a8a29e] hover:text-[#78716c]'
         }`}
-        aria-label="More information"
+        aria-label={ariaLabel}
       >
         <Info className="w-3.5 h-3.5" />
       </button>
@@ -111,7 +108,8 @@ function InfoTooltip({ content, isDark }: { content: string; isDark: boolean }) 
  * Displays the connected wallet's native token balance with USD equivalent
  * and estimated network transaction fee.
  *
- * States: default, insufficient-balance, loading, stale, fee-unavailable.
+ * States: default, insufficient-balance, loading, stale, fee-unavailable,
+ * and partial quotes (USD or fee USD missing).
  */
 export function WalletBalanceFeeDisplay({
   balance,
@@ -129,8 +127,9 @@ export function WalletBalanceFeeDisplay({
   const insufficientBalance = balance !== null && parseFloat(balance.replace(/,/g, '')) <= 0;
   const feeAvailable = estimatedFee !== null;
 
-  const feeTooltipText =
-    'Estimated network fee based on current Stellar base fee. Actual fee may vary.';
+  const feeTooltipText = WALLET_FEE_DISCLOSURE_COPY.feeTooltip;
+  const staleUpdatedLabel =
+    isStale && lastUpdated ? staleBalanceAriaLabel(lastUpdated) : undefined;
 
   // -----------------------------------------------------------------------
   // Loading state
@@ -139,7 +138,7 @@ export function WalletBalanceFeeDisplay({
     return (
       <div
         aria-busy="true"
-        aria-label="Loading wallet balance"
+        aria-label={WALLET_FEE_DISCLOSURE_COPY.loadingAriaLabel}
         className={`mx-6 mb-4 p-4 rounded-[16px] border backdrop-blur-[40px] ${
           isDark
             ? 'bg-white/[0.04] border-white/[0.08]'
@@ -235,7 +234,8 @@ export function WalletBalanceFeeDisplay({
               className={`inline-block w-3 h-3 ml-1.5 -mt-0.5 ${
                 isDark ? 'text-[#f59e0b]' : 'text-[#d97706]'
               }`}
-              aria-hidden="true"
+              aria-label={staleUpdatedLabel ?? 'Balance may be outdated'}
+              title={lastUpdated ? `Last updated ${formatTimeAgo(lastUpdated)}` : undefined}
             />
           )}
           {insufficientBalance && (
@@ -258,8 +258,8 @@ export function WalletBalanceFeeDisplay({
           }`}
         >
           {usdEquivalent !== null
-            ? `≈ ${formatUsd(usdEquivalent)} USD`
-            : 'USD equivalent unavailable'}
+            ? `≈ ${formatWalletUsd(usdEquivalent)} USD`
+            : WALLET_FEE_DISCLOSURE_COPY.usdUnavailable}
         </span>
       </div>
 
@@ -273,7 +273,21 @@ export function WalletBalanceFeeDisplay({
           }`}
         >
           <Clock className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
-          Balance may be outdated. Pull to refresh.
+          {WALLET_FEE_DISCLOSURE_COPY.staleBanner}
+        </div>
+      )}
+
+      {insufficientBalance && (
+        <div
+          role="alert"
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-[8px] text-[12px] mb-3 ${
+            isDark
+              ? 'bg-[#ef4444]/[0.08] text-[#ef4444]'
+              : 'bg-[#dc2626]/[0.08] text-[#dc2626]'
+          }`}
+        >
+          <AlertTriangle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+          {WALLET_FEE_DISCLOSURE_COPY.insufficientBalanceAlert}
         </div>
       )}
 
@@ -281,7 +295,7 @@ export function WalletBalanceFeeDisplay({
       <div
         className={`flex items-center gap-3 pt-3 border-t ${
           isDark ? 'border-white/[0.06]' : 'border-white/40'
-        }`}
+        } ${insufficientBalance ? 'opacity-60' : ''}`}
       >
         <div className="w-6 flex-shrink-0" />
         <span
@@ -289,16 +303,20 @@ export function WalletBalanceFeeDisplay({
             isDark ? 'text-[#8a7e70]' : 'text-[#a8a29e]'
           }`}
         >
-          Est. fee
+          {WALLET_FEE_DISCLOSURE_COPY.feeLabel}
         </span>
         {feeAvailable ? (
-          <InfoTooltip content={feeTooltipText} isDark={isDark} />
+          <InfoTooltip
+            content={feeTooltipText}
+            isDark={isDark}
+            ariaLabel={WALLET_FEE_DISCLOSURE_COPY.infoButtonAriaLabel}
+          />
         ) : (
           <AlertCircle
             className={`w-3.5 h-3.5 ${
               isDark ? 'text-[#8a7e70]' : 'text-[#a8a29e]'
             }`}
-            aria-hidden="true"
+            aria-label={WALLET_FEE_DISCLOSURE_COPY.feeUnavailableAriaLabel}
           />
         )}
         <span
@@ -321,12 +339,12 @@ export function WalletBalanceFeeDisplay({
                     isDark ? 'text-[#8a7e70]' : 'text-[#a8a29e]'
                   }`}
                 >
-                  (≈ {formatUsd(feeUsdEquivalent)})
+                  (≈ {formatWalletUsd(feeUsdEquivalent)})
                 </span>
               )}
             </>
           ) : (
-            'Fee unavailable'
+            WALLET_FEE_DISCLOSURE_COPY.feeUnavailable
           )}
         </span>
       </div>

--- a/frontend/src/features/auth/components/__tests__/WalletBalanceFeeDisplay.test.tsx
+++ b/frontend/src/features/auth/components/__tests__/WalletBalanceFeeDisplay.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext';
+import { WalletBalanceFeeDisplay } from '../WalletBalanceFeeDisplay';
+import { WALLET_FEE_DISCLOSURE_COPY } from '../walletFeeDisclosureCopy';
+
+const baseProps = {
+  balance: '1,245.80',
+  usdEquivalent: 312.45,
+  estimatedFee: '0.00001',
+  feeUsdEquivalent: 0.0000025,
+  isLoading: false,
+  isStale: false,
+  lastUpdated: null as Date | null,
+};
+
+function renderDisplay(overrides: Partial<typeof baseProps & { ticker?: string }> = {}) {
+  localStorage.setItem('theme', 'light');
+  return render(
+    <ThemeProvider>
+      <WalletBalanceFeeDisplay {...baseProps} {...overrides} />
+    </ThemeProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = '';
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe('WalletBalanceFeeDisplay — visibility', () => {
+  it('renders nothing when balance is null (wallet not connected)', () => {
+    const { container } = renderDisplay({ balance: null });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows loading skeleton with busy state', () => {
+    renderDisplay({ isLoading: true });
+    expect(screen.getByLabelText(WALLET_FEE_DISCLOSURE_COPY.loadingAriaLabel)).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});
+
+describe('WalletBalanceFeeDisplay — fee disclosure copy', () => {
+  it('shows network fee label and XLM amount with sub-cent USD', () => {
+    renderDisplay();
+    expect(screen.getByText(WALLET_FEE_DISCLOSURE_COPY.feeLabel)).toBeInTheDocument();
+    expect(screen.getByText(/0\.00001/)).toBeInTheDocument();
+    expect(screen.getByText(/< \$0\.01/)).toBeInTheDocument();
+  });
+
+  it('reveals expanded fee tooltip on info button click', async () => {
+    const user = userEvent.setup();
+    renderDisplay();
+    await user.click(screen.getByRole('button', { name: WALLET_FEE_DISCLOSURE_COPY.infoButtonAriaLabel }));
+    expect(screen.getByRole('tooltip')).toHaveTextContent(WALLET_FEE_DISCLOSURE_COPY.feeTooltip);
+  });
+
+  it('shows fee-unavailable copy and accessible alert icon', () => {
+    renderDisplay({ estimatedFee: null, feeUsdEquivalent: null });
+    expect(screen.getByText(WALLET_FEE_DISCLOSURE_COPY.feeUnavailable)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(WALLET_FEE_DISCLOSURE_COPY.feeUnavailableAriaLabel)
+    ).toBeInTheDocument();
+  });
+
+  it('omits fee USD line when feeUsdEquivalent is null but native fee exists', () => {
+    renderDisplay({ feeUsdEquivalent: null });
+    expect(screen.getByText(/0\.00001/)).toBeInTheDocument();
+    expect(screen.queryByText(/≈ \$/)).not.toBeInTheDocument();
+  });
+
+  it('shows USD unavailable copy when balance USD is missing', () => {
+    renderDisplay({ usdEquivalent: null });
+    expect(screen.getByText(WALLET_FEE_DISCLOSURE_COPY.usdUnavailable)).toBeInTheDocument();
+  });
+});
+
+describe('WalletBalanceFeeDisplay — edge states', () => {
+  it('flags insufficient balance with alert and aria-invalid', () => {
+    renderDisplay({ balance: '0.00' });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      WALLET_FEE_DISCLOSURE_COPY.insufficientBalanceAlert
+    );
+    expect(screen.getByText('0.00').closest('[aria-invalid="true"]')).toBeTruthy();
+  });
+
+  it('parses comma-separated balances for insufficient check', () => {
+    renderDisplay({ balance: '0,00' });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows stale banner and last-updated label on clock when lastUpdated is set', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'));
+    const lastUpdated = new Date('2026-07-27T11:55:00.000Z');
+    renderDisplay({ isStale: true, lastUpdated });
+    expect(screen.getByText(WALLET_FEE_DISCLOSURE_COPY.staleBanner)).toBeInTheDocument();
+    expect(screen.getByLabelText('Balance last updated 5m ago')).toBeInTheDocument();
+  });
+
+  it('uses custom ticker in fee row', () => {
+    renderDisplay({ ticker: 'TEST' });
+    expect(screen.getAllByText('TEST').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('WalletBalanceFeeDisplay — live region', () => {
+  it('announces balance updates politely', () => {
+    renderDisplay();
+    expect(screen.getByText('1,245.80').closest('[aria-live="polite"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/auth/components/__tests__/walletFeeDisclosureCopy.test.ts
+++ b/frontend/src/features/auth/components/__tests__/walletFeeDisclosureCopy.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WALLET_FEE_DISCLOSURE_COPY,
+  formatTimeAgo,
+  formatWalletUsd,
+  staleBalanceAriaLabel,
+} from '../walletFeeDisclosureCopy';
+
+describe('walletFeeDisclosureCopy — strings', () => {
+  it('documents fee tooltip mentions Stellar network and payouts', () => {
+    expect(WALLET_FEE_DISCLOSURE_COPY.feeTooltip).toMatch(/Stellar network fee/i);
+    expect(WALLET_FEE_DISCLOSURE_COPY.feeTooltip).toMatch(/payouts/i);
+  });
+
+  it('documents fee-unavailable screen reader hint', () => {
+    expect(WALLET_FEE_DISCLOSURE_COPY.feeUnavailableAriaLabel.length).toBeGreaterThan(20);
+  });
+});
+
+describe('formatWalletUsd', () => {
+  it('shows sub-cent values as bounded text', () => {
+    expect(formatWalletUsd(0.0000025)).toBe('< $0.01');
+  });
+
+  it('formats standard USD amounts', () => {
+    expect(formatWalletUsd(312.45)).toBe('$312.45');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-07-27T12:00:00.000Z').getTime();
+
+  it('reports seconds under one minute', () => {
+    const date = new Date(now - 45 * 1000);
+    expect(formatTimeAgo(date, now)).toBe('45s ago');
+  });
+
+  it('reports minutes under one hour', () => {
+    const date = new Date(now - 12 * 60 * 1000);
+    expect(formatTimeAgo(date, now)).toBe('12m ago');
+  });
+
+  it('reports hours beyond one hour', () => {
+    const date = new Date(now - 3 * 60 * 60 * 1000);
+    expect(formatTimeAgo(date, now)).toBe('3h ago');
+  });
+});
+
+describe('staleBalanceAriaLabel', () => {
+  it('includes relative last-updated text', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-27T12:00:00.000Z'));
+    const lastUpdated = new Date('2026-07-27T11:50:00.000Z');
+    expect(staleBalanceAriaLabel(lastUpdated)).toBe('Balance last updated 10m ago');
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/features/auth/components/walletFeeDisclosureCopy.ts
+++ b/frontend/src/features/auth/components/walletFeeDisclosureCopy.ts
@@ -1,0 +1,38 @@
+/**
+ * User-facing copy for wallet balance and network fee disclosure in connect flows.
+ * Kept in one module so tests and design docs can pin exact strings.
+ */
+export const WALLET_FEE_DISCLOSURE_COPY = {
+  feeLabel: 'Est. network fee',
+  feeTooltip:
+    'Estimated Stellar network fee for signing transactions, including payouts. Based on the current base fee; your wallet shows the exact amount before you confirm.',
+  feeUnavailable: 'Fee unavailable',
+  feeUnavailableAriaLabel:
+    'Network fee estimate unavailable. Your wallet will show the exact fee before you confirm a transaction.',
+  usdUnavailable: 'USD equivalent unavailable',
+  staleBanner: 'Balance may be outdated. Pull to refresh.',
+  insufficientBalanceAlert:
+    'Insufficient balance to cover typical network fees. Add XLM before signing transactions or receiving payouts.',
+  loadingAriaLabel: 'Loading wallet balance',
+  infoButtonAriaLabel: 'More information about the estimated network fee',
+} as const;
+
+export function staleBalanceAriaLabel(lastUpdated: Date): string {
+  return `Balance last updated ${formatTimeAgo(lastUpdated)}`;
+}
+
+/** Relative time for stale indicators and tooltips. */
+export function formatTimeAgo(date: Date, nowMs: number = Date.now()): string {
+  const seconds = Math.floor((nowMs - date.getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+/** USD formatting for balance and fee equivalents shown in the wallet panel. */
+export function formatWalletUsd(value: number): string {
+  if (value < 0.01) return '< $0.01';
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}


### PR DESCRIPTION
Closes #1625

## Summary
- Expand payout fee disclosure copy

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths