### PR TITLE
test: add precedence coverage for overlapping escrow and address freezes

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -24,7 +24,8 @@ mod test_fee_on_transfer;
 mod test_filter_pagination;
 #[cfg(test)]
 mod test_multi_token_fees;
-// #[cfg(test)] mod test_frozen_balance; // pre-existing SDK/API drift blocks filtered test builds
+#[cfg(test)]
+mod test_frozen_balance;
 #[cfg(test)]
 mod test_reentrancy_guard;
 // #[cfg(test)] mod test_admin_rotation; // pre-existing SDK/API drift blocks filtered test builds
@@ -2607,6 +2608,32 @@ impl BountyEscrowContract {
             .get(&DataKey::AddressFreeze(address.clone()))
     }
 
+    /// # Freeze precedence (escrow-level vs address-level)
+    ///
+    /// The contract has two **independent** freeze layers:
+    /// - escrow-level: `EscrowFreeze(bounty_id)` via `freeze_escrow`
+    /// - address-level: `AddressFreeze(address)` via `freeze_address`,
+    ///   keyed on the escrow **depositor**
+    ///
+    /// Every funds-out path (release, partial/batch release, refund, claim,
+    /// authorize_claim, renew, queued-release execution) checks BOTH layers,
+    /// escrow first, then depositor address:
+    ///
+    /// * **Either freeze independently blocks** the operation; both layers
+    ///   must be unfrozen for it to proceed.
+    /// * When **both** apply, the escrow-level check runs first, so the
+    ///   deterministic error is [`Error::EscrowFrozen`], never
+    ///   [`Error::AddressFrozen`].
+    /// * Unfreezing one layer never touches the other layer's record;
+    ///   `get_escrow_freeze_record` and `get_address_freeze_record` stay
+    ///   independently queryable and accurate.
+    /// * Address freezes gate the **depositor** only: a frozen payee
+    ///   (contributor / claim recipient) does not block payouts — freeze the
+    ///   escrow itself to stop a payout to a specific recipient.
+    /// * Freezes gate funds-out only: `lock_funds` and read-only queries are
+    ///   unaffected.
+    ///
+    /// Covered by the precedence matrix tests in `test_frozen_balance.rs`.
     fn ensure_escrow_not_frozen(env: &Env, bounty_id: u64) -> Result<(), Error> {
         if Self::get_escrow_freeze_record_internal(env, bounty_id)
             .map(|record| record.frozen)
@@ -2655,6 +2682,13 @@ impl BountyEscrowContract {
     /// Freeze a specific escrow so release and refund paths fail before any token transfer.
     ///
     /// Read-only queries remain available while the freeze is active.
+    ///
+    /// # Precedence
+    /// Independent of any address-level freeze: this blocks the escrow even
+    /// if its depositor is unfrozen, and unfreezing it does not lift an
+    /// address-level freeze on the depositor (see `ensure_escrow_not_frozen`
+    /// for the full precedence rules). When both layers are frozen, this
+    /// layer's error (`EscrowFrozen`) is the one reported.
     pub fn freeze_escrow(
         env: Env,
         bounty_id: u64,
@@ -2746,6 +2780,14 @@ impl BountyEscrowContract {
     /// Freeze all release/refund operations for escrows owned by `address`.
     ///
     /// Read-only queries remain available while the freeze is active.
+    ///
+    /// # Precedence
+    /// `address` is matched against the escrow **depositor** on every
+    /// funds-out path; freezing a contributor or claim recipient has no
+    /// blocking effect. Independent of any escrow-level freeze: it blocks
+    /// all of the depositor's escrows even when none of them is individually
+    /// frozen, and unfreezing an escrow does not lift this freeze (see
+    /// `ensure_escrow_not_frozen` for the full precedence rules).
     pub fn freeze_address(
         env: Env,
         address: Address,

--- a/contracts/bounty_escrow/contracts/escrow/src/test_frozen_balance.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_frozen_balance.rs
@@ -1,3 +1,23 @@
+//! Freeze-mechanism tests for `BountyEscrowContract`.
+//!
+//! Two independent freeze layers exist:
+//! - **Escrow-level**: `freeze_escrow` / `unfreeze_escrow`, keyed by `bounty_id`
+//! - **Address-level**: `freeze_address` / `unfreeze_address`, keyed by the
+//!   escrow **depositor** address
+//!
+//! Precedence (locked in by the matrix tests below):
+//! - **Either freeze independently blocks** release, refund, and claim.
+//!   Both freezes must be absent for the operation to proceed (logical OR of
+//!   blocks; equivalently AND of permissions).
+//! - When **both** freezes apply, the escrow-level check runs first, so the
+//!   deterministic error is `EscrowFrozen` (never `AddressFrozen`).
+//! - Address freezes are keyed on the **depositor**: a frozen contributor /
+//!   claim recipient does NOT block release or claim (funds-out is gated on
+//!   the escrow and its owner, not the payee). Freezing a payee requires
+//!   freezing the escrow itself.
+//! - Freezes gate funds-out paths only: a frozen depositor can still lock
+//!   new funds, and read-only queries always succeed.
+
 #![cfg(test)]
 
 use soroban_sdk::{
@@ -5,11 +25,10 @@ use soroban_sdk::{
     token, Address, Env,
 };
 
-use crate::{BountyEscrowContract, BountyEscrowContractClient, DataKey, Error};
+use crate::{BountyEscrowContract, BountyEscrowContractClient, DisputeReason, Error};
 
 struct TestEnv<'a> {
     env: Env,
-    contract_id: Address,
     client: BountyEscrowContractClient<'a>,
     token_admin: token::StellarAssetClient<'a>,
     admin: Address,
@@ -26,7 +45,8 @@ impl<'a> TestEnv<'a> {
         let depositor = Address::generate(&env);
         let contributor = Address::generate(&env);
 
-        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
         let token_admin = token::StellarAssetClient::new(&env, &token_id);
 
         let contract_id = env.register_contract(None, BountyEscrowContract);
@@ -39,7 +59,6 @@ impl<'a> TestEnv<'a> {
 
         Self {
             env,
-            contract_id,
             client,
             token_admin,
             admin,
@@ -52,6 +71,30 @@ impl<'a> TestEnv<'a> {
         let deadline = self.env.ledger().timestamp() + 10_000;
         self.client
             .lock_funds(&self.depositor, &bounty_id, &amount, &deadline);
+    }
+
+    /// Apply one of the four {escrow frozen} x {depositor frozen} combos.
+    fn apply_freezes(&self, bounty_id: u64, escrow_frozen: bool, address_frozen: bool) {
+        if escrow_frozen {
+            self.client.freeze_escrow(&bounty_id, &None);
+        }
+        if address_frozen {
+            self.client.freeze_address(&self.depositor, &None);
+        }
+    }
+
+    /// Advance the ledger clock past every deadline used by `lock`.
+    fn pass_deadline(&self) {
+        self.env
+            .ledger()
+            .set_timestamp(self.env.ledger().timestamp() + 20_000);
+    }
+
+    /// Authorize a claim for `bounty_id` payable to the contributor.
+    fn authorize_claim(&self, bounty_id: u64) {
+        self.client.set_claim_window(&10_000);
+        self.client
+            .authorize_claim(&bounty_id, &self.contributor, &DisputeReason::Other);
     }
 }
 
@@ -74,10 +117,7 @@ fn test_freeze_escrow_blocks_refund() {
     let t = TestEnv::new();
     t.lock(1, 1000);
     t.client.freeze_escrow(&1, &None);
-    // advance past deadline
-    t.env
-        .ledger()
-        .set_timestamp(t.env.ledger().timestamp() + 20_000);
+    t.pass_deadline();
     let result = t.client.try_refund(&1);
     assert_eq!(result.unwrap_err().unwrap(), Error::EscrowFrozen);
 }
@@ -138,9 +178,7 @@ fn test_unfreeze_escrow_allows_refund() {
     t.lock(1, 1000);
     t.client.freeze_escrow(&1, &None);
     t.client.unfreeze_escrow(&1);
-    t.env
-        .ledger()
-        .set_timestamp(t.env.ledger().timestamp() + 20_000);
+    t.pass_deadline();
     t.client.refund(&1);
     let info = t.client.get_escrow_info(&1);
     assert_eq!(info.status, crate::EscrowStatus::Refunded);
@@ -168,27 +206,10 @@ fn test_unfreeze_escrow_emits_event() {
 }
 
 #[test]
-fn test_non_admin_cannot_freeze_escrow() {
+fn test_freeze_escrow_missing_bounty_rejected() {
     let t = TestEnv::new();
-    t.lock(1, 1000);
-    // mock_all_auths is on, so we test by calling without setting admin
-    // Use try_ variant to catch the panic from require_auth when a non-admin calls
-    // Since mock_all_auths is on, we verify the admin check via a second contract instance
-    let non_admin = Address::generate(&t.env);
-    // The function internally fetches admin and calls admin.require_auth()
-    // With mock_all_auths this will pass auth but we can verify the contract
-    // correctly restricts by checking only admin can call it structurally.
-    // For a stricter test, create a fresh env without mock_all_auths:
-    let env2 = Env::default();
-    let admin2 = Address::generate(&env2);
-    let token_id2 = env2.register_stellar_asset_contract_v2(admin2.clone());
-    let contract_id2 = env2.register_contract(None, BountyEscrowContract);
-    let client2 = BountyEscrowContractClient::new(&env2, &contract_id2);
-    env2.mock_all_auths();
-    client2.init(&admin2, &token_id2);
-    // freeze_escrow on non-existent bounty returns BountyNotFound, not auth error
-    // The admin check happens first — with mock_all_auths it passes, but BountyNotFound fires
-    let result = client2.try_freeze_escrow(&999, &None);
+    // freeze_escrow on a non-existent bounty returns BountyNotFound
+    let result = t.client.try_freeze_escrow(&999, &None);
     assert_eq!(result.unwrap_err().unwrap(), Error::BountyNotFound);
 }
 
@@ -210,8 +231,7 @@ fn test_freeze_escrow_does_not_block_new_lock_on_different_id() {
     t.lock(1, 1000);
     t.client.freeze_escrow(&1, &None);
     // locking a new bounty id should work fine
-    let deadline = t.env.ledger().timestamp() + 10_000;
-    t.client.lock_funds(&t.depositor, &2, &500, &deadline);
+    t.lock(2, 500);
     let info = t.client.get_escrow_info(&2);
     assert_eq!(info.status, crate::EscrowStatus::Locked);
 }
@@ -225,6 +245,7 @@ fn test_get_escrow_freeze_record_returns_correct_data() {
     let record = t.client.get_escrow_freeze_record(&1).unwrap();
     assert!(record.frozen);
     assert_eq!(record.reason, Some(reason));
+    assert_eq!(record.frozen_by, t.admin);
 }
 
 // ── Address-level freeze ─────────────────────────────────────────────────────
@@ -237,9 +258,7 @@ fn test_freeze_address_blocks_refund() {
         &t.depositor,
         &Some(soroban_sdk::String::from_str(&t.env, "kyc")),
     );
-    t.env
-        .ledger()
-        .set_timestamp(t.env.ledger().timestamp() + 20_000);
+    t.pass_deadline();
     let result = t.client.try_refund(&1);
     assert_eq!(result.unwrap_err().unwrap(), Error::AddressFrozen);
 }
@@ -286,7 +305,7 @@ fn test_freeze_address_does_not_affect_different_depositor() {
     let deadline = t.env.ledger().timestamp() + 10_000;
     t.client.lock_funds(&t.depositor, &1, &1000, &deadline);
     t.client.lock_funds(&other, &2, &500, &deadline);
-    t.client.freeze_address(&t.depositor);
+    t.client.freeze_address(&t.depositor, &None);
     // other depositor's escrow unaffected
     t.client.release_funds(&2, &t.contributor);
     let info = t.client.get_escrow_info(&2);
@@ -312,4 +331,384 @@ fn test_get_address_freeze_record() {
     let record = t.client.get_address_freeze_record(&t.depositor).unwrap();
     assert!(record.frozen);
     assert_eq!(record.reason, Some(reason));
+    assert_eq!(record.frozen_by, t.admin);
+}
+
+// ── Overlapping freeze precedence: {escrow} x {address} matrix ───────────────
+//
+// Locked-in precedence: either freeze independently blocks release, refund,
+// and claim. When both apply, the escrow-level check runs first, so the
+// deterministic error is EscrowFrozen. A future change that makes one layer
+// bypass the other flips a row in these matrices and fails the test.
+
+/// Expected outcome for a funds-out operation under a freeze combination.
+/// `None` = operation must succeed; `Some(e)` = must fail with exactly `e`.
+fn expected_error(escrow_frozen: bool, address_frozen: bool) -> Option<Error> {
+    match (escrow_frozen, address_frozen) {
+        (false, false) => None,
+        (true, _) => Some(Error::EscrowFrozen), // escrow check runs first
+        (false, true) => Some(Error::AddressFrozen),
+    }
+}
+
+#[test]
+fn test_release_freeze_precedence_matrix() {
+    for escrow_frozen in [false, true] {
+        for address_frozen in [false, true] {
+            let t = TestEnv::new();
+            t.lock(1, 1000);
+            t.apply_freezes(1, escrow_frozen, address_frozen);
+
+            let result = t.client.try_release_funds(&1, &t.contributor);
+            match expected_error(escrow_frozen, address_frozen) {
+                None => {
+                    assert!(
+                        result.is_ok(),
+                        "release must succeed when neither freeze applies"
+                    );
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Released
+                    );
+                }
+                Some(expected) => {
+                    assert_eq!(
+                        result.unwrap_err().unwrap(),
+                        expected,
+                        "release: wrong outcome for escrow_frozen={}, address_frozen={}",
+                        escrow_frozen,
+                        address_frozen
+                    );
+                    // Blocked release must not move state.
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Locked
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_refund_freeze_precedence_matrix() {
+    for escrow_frozen in [false, true] {
+        for address_frozen in [false, true] {
+            let t = TestEnv::new();
+            t.lock(1, 1000);
+            t.apply_freezes(1, escrow_frozen, address_frozen);
+            t.pass_deadline();
+
+            let result = t.client.try_refund(&1);
+            match expected_error(escrow_frozen, address_frozen) {
+                None => {
+                    assert!(
+                        result.is_ok(),
+                        "refund must succeed when neither freeze applies"
+                    );
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Refunded
+                    );
+                }
+                Some(expected) => {
+                    assert_eq!(
+                        result.unwrap_err().unwrap(),
+                        expected,
+                        "refund: wrong outcome for escrow_frozen={}, address_frozen={}",
+                        escrow_frozen,
+                        address_frozen
+                    );
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Locked
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_claim_freeze_precedence_matrix() {
+    for escrow_frozen in [false, true] {
+        for address_frozen in [false, true] {
+            let t = TestEnv::new();
+            t.lock(1, 1000);
+            // Authorize before freezing: authorize_claim itself checks both
+            // freezes, so the freeze must land between authorize and claim.
+            t.authorize_claim(1);
+            t.apply_freezes(1, escrow_frozen, address_frozen);
+
+            let result = t.client.try_claim(&1);
+            match expected_error(escrow_frozen, address_frozen) {
+                None => {
+                    assert!(
+                        result.is_ok(),
+                        "claim must succeed when neither freeze applies"
+                    );
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Released
+                    );
+                }
+                Some(expected) => {
+                    assert_eq!(
+                        result.unwrap_err().unwrap(),
+                        expected,
+                        "claim: wrong outcome for escrow_frozen={}, address_frozen={}",
+                        escrow_frozen,
+                        address_frozen
+                    );
+                    assert_eq!(
+                        t.client.get_escrow_info(&1).status,
+                        crate::EscrowStatus::Locked
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// authorize_claim is itself a gated path: both freezes independently block
+/// creating a new pending claim in the first place.
+#[test]
+fn test_authorize_claim_blocked_by_either_freeze() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.client.freeze_escrow(&1, &None);
+    t.client.set_claim_window(&10_000);
+    assert_eq!(
+        t.client
+            .try_authorize_claim(&1, &t.contributor, &DisputeReason::Other)
+            .unwrap_err()
+            .unwrap(),
+        Error::EscrowFrozen
+    );
+
+    let t2 = TestEnv::new();
+    t2.lock(1, 1000);
+    t2.client.freeze_address(&t2.depositor, &None);
+    t2.client.set_claim_window(&10_000);
+    assert_eq!(
+        t2.client
+            .try_authorize_claim(&1, &t2.contributor, &DisputeReason::Other)
+            .unwrap_err()
+            .unwrap(),
+        Error::AddressFrozen
+    );
+}
+
+// ── Freeze scope boundaries (documented behavior) ────────────────────────────
+
+/// Address freezes are keyed on the escrow **depositor**. Freezing the
+/// contributor (payee) does NOT block release — funds-out gating follows the
+/// escrow and its owner. To stop a payout to a specific recipient, freeze the
+/// escrow itself.
+#[test]
+fn test_contributor_freeze_does_not_block_release() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.client.freeze_address(&t.contributor, &None);
+
+    t.client.release_funds(&1, &t.contributor);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Released
+    );
+}
+
+/// Same boundary on the claim path: a frozen claim recipient can still claim
+/// as long as the escrow and its depositor are unfrozen.
+#[test]
+fn test_recipient_freeze_does_not_block_claim() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.authorize_claim(1);
+    t.client.freeze_address(&t.contributor, &None);
+
+    t.client.claim(&1);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Released
+    );
+}
+
+/// Freezes gate funds-out only: a frozen depositor can still lock new funds.
+#[test]
+fn test_frozen_depositor_can_still_lock_new_funds() {
+    let t = TestEnv::new();
+    t.client.freeze_address(&t.depositor, &None);
+    t.lock(1, 1000);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Locked
+    );
+    // ... but cannot release it while frozen.
+    assert_eq!(
+        t.client
+            .try_release_funds(&1, &t.contributor)
+            .unwrap_err()
+            .unwrap(),
+        Error::AddressFrozen
+    );
+}
+
+// ── Overlapping freeze/unfreeze sequences and record independence ────────────
+
+/// Both freezes active, then lifted one at a time (escrow first): the records
+/// stay independently queryable and accurate at every step, and the operation
+/// stays blocked until BOTH freezes are lifted.
+#[test]
+fn test_overlapping_freezes_unfreeze_escrow_first() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+
+    let escrow_reason = soroban_sdk::String::from_str(&t.env, "dispute");
+    let address_reason = soroban_sdk::String::from_str(&t.env, "aml");
+    t.client.freeze_escrow(&1, &Some(escrow_reason.clone()));
+    t.client
+        .freeze_address(&t.depositor, &Some(address_reason.clone()));
+
+    // Both records exist, each with its own reason.
+    let esc = t.client.get_escrow_freeze_record(&1).unwrap();
+    let adr = t.client.get_address_freeze_record(&t.depositor).unwrap();
+    assert!(esc.frozen && adr.frozen);
+    assert_eq!(esc.reason, Some(escrow_reason));
+    assert_eq!(adr.reason, Some(address_reason.clone()));
+
+    // Both frozen → escrow error wins (checked first).
+    assert_eq!(
+        t.client
+            .try_release_funds(&1, &t.contributor)
+            .unwrap_err()
+            .unwrap(),
+        Error::EscrowFrozen
+    );
+
+    // Lift the escrow freeze: its record is gone, the address record is
+    // untouched, and the operation is still blocked — now by the address.
+    t.client.unfreeze_escrow(&1);
+    assert!(t.client.get_escrow_freeze_record(&1).is_none());
+    let adr = t.client.get_address_freeze_record(&t.depositor).unwrap();
+    assert!(adr.frozen);
+    assert_eq!(adr.reason, Some(address_reason));
+    assert_eq!(
+        t.client
+            .try_release_funds(&1, &t.contributor)
+            .unwrap_err()
+            .unwrap(),
+        Error::AddressFrozen
+    );
+
+    // Lift the address freeze: both records gone, operation proceeds.
+    t.client.unfreeze_address(&t.depositor);
+    assert!(t.client.get_address_freeze_record(&t.depositor).is_none());
+    t.client.release_funds(&1, &t.contributor);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Released
+    );
+}
+
+/// Same sequence in the reverse order (address lifted first): still blocked by
+/// the remaining escrow freeze, records stay independent throughout.
+#[test]
+fn test_overlapping_freezes_unfreeze_address_first() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.client.freeze_escrow(&1, &None);
+    t.client.freeze_address(&t.depositor, &None);
+
+    t.client.unfreeze_address(&t.depositor);
+    assert!(t.client.get_address_freeze_record(&t.depositor).is_none());
+    assert!(t.client.get_escrow_freeze_record(&1).unwrap().frozen);
+
+    assert_eq!(
+        t.client
+            .try_release_funds(&1, &t.contributor)
+            .unwrap_err()
+            .unwrap(),
+        Error::EscrowFrozen
+    );
+
+    t.client.unfreeze_escrow(&1);
+    t.client.release_funds(&1, &t.contributor);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Released
+    );
+}
+
+/// Overlapping freezes block refund identically, in both unfreeze orders.
+#[test]
+fn test_overlapping_freezes_block_refund_until_both_lifted() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.client.freeze_escrow(&1, &None);
+    t.client.freeze_address(&t.depositor, &None);
+    t.pass_deadline();
+
+    assert_eq!(
+        t.client.try_refund(&1).unwrap_err().unwrap(),
+        Error::EscrowFrozen
+    );
+
+    t.client.unfreeze_escrow(&1);
+    assert_eq!(
+        t.client.try_refund(&1).unwrap_err().unwrap(),
+        Error::AddressFrozen
+    );
+
+    t.client.unfreeze_address(&t.depositor);
+    t.client.refund(&1);
+    assert_eq!(
+        t.client.get_escrow_info(&1).status,
+        crate::EscrowStatus::Refunded
+    );
+}
+
+/// Unfreezing the escrow must not clear the address record, and vice versa —
+/// re-freezing one layer updates only that layer's record.
+#[test]
+fn test_refreeze_updates_only_its_own_record() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+
+    let first = soroban_sdk::String::from_str(&t.env, "first");
+    let second = soroban_sdk::String::from_str(&t.env, "second");
+    let addr_reason = soroban_sdk::String::from_str(&t.env, "addr");
+
+    t.client.freeze_escrow(&1, &Some(first));
+    t.client
+        .freeze_address(&t.depositor, &Some(addr_reason.clone()));
+
+    t.client.unfreeze_escrow(&1);
+    t.client.freeze_escrow(&1, &Some(second.clone()));
+
+    // Escrow record reflects the second freeze; address record untouched.
+    let esc = t.client.get_escrow_freeze_record(&1).unwrap();
+    assert!(esc.frozen);
+    assert_eq!(esc.reason, Some(second));
+    assert_eq!(esc.frozen_by, t.admin);
+    let adr = t.client.get_address_freeze_record(&t.depositor).unwrap();
+    assert!(adr.frozen);
+    assert_eq!(adr.reason, Some(addr_reason));
+}
+
+/// Freeze records for unrelated keys are never created as a side effect.
+#[test]
+fn test_no_phantom_records_from_overlapping_freezes() {
+    let t = TestEnv::new();
+    t.lock(1, 1000);
+    t.lock(2, 500);
+    t.client.freeze_escrow(&1, &None);
+    t.client.freeze_address(&t.depositor, &None);
+
+    // Escrow 2 has no escrow-level record; contributor has no address record.
+    assert!(t.client.get_escrow_freeze_record(&2).is_none());
+    assert!(t
+        .client
+        .get_address_freeze_record(&t.contributor)
+        .is_none());
 }

--- a/contracts/bounty_escrow/docs/freeze-precedence.md
+++ b/contracts/bounty_escrow/docs/freeze-precedence.md
@@ -1,0 +1,101 @@
+# Freeze Precedence: Escrow-Level vs Address-Level Freezes
+
+**Contract:** `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
+**Checks:** `ensure_escrow_not_frozen`, `ensure_address_not_frozen`
+**Tests:** `contracts/bounty_escrow/contracts/escrow/src/test_frozen_balance.rs`
+
+## The question
+
+The escrow contract exposes two independent freeze mechanisms:
+
+1. **Escrow-level** — `freeze_escrow` / `unfreeze_escrow`, keyed by
+   `bounty_id`, stored at `EscrowFreeze(bounty_id)`.
+2. **Address-level** — `freeze_address` / `unfreeze_address`, keyed by an
+   `Address`, stored at `AddressFreeze(address)`.
+
+What happens when both apply simultaneously to the same bounty and
+depositor — or when only one layer applies? Undefined precedence could let an
+operation slip through when it should be blocked, or block one that
+shouldn't be.
+
+## Locked-in behavior
+
+**Either freeze independently blocks.** Every funds-out path checks both
+layers, escrow first, then the escrow's **depositor** address:
+
+```rust
+Self::ensure_escrow_not_frozen(&env, bounty_id)?;   // -> Error::EscrowFrozen
+Self::ensure_address_not_frozen(&env, &escrow.depositor)?; // -> Error::AddressFrozen
+```
+
+Gated paths: `release_funds`, `partial_release`, `batch_release_funds`,
+`release_with_capability`, `release_with_conversion`, `execute_queued_release`,
+`refund`, `refund_with_capability`, `authorize_claim`, `claim`,
+`claim_with_capability`, `renew_escrow`, and the dry-run/eligibility views.
+
+### Outcome matrix (release, refund, and claim)
+
+| Escrow frozen | Depositor frozen | Outcome |
+|---|---|---|
+| no  | no  | ✅ operation proceeds |
+| yes | no  | ❌ `Error::EscrowFrozen` |
+| no  | yes | ❌ `Error::AddressFrozen` |
+| yes | yes | ❌ `Error::EscrowFrozen` (escrow check runs first — deterministic error ordering) |
+
+### Record independence
+
+The two layers never touch each other's storage:
+
+- Unfreezing the escrow removes only `EscrowFreeze(bounty_id)`; an active
+  `AddressFreeze(depositor)` keeps blocking (and vice versa). The operation
+  proceeds only once **both** freezes are lifted, in either order.
+- `get_escrow_freeze_record` and `get_address_freeze_record` remain
+  independently queryable and accurate throughout overlapping
+  freeze/unfreeze sequences — each keeps its own `reason`, `frozen_at`, and
+  `frozen_by`.
+- Re-freezing one layer updates only that layer's record.
+
+### Scope boundaries (intentional)
+
+- **Address freezes are depositor-keyed.** The address is matched against
+  `escrow.depositor` only. Freezing a contributor or claim recipient does
+  **not** block release or claim. To stop a payout to a specific recipient,
+  freeze the escrow itself (`freeze_escrow`).
+- **Funds-out only.** A frozen depositor can still `lock_funds` (money in is
+  never blocked; money out is), and read-only queries always succeed while
+  any freeze is active.
+
+## Security rationale
+
+- **No bypass through the narrower key.** An admin investigating a depositor
+  can freeze the address once and every present and future escrow they own
+  is blocked — an individually-unfrozen escrow cannot slip through.
+- **No accidental unblocking.** Lifting an escrow-level hold (e.g. a resolved
+  per-bounty dispute) cannot silently release funds still held under an
+  address-level compliance hold, and vice versa: both layers must clear.
+- **Deterministic errors.** With both layers frozen the caller always sees
+  `EscrowFrozen`, keeping error ordering stable for clients and monitoring.
+- **Checks precede transfers.** Both checks run before any state mutation or
+  token transfer on every gated path (CEI-consistent), so a blocked
+  operation leaves no partial state.
+
+## Regression tests
+
+`test_frozen_balance.rs` locks this in:
+
+- `test_release_freeze_precedence_matrix`, `test_refund_freeze_precedence_matrix`,
+  `test_claim_freeze_precedence_matrix` — all four
+  {escrow frozen} × {depositor frozen} combinations per operation, asserting
+  the exact error and that blocked operations leave the escrow `Locked`.
+- `test_overlapping_freezes_unfreeze_escrow_first` / `..._address_first` /
+  `..._block_refund_until_both_lifted` — overlapping sequences stay blocked
+  until both layers are lifted, in either order, with records asserted
+  accurate at every step.
+- `test_refreeze_updates_only_its_own_record`,
+  `test_no_phantom_records_from_overlapping_freezes` — record independence.
+- `test_contributor_freeze_does_not_block_release`,
+  `test_recipient_freeze_does_not_block_claim`,
+  `test_frozen_depositor_can_still_lock_new_funds` — the documented scope
+  boundaries.
+- `test_authorize_claim_blocked_by_either_freeze` — the claim-authorization
+  path is gated the same way.


### PR DESCRIPTION
Closes #1462

---

<head></head><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">test: add precedence coverage for overlapping escrow-level and address-level freezes</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Closes the issue asking what happens when <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">freeze_escrow</code> (per <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bounty_id</code>) and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">freeze_address</code> (per <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Address</code>) apply simultaneously to the same bounty and depositor. The precedence was untested — an undefined interaction here could let a funds-out operation slip through a hold, or keep one blocked after it should have cleared. This PR verifies, locks in, and documents the behavior. <strong>No contract behavior changes</strong> — test coverage and documentation only.</p><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Locked-in precedence</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Every funds-out path (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">release_funds</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">partial_release</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">batch_release_funds</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">refund</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">claim</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">authorize_claim</code>, capability/conversion/queued variants, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">renew_escrow</code>) checks both layers sequentially — escrow first, then the escrow's <strong>depositor</strong> address:</p><div class="codeBlockWrapper_-a7MRw" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: 0% 0% repeat rgb(18, 19, 20); border: 1px solid rgb(42, 43, 44); cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-rust" style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Self::ensure_escrow_not_frozen(&amp;env, bounty_id)?;          // -&gt; Error::EscrowFrozen
Self::ensure_address_not_frozen(&amp;env, &amp;escrow.depositor)?; // -&gt; Error::AddressFrozen
</code></pre></div><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><strong>Either freeze independently blocks.</strong> Both layers must be unfrozen for the operation to proceed:</p>
Escrow frozen | Depositor frozen | Outcome
-- | -- | --
no | no | ✅ proceeds
yes | no | ❌ EscrowFrozen
no | yes | ❌ AddressFrozen
yes | yes | ❌ EscrowFrozen — escrow check runs first (deterministic error ordering)

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><strong>Record independence:</strong> unfreezing one layer never touches the other layer's record; <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_escrow_freeze_record</code> / <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_address_freeze_record</code> stay independently queryable and accurate through overlapping freeze/unfreeze sequences, each keeping its own <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">reason</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frozen_at</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frozen_by</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><strong>Scope boundaries (intentional, now documented):</strong> address freezes match the <strong>depositor</strong> only — a frozen contributor/claim recipient does not block payouts (freeze the escrow itself for that); freezes gate funds-out only, so a frozen depositor can still <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lock_funds</code> and read-only queries always succeed.</p><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Tests</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Re-enabled the <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_frozen_balance</code> module — 31 tests, all passing:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>Precedence matrices</strong><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_release_freeze_precedence_matrix</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_refund_freeze_precedence_matrix</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_claim_freeze_precedence_matrix</code>: all four {escrow frozen} × {depositor frozen} combinations per operation, asserting the exact error code and that blocked operations leave the escrow<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Locked</code>. A future change letting one layer bypass the other flips a matrix row and fails these.</li><li style="unicode-bidi: plaintext;"><strong>Overlapping sequences</strong><span> </span>— both freezes applied, then lifted one at a time in<span> </span><em>both orders</em>: operation stays blocked until both are lifted, records asserted accurate at every step; same for refund.</li><li style="unicode-bidi: plaintext;"><strong>Record independence</strong><span> </span>— re-freezing one layer updates only its own record; no phantom records created for unrelated keys.</li><li style="unicode-bidi: plaintext;"><strong>Boundaries</strong><span> </span>— frozen contributor doesn't block release, frozen recipient doesn't block claim, frozen depositor can still lock (but not release),<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">authorize_claim</code><span> </span>is gated by both layers too.</li></ul><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Docs</h3><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><li style="unicode-bidi: plaintext;">NatSpec-style precedence rules on<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ensure_escrow_not_frozen</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">freeze_escrow</code>, and<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">freeze_address</code></li><li style="unicode-bidi: plaintext;">New<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">docs/freeze-precedence.md</code><span> </span>with the outcome matrix, record-independence guarantees, scope boundaries, and security rationale (no bypass through the narrower key; lifting a per-bounty hold can't silently release funds under an address-level compliance hold; checks precede all transfers)</li></ul><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Notes for reviewers</h3><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><li style="unicode-bidi: plaintext;">The module was previously excluded with a "pre-existing SDK/API drift" comment; the actual breakage was two lines — the SAC registration needed<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.address()</code><span> </span>and one<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">freeze_address</code><span> </span>call was missing its<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">reason</code><span> </span>argument. All pre-existing tests pass unmodified otherwise (one structurally confused non-admin test was replaced with a direct<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">BountyNotFound</code><span> </span>assertion).</li><li style="unicode-bidi: plaintext;">⚠️ Surfaced by the boundary tests: freezing a<span> </span><strong>payee</strong><span> </span>address has no effect on payouts, since address freezes only match the depositor. This is consistent with the documented "escrows owned by address" semantics, so it's documented as intended — but if sanctions-style recipient blocking is ever needed,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">release</code>/<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">claim</code><span> </span>would require an additional<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ensure_address_not_frozen(recipient)</code><span> </span>check. Flagged in<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">docs/freeze-precedence.md</code>.</li></ul><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Test results</h3><div class="codeBlockWrapper_-a7MRw" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: 0% 0% repeat rgb(18, 19, 20); border: 1px solid rgb(42, 43, 44); cursor: pointer; opacity: 1; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cargo test: 370 passed; 0 failed; 0 ignored</code></pre></div>