### PR TITLE
feat(backend): refine CSRF security edge cases, browser middleware, and test coverage

### DIFF
--- a/backend/SECURITY_EDGE_CASES.md
+++ b/backend/SECURITY_EDGE_CASES.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This document specifies the current behavior, security-sensitive edge cases, and expected regression surface for browser-facing request security in the backend service, specifically focusing on CSRF protection, state parameter validation, open redirect prevention, and authentication middleware.
+This document specifies the current behavior, security-sensitive edge cases, and expected regression surface for browser-facing request security in the backend service, specifically focusing on CSRF protection, browser-facing middleware, state parameter validation, open redirect prevention, and authentication middleware.
 
 ---
 
@@ -28,9 +28,15 @@ This document specifies the current behavior, security-sensitive edge cases, and
    - Validates that origin matches an allowed scheme and host whitelist:
      - Development: `http://localhost:*`, `http://127.0.0.1:*`, `https://localhost:*`, `https://127.0.0.1:*`.
      - Vercel Preview Deployments: `*.vercel.app` or `vercel.app`.
-     - Configured Origins: `CORSOrigins` and `FrontendBaseURL`.
+     - Configured Origins: `CORSOrigins` and `FrontendBaseURL` (normalized for trailing slashes).
    - If allowed, redirects user to `{redirect_uri}/auth/callback?token={jwt}&github={login}`.
    - If disallowed or missing, rejects request or falls back to production configured base URL.
+
+4. **Browser-Facing Request Security Middleware (`createCsrfMiddleware`):**
+   - Inspects state-changing HTTP requests (`POST`, `PUT`, `DELETE`, `PATCH`).
+   - Validates `x-csrf-token` header for browser-originating requests (requests with `Origin` or `Referer`).
+   - Validates `Origin` and `Referer` against `isAllowedRedirectURI`.
+   - Non-browser API clients (requests without `Origin` or `Referer`) bypass browser CSRF checks.
 
 ---
 
@@ -40,6 +46,8 @@ This document specifies the current behavior, security-sensitive edge cases, and
 |----------|-------------------|--------------------------|------------------|
 | **Origin Checking** | Malicious host suffix (e.g. `http://localhost.attacker.com`) | Rejected (`false`) | Prevents domain spoofing open redirects |
 | **Origin Checking** | Subdomain takeover target (e.g. `https://vercel.app.attacker.com`) | Rejected (`false`) | Prevents sub-domain string matching bypasses |
+| **Origin Checking** | URL containing userinfo credentials (`http://user:pass@localhost:3000`) | Rejected (`false`) | Prevents credential exposure & phishing via URL auth |
+| **Origin Checking** | Configured origin with trailing slash (`https://grainlify.io/`) | Allowed (`true`) | Prevents config format mismatch false negatives |
 | **Origin Checking** | Non-HTTP schemes (`javascript:...`, `data:...`, `file:...`) | Rejected (`false`) | Prevents XSS / payload injection via URL schemes |
 | **Origin Checking** | Localhost dev origins (`http://localhost:3000`, `http://127.0.0.1:5173`) | Allowed (`true`) | Preserves developer workflow without weakening production |
 | **Origin Checking** | Vercel preview domains (`https://pr-42.vercel.app`) | Allowed (`true`) | Supports dynamic preview deployments securely |
@@ -48,6 +56,11 @@ This document specifies the current behavior, security-sensitive edge cases, and
 | **State Parameter** | Malformed / invalid base64 string in `state` | Fallback to raw string | Prevents panics or 500 errors on invalid inputs |
 | **State Parameter** | Replay of previously consumed `state` parameter | Rejected (`invalid_or_expired_state`) | Ensures single-use state tokens |
 | **State Parameter** | State lookup after 10-minute expiration | Rejected (`invalid_or_expired_state`) | Enforces time-bound state validity |
+| **CSRF Validation** | Non-string / null token arguments passed | Rejected (`false`) | Prevents type confusion & runtime crashes |
+| **CSRF Validation** | Invalid `Date` instance passed as `expiresAt` | Rejected (`false`) | Prevents `NaN` comparison bypasses |
+| **Browser Middleware** | State-changing request with `Origin`/`Referer` missing `x-csrf-token` | HTTP 403 (`missing_csrf_token`) | Blocks browser CSRF attempts |
+| **Browser Middleware** | Browser request with disallowed `Origin` or `Referer` | HTTP 403 (`disallowed_origin`) | Blocks cross-origin browser requests from untrusted origins |
+| **Browser Middleware** | Non-browser request (no `Origin` or `Referer`) | Allowed (`next()`) | Allows direct server-to-server & CLI API calls |
 | **Auth Middleware** | Request missing `Authorization` header | HTTP 401 (`missing_bearer_token`) | Prevents unauthenticated access to protected routes |
 | **Auth Middleware** | `Authorization` header with non-Bearer scheme (`Basic ...`) | HTTP 401 (`missing_bearer_token`) | Enforces Bearer JWT standard |
 | **Auth Middleware** | `Authorization` header with `Bearer ` but empty payload | HTTP 401 (`missing_bearer_token`) | Rejects empty tokens |
@@ -69,7 +82,7 @@ To ensure future changes do not introduce security regressions or break existing
    - The database deletion `DELETE FROM oauth_states WHERE state = $1` MUST execute before or during callback processing. Re-using a state token MUST fail on second attempt.
 
 4. **Response Contract Invariant:**
-   - Error responses for authentication failures MUST preserve exact JSON error keys (`missing_bearer_token`, `invalid_token`, `invalid_or_expired_state`, `redirect_uri_not_allowed`).
+   - Error responses for authentication failures MUST preserve exact JSON error keys (`missing_bearer_token`, `invalid_token`, `invalid_or_expired_state`, `redirect_uri_not_allowed`, `missing_csrf_token`, `disallowed_origin`).
 
 5. **Determinism & Retry Stability Invariant:**
    - State parameter encoding, decoding, and origin validation helper functions MUST be pure and strictly deterministic across retries, re-renders, and concurrent evaluations. Calling `encodeStateWithRedirect`, `decodeStateWithRedirect`, or `isAllowedRedirectURI` 100 times sequentially with identical input parameters MUST produce identical output results without state leakage or side effects.
@@ -82,3 +95,4 @@ The regression surface is explicitly covered and pinned down by unit test suites
 - **Go Handlers & OAuth Edge Cases:** `backend/internal/handlers/github_oauth_test.go`
 - **Go Auth Middleware Edge Cases:** `backend/internal/auth/middleware_test.go`
 - **TypeScript CSRF & Security Edge Cases:** `backend/src/middleware/csrf.test.ts`
+

--- a/backend/src/middleware/csrf.test.ts
+++ b/backend/src/middleware/csrf.test.ts
@@ -1,4 +1,5 @@
-import { isAllowedRedirectURI, encodeStateWithRedirect, decodeStateWithRedirect, validateCSRFToken } from './csrf';
+import { describe, it, expect } from 'vitest';
+import { isAllowedRedirectURI, encodeStateWithRedirect, decodeStateWithRedirect, validateCSRFToken, createCsrfMiddleware, RequestWithHeaders, ResponseWithStatus } from './csrf';
 
 describe('CSRF and Browser Security Edge Cases', () => {
   describe('isAllowedRedirectURI', () => {
@@ -21,6 +22,16 @@ describe('CSRF and Browser Security Edge Cases', () => {
       expect(isAllowedRedirectURI('https://dashboard.grainlify.io', config)).toBe(true);
     });
 
+    it('normalizes origins configured with trailing slashes', () => {
+      const config = { corsOrigins: 'https://grainlify.io/', frontendBaseUrl: 'https://dashboard.grainlify.io/' };
+      expect(isAllowedRedirectURI('https://grainlify.io/auth', config)).toBe(true);
+      expect(isAllowedRedirectURI('https://dashboard.grainlify.io', config)).toBe(true);
+    });
+
+    it('trims whitespace from input redirect URIs', () => {
+      expect(isAllowedRedirectURI('  https://my-app.vercel.app  ')).toBe(true);
+    });
+
     it('rejects malicious or disallowed origins (Open Redirect protection)', () => {
       expect(isAllowedRedirectURI('http://localhost.attacker.com')).toBe(false);
       expect(isAllowedRedirectURI('https://vercel.app.evil.com')).toBe(false);
@@ -28,6 +39,11 @@ describe('CSRF and Browser Security Edge Cases', () => {
       expect(isAllowedRedirectURI('data:text/html,<script>alert(1)</script>')).toBe(false);
       expect(isAllowedRedirectURI('https://untrusted-site.com')).toBe(false);
       expect(isAllowedRedirectURI('')).toBe(false);
+    });
+
+    it('rejects redirect URIs containing embedded userinfo credentials', () => {
+      expect(isAllowedRedirectURI('http://user:password@localhost:3000')).toBe(false);
+      expect(isAllowedRedirectURI('https://admin:secret@my-app.vercel.app')).toBe(false);
     });
   });
 
@@ -53,6 +69,15 @@ describe('CSRF and Browser Security Edge Cases', () => {
       expect(decoded.redirectURI).toBe('');
     });
 
+    it('handles redirect URIs containing pipe characters in query params', () => {
+      const token = 'token_with_pipes';
+      const redirect = 'https://my-app.vercel.app/callback?filter=a|b';
+      const encoded = encodeStateWithRedirect(token, redirect);
+      const decoded = decodeStateWithRedirect(encoded);
+      expect(decoded.csrfToken).toBe(token);
+      expect(decoded.redirectURI).toBe(redirect);
+    });
+
     it('handles malformed base64 state gracefully', () => {
       const malformed = '!!!not_valid_base64!!!';
       const decoded = decodeStateWithRedirect(malformed);
@@ -60,8 +85,11 @@ describe('CSRF and Browser Security Edge Cases', () => {
       expect(decoded.redirectURI).toBe('');
     });
 
-    it('handles empty or null state', () => {
+    it('handles empty or non-string state gracefully', () => {
       expect(decodeStateWithRedirect('')).toEqual({ csrfToken: '', redirectURI: '' });
+      expect(decodeStateWithRedirect('   ')).toEqual({ csrfToken: '', redirectURI: '' });
+      expect(decodeStateWithRedirect(null as any)).toEqual({ csrfToken: '', redirectURI: '' });
+      expect(encodeStateWithRedirect(null as any)).toBe('');
     });
   });
 
@@ -77,6 +105,123 @@ describe('CSRF and Browser Security Edge Cases', () => {
     it('rejects expired tokens', () => {
       const past = new Date(Date.now() - 10000);
       expect(validateCSRFToken('token_1', 'token_1', past)).toBe(false);
+    });
+
+    it('rejects invalid Date objects for expiration', () => {
+      const invalidDate = new Date('invalid_date_string');
+      expect(validateCSRFToken('token_1', 'token_1', invalidDate)).toBe(false);
+    });
+
+    it('rejects non-string or whitespace-only tokens', () => {
+      expect(validateCSRFToken(null as any, 'token_1')).toBe(false);
+      expect(validateCSRFToken('token_1', undefined as any)).toBe(false);
+      expect(validateCSRFToken('   ', 'token_1')).toBe(false);
+      expect(validateCSRFToken('token_1', '   ')).toBe(false);
+    });
+  });
+
+  describe('createCsrfMiddleware', () => {
+    const config = { corsOrigins: 'https://app.grainlify.io' };
+    const csrfMiddleware = createCsrfMiddleware(config);
+
+    function createMockRes() {
+      const res: any = {
+        statusCode: 200,
+        body: null,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          this.body = payload;
+          return this;
+        }
+      };
+      return res as ResponseWithStatus & { statusCode: number; body: any };
+    }
+
+    it('allows read-only HTTP methods without CSRF token headers', () => {
+      const req: RequestWithHeaders = { method: 'GET', headers: { origin: 'https://app.grainlify.io' } };
+      const res = createMockRes();
+      let nextCalled = false;
+      csrfMiddleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(true);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('allows non-browser API clients (no Origin or Referer)', () => {
+      const req: RequestWithHeaders = { method: 'POST', headers: {} };
+      const res = createMockRes();
+      let nextCalled = false;
+      csrfMiddleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(true);
+    });
+
+    it('rejects browser POST request missing x-csrf-token header', () => {
+      const req: RequestWithHeaders = { method: 'POST', headers: { origin: 'https://app.grainlify.io' } };
+      const res = createMockRes();
+      let nextCalled = false;
+      csrfMiddleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(false);
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({ error: 'missing_csrf_token', message: 'CSRF token is required for browser-facing requests' });
+    });
+
+    it('rejects browser POST request from disallowed origin', () => {
+      const req: RequestWithHeaders = {
+        method: 'POST',
+        headers: {
+          origin: 'https://evil-attacker.com',
+          'x-csrf-token': 'valid_token'
+        }
+      };
+      const res = createMockRes();
+      let nextCalled = false;
+      csrfMiddleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(false);
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({ error: 'disallowed_origin', message: 'Origin or Referer not allowed' });
+    });
+
+    it('accepts browser POST request from allowed origin with x-csrf-token header', () => {
+      const req: RequestWithHeaders = {
+        method: 'POST',
+        headers: {
+          origin: 'https://app.grainlify.io',
+          'x-csrf-token': 'valid_token'
+        }
+      };
+      const res = createMockRes();
+      let nextCalled = false;
+      csrfMiddleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(true);
+    });
+
+    it('validates Referer header when Origin header is absent', () => {
+      const reqValid: RequestWithHeaders = {
+        method: 'POST',
+        headers: {
+          referer: 'https://app.grainlify.io/dashboard',
+          'x-csrf-token': 'valid_token'
+        }
+      };
+      const resValid = createMockRes();
+      let nextValid = false;
+      csrfMiddleware(reqValid, resValid, () => { nextValid = true; });
+      expect(nextValid).toBe(true);
+
+      const reqInvalid: RequestWithHeaders = {
+        method: 'POST',
+        headers: {
+          referer: 'https://attacker.com/page',
+          'x-csrf-token': 'valid_token'
+        }
+      };
+      const resInvalid = createMockRes();
+      let nextInvalid = false;
+      csrfMiddleware(reqInvalid, resInvalid, () => { nextInvalid = true; });
+      expect(nextInvalid).toBe(false);
+      expect(resInvalid.statusCode).toBe(403);
     });
   });
 
@@ -100,3 +245,4 @@ describe('CSRF and Browser Security Edge Cases', () => {
     });
   });
 });
+

--- a/backend/src/middleware/csrf.ts
+++ b/backend/src/middleware/csrf.ts
@@ -2,7 +2,7 @@
  * CSRF and Browser-Facing Request Security Middleware / Utilities
  * 
  * Provides state parameter encoding/decoding, origin validation for open redirect prevention,
- * and CSRF token verification for browser-facing OAuth and API flows.
+ * CSRF token verification, and Express middleware for browser-facing API requests.
  */
 
 export interface SecurityConfig {
@@ -13,6 +13,33 @@ export interface SecurityConfig {
 export interface DecodedState {
   csrfToken: string;
   redirectURI: string;
+}
+
+export interface RequestWithHeaders {
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export interface ResponseWithStatus {
+  status(code: number): ResponseWithStatus;
+  json(body: any): any;
+}
+
+export type NextFunction = (err?: any) => void;
+
+/**
+ * Normalizes an origin or URL string by trimming trailing slashes and extracting protocol+host.
+ */
+function normalizeAllowedOrigin(allowedStr: string): string {
+  const trimmed = allowedStr.trim();
+  if (!trimmed) return '';
+  try {
+    const url = new URL(trimmed);
+    return url.origin;
+  } catch {
+    // Strip trailing slashes if URL parsing fails
+    return trimmed.replace(/\/+$/, '');
+  }
 }
 
 /**
@@ -26,6 +53,7 @@ export interface DecodedState {
  * Rejecting:
  * - Non http/https schemes (javascript:, data:, file:)
  * - Subdomain spoofing (e.g., http://localhost.attacker.com)
+ * - Userinfo credentials embedded in URL (e.g. http://user:pass@localhost)
  * - Malformed URLs
  */
 export function isAllowedRedirectURI(redirectURI: string, config: SecurityConfig = {}): boolean {
@@ -33,15 +61,25 @@ export function isAllowedRedirectURI(redirectURI: string, config: SecurityConfig
     return false;
   }
 
+  const trimmedURI = redirectURI.trim();
+  if (!trimmedURI) {
+    return false;
+  }
+
   let parsed: URL;
   try {
-    parsed = new URL(redirectURI);
+    parsed = new URL(trimmedURI);
   } catch {
     return false;
   }
 
   // Reject non-http/https schemes
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  // Reject URLs with embedded credentials to prevent credential exposure & open redirect confusion
+  if (parsed.username || parsed.password) {
     return false;
   }
 
@@ -69,7 +107,8 @@ export function isAllowedRedirectURI(redirectURI: string, config: SecurityConfig
   if (config.corsOrigins && config.corsOrigins.trim() !== '') {
     const origins = config.corsOrigins.split(',').map(o => o.trim()).filter(Boolean);
     for (const allowed of origins) {
-      if (origin === allowed || origin.startsWith(allowed + '/')) {
+      const normalizedAllowed = normalizeAllowedOrigin(allowed);
+      if (origin === normalizedAllowed || origin === allowed || origin.startsWith(normalizedAllowed + '/')) {
         return true;
       }
     }
@@ -78,7 +117,8 @@ export function isAllowedRedirectURI(redirectURI: string, config: SecurityConfig
   // Check FrontendBaseURL
   if (config.frontendBaseUrl && config.frontendBaseUrl.trim() !== '') {
     const baseUrl = config.frontendBaseUrl.trim();
-    if (origin === baseUrl || origin.startsWith(baseUrl + '/')) {
+    const normalizedBase = normalizeAllowedOrigin(baseUrl);
+    if (origin === normalizedBase || origin === baseUrl || origin.startsWith(normalizedBase + '/')) {
       return true;
     }
   }
@@ -92,10 +132,16 @@ export function isAllowedRedirectURI(redirectURI: string, config: SecurityConfig
  * If no redirect_uri is provided, returns raw csrfToken for backward compatibility.
  */
 export function encodeStateWithRedirect(csrfToken: string, redirectURI?: string): string {
-  if (!redirectURI || redirectURI.trim() === '') {
-    return csrfToken;
+  if (!csrfToken || typeof csrfToken !== 'string') {
+    return '';
   }
-  const payload = `${csrfToken}|${redirectURI}`;
+  const trimmedToken = csrfToken.trim();
+  const trimmedURI = redirectURI ? redirectURI.trim() : '';
+
+  if (!trimmedURI) {
+    return trimmedToken;
+  }
+  const payload = `${trimmedToken}|${trimmedURI}`;
   return base64UrlEncode(payload);
 }
 
@@ -110,8 +156,13 @@ export function decodeStateWithRedirect(encodedState: string): DecodedState {
     return { csrfToken: '', redirectURI: '' };
   }
 
+  const trimmedState = encodedState.trim();
+  if (!trimmedState) {
+    return { csrfToken: '', redirectURI: '' };
+  }
+
   try {
-    const decoded = base64UrlDecode(encodedState);
+    const decoded = base64UrlDecode(trimmedState);
     const firstPipeIndex = decoded.indexOf('|');
     if (firstPipeIndex !== -1) {
       const csrfToken = decoded.substring(0, firstPipeIndex);
@@ -123,7 +174,7 @@ export function decodeStateWithRedirect(encodedState: string): DecodedState {
   }
 
   // Legacy fallback: unencoded CSRF token
-  return { csrfToken: encodedState, redirectURI: '' };
+  return { csrfToken: trimmedState, redirectURI: '' };
 }
 
 /**
@@ -156,16 +207,80 @@ function base64UrlDecode(str: string): string {
 
 /**
  * Validates CSRF token against stored token and optional expiration timestamp.
+ * Type-safe, rejects non-strings and empty values.
  */
 export function validateCSRFToken(tokenFromRequest: string, tokenFromStorage: string, expiresAt?: Date): boolean {
-  if (!tokenFromRequest || !tokenFromStorage) {
+  if (typeof tokenFromRequest !== 'string' || typeof tokenFromStorage !== 'string') {
     return false;
   }
-  if (tokenFromRequest !== tokenFromStorage) {
+  const reqToken = tokenFromRequest.trim();
+  const storeToken = tokenFromStorage.trim();
+
+  if (!reqToken || !storeToken) {
     return false;
   }
-  if (expiresAt && expiresAt.getTime() < Date.now()) {
+  if (reqToken !== storeToken) {
     return false;
+  }
+  if (expiresAt !== undefined) {
+    if (!(expiresAt instanceof Date) || isNaN(expiresAt.getTime())) {
+      return false;
+    }
+    if (expiresAt.getTime() < Date.now()) {
+      return false;
+    }
   }
   return true;
 }
+
+/**
+ * Express-compatible CSRF middleware factory for browser-facing request security.
+ * Inspects x-csrf-token, Origin, and Referer headers for state-changing HTTP requests (POST, PUT, DELETE, PATCH).
+ * Non-browser API clients (without Origin or Referer) are allowed through.
+ */
+export function createCsrfMiddleware(config: SecurityConfig = {}) {
+  return function csrfMiddleware(req: RequestWithHeaders, res: ResponseWithStatus, next: NextFunction) {
+    const method = (req.method || 'GET').toUpperCase();
+
+    // Safe methods (GET, HEAD, OPTIONS) do not alter server state
+    if (['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+      return next();
+    }
+
+    const headers = req.headers || {};
+    const originHeader = Array.isArray(headers['origin']) ? headers['origin'][0] : headers['origin'];
+    const refererHeader = Array.isArray(headers['referer']) ? headers['referer'][0] : headers['referer'];
+    const csrfTokenHeader = Array.isArray(headers['x-csrf-token']) ? headers['x-csrf-token'][0] : headers['x-csrf-token'];
+
+    const isBrowserRequest = Boolean(originHeader || refererHeader);
+
+    if (!isBrowserRequest) {
+      // Non-browser API clients (curl, automated scripts) are allowed through
+      return next();
+    }
+
+    // Browser request requires valid CSRF token header
+    if (!csrfTokenHeader || typeof csrfTokenHeader !== 'string' || csrfTokenHeader.trim() === '') {
+      return res.status(403).json({ error: 'missing_csrf_token', message: 'CSRF token is required for browser-facing requests' });
+    }
+
+    // Determine request origin from Origin or Referer header
+    let requestOrigin: string | null = null;
+    if (originHeader) {
+      requestOrigin = originHeader;
+    } else if (refererHeader) {
+      try {
+        requestOrigin = new URL(refererHeader).origin;
+      } catch {
+        return res.status(403).json({ error: 'disallowed_origin', message: 'Malformed Referer header' });
+      }
+    }
+
+    if (requestOrigin && !isAllowedRedirectURI(requestOrigin, config)) {
+      return res.status(403).json({ error: 'disallowed_origin', message: 'Origin or Referer not allowed' });
+    }
+
+    return next();
+  };
+}
+


### PR DESCRIPTION
## Summary

Refined and hardened security edge case handling and browser-facing request security in `backend/src/middleware/csrf.ts`:
- Implemented Express-compatible `createCsrfMiddleware` for inspecting `x-csrf-token`, `Origin`, and `Referer` headers on state-changing requests (`POST`, `PUT`, `DELETE`, `PATCH`).
- Normalized `corsOrigins` and `frontendBaseUrl` configurations with trailing slashes and explicitly blocked redirect URIs containing embedded userinfo credentials (`http://user:pass@domain`).
- Hardened `validateCSRFToken` against non-string arguments, empty tokens, and invalid `Date` (`NaN`) comparison bypasses.
- Expanded test coverage in `backend/src/middleware/csrf.test.ts` to 24 passing tests and updated `backend/SECURITY_EDGE_CASES.md`.

## Linked Issue

Closes #1649 

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [x] refactor
- [x] test
- [ ] chore

## Validation

- [x] Lint passed for affected area(s)
- [x] Tests passed for affected area(s)
- [x] Manual verification completed (if applicable)

## Documentation

- [x] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria
