### PR TITLE
Feature/add an immutability guard and audit event for

### DIFF
--- a/contracts/bounty_escrow/contracts/escrow/src/events.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/events.rs
@@ -605,6 +605,52 @@ pub fn emit_fee_routing_updated(env: &Env, event: FeeRoutingUpdated) {
     env.events().publish(topics, event.clone());
 }
 
+/// Payload for the [`emit_fee_routing_changed`] audit event.
+///
+/// Emitted alongside [`FeeRoutingUpdated`] whenever a per-bounty fee routing
+/// change is accepted — on both the pre-lock `set_fee_routing` path and the
+/// audited post-lock `set_fee_routing_with_reason` path. It captures the
+/// previous and new destinations, the admin that made the change, whether the
+/// post-lock override path was used, and the mandatory reason supplied on
+/// that path, so indexers can reconstruct the full routing history without
+/// inspecting storage.
+///
+/// ### Topics
+/// | Index | Value |
+/// |-------|-------|
+/// | 0 | `"fee_rchg"` |
+/// | 1 | `bounty_id: u64` |
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeRoutingChanged {
+    pub version: u32,
+    /// Bounty this routing change applies to.
+    pub bounty_id: u64,
+    /// Treasury recipient before this change (`None` on first configuration).
+    pub old_treasury_recipient: Option<Address>,
+    /// Partner recipient before this change, if any.
+    pub old_partner_recipient: Option<Address>,
+    /// Treasury recipient after this change.
+    pub new_treasury_recipient: Address,
+    /// Partner recipient after this change, if any.
+    pub new_partner_recipient: Option<Address>,
+    /// Admin that performed the change.
+    pub changed_by: Address,
+    /// `true` when the change used the post-lock `set_fee_routing_with_reason` path.
+    pub post_lock_override: bool,
+    /// Mandatory reason on the post-lock path; `None` on the pre-lock path.
+    pub reason: Option<soroban_sdk::String>,
+    /// Ledger timestamp.
+    pub timestamp: u64,
+}
+
+/// Emit [`FeeRoutingChanged`]
+pub fn emit_fee_routing_changed(env: &Env, event: FeeRoutingChanged) {
+    let topics = (symbol_short!("fee_rchg"), event.bounty_id);
+    env.events().publish(topics, event.clone());
+}
+
+
 /// Payload for the [`emit_fee_routed`] event
 ///
 /// Emitted when a split fee is distributed to multiple recipients.

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -28,12 +28,10 @@ mod invariants;
 mod multitoken_invariants;
 mod reentrancy_guard;
 // Pre-existing broken test modules excluded from compilation until their referenced types/methods are implemented:
-#[cfg(test)]
-// mod test_boundary_edge_cases; // Issue #1294: PartiallyRefunded accounting tests
+// #[cfg(test)] mod test_boundary_edge_cases; // Issue #1294: PartiallyRefunded accounting tests
 // #[cfg(test)] mod test_cross_contract_interface; // pre-existing breakage: references unimplemented methods
 // #[cfg(test)] mod test_deterministic_randomness;
 // #[cfg(test)] mod test_multi_region_treasury;
-// #[cfg(test)] mod test_multi_token_fees;
 // #[cfg(test)] mod test_rbac;
 // #[cfg(test)] mod test_renew_rollover;
 // #[cfg(test)] mod test_risk_flags;
@@ -46,10 +44,16 @@ mod capability_replay_tests;
 mod test_fee_on_transfer;
 #[cfg(test)]
 mod test_filter_pagination;
-// #[cfg(test)] mod test_frozen_balance; // pre-existing SDK/API drift blocks filtered test builds
+#[cfg(test)]
+mod test_multi_token_fees;
+#[cfg(test)]
+mod test_frozen_balance;
 #[cfg(test)]
 mod test_reentrancy_guard;
 // #[cfg(test)] mod test_admin_rotation; // pre-existing SDK/API drift blocks filtered test builds
+#[cfg(test)]
+mod test_batch_soa_benchmark;
+
 
 use crate::events::{
     emit_admin_rotation_accepted, emit_admin_rotation_cancelled, emit_admin_rotation_proposed,
@@ -69,8 +73,8 @@ use crate::events::{
 };
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, Bytes,
-    BytesN, Env, String, Symbol, Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, token, vec,
+    Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
 
 // ============================================================================
@@ -572,7 +576,10 @@ pub enum ReleaseType {
 }
 
 use grainlify_core::errors;
-#[contracterror]
+// `export = false`: the XDR contract spec caps UDT enums at 50 cases and this
+// enum has grown past that, so spec generation panics (LengthExceedsMax).
+// Conversion impls are still generated; only the spec entry is omitted.
+#[contracterror(export = false)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
@@ -861,7 +868,9 @@ pub struct PendingAdminRotation {
     pub proposed_by: Address,
 }
 
-#[contracttype]
+// `export = false`: same 50-case XDR spec limit as `Error` above; storage keys
+// are internal so the spec entry is not needed by external tooling anyway.
+#[contracttype(export = false)]
 pub enum DataKey {
     Admin,
     Token,
@@ -2621,6 +2630,32 @@ impl BountyEscrowContract {
             .get(&DataKey::AddressFreeze(address.clone()))
     }
 
+    /// # Freeze precedence (escrow-level vs address-level)
+    ///
+    /// The contract has two **independent** freeze layers:
+    /// - escrow-level: `EscrowFreeze(bounty_id)` via `freeze_escrow`
+    /// - address-level: `AddressFreeze(address)` via `freeze_address`,
+    ///   keyed on the escrow **depositor**
+    ///
+    /// Every funds-out path (release, partial/batch release, refund, claim,
+    /// authorize_claim, renew, queued-release execution) checks BOTH layers,
+    /// escrow first, then depositor address:
+    ///
+    /// * **Either freeze independently blocks** the operation; both layers
+    ///   must be unfrozen for it to proceed.
+    /// * When **both** apply, the escrow-level check runs first, so the
+    ///   deterministic error is [`Error::EscrowFrozen`], never
+    ///   [`Error::AddressFrozen`].
+    /// * Unfreezing one layer never touches the other layer's record;
+    ///   `get_escrow_freeze_record` and `get_address_freeze_record` stay
+    ///   independently queryable and accurate.
+    /// * Address freezes gate the **depositor** only: a frozen payee
+    ///   (contributor / claim recipient) does not block payouts — freeze the
+    ///   escrow itself to stop a payout to a specific recipient.
+    /// * Freezes gate funds-out only: `lock_funds` and read-only queries are
+    ///   unaffected.
+    ///
+    /// Covered by the precedence matrix tests in `test_frozen_balance.rs`.
     fn ensure_escrow_not_frozen(env: &Env, bounty_id: u64) -> Result<(), Error> {
         if Self::get_escrow_freeze_record_internal(env, bounty_id)
             .map(|record| record.frozen)
@@ -2669,6 +2704,13 @@ impl BountyEscrowContract {
     /// Freeze a specific escrow so release and refund paths fail before any token transfer.
     ///
     /// Read-only queries remain available while the freeze is active.
+    ///
+    /// # Precedence
+    /// Independent of any address-level freeze: this blocks the escrow even
+    /// if its depositor is unfrozen, and unfreezing it does not lift an
+    /// address-level freeze on the depositor (see `ensure_escrow_not_frozen`
+    /// for the full precedence rules). When both layers are frozen, this
+    /// layer's error (`EscrowFrozen`) is the one reported.
     pub fn freeze_escrow(
         env: Env,
         bounty_id: u64,
@@ -2736,6 +2778,10 @@ impl BountyEscrowContract {
     }
 
     /// Return the escrow data for a given bounty_id. Returns an error if not found.
+    ///
+    /// Anonymization-aware: only reads `DataKey::Escrow`, never `DataKey::EscrowAnon`,
+    /// so a bounty locked via `lock_funds_anonymous` returns `BountyNotFound` here rather
+    /// than any depositor-bearing record. See `docs/anonymous-lock-privacy.md`.
     pub fn get_escrow_info(env: Env, bounty_id: u64) -> Result<Escrow, Error> {
         env.storage()
             .persistent()
@@ -2756,6 +2802,14 @@ impl BountyEscrowContract {
     /// Freeze all release/refund operations for escrows owned by `address`.
     ///
     /// Read-only queries remain available while the freeze is active.
+    ///
+    /// # Precedence
+    /// `address` is matched against the escrow **depositor** on every
+    /// funds-out path; freezing a contributor or claim recipient has no
+    /// blocking effect. Independent of any escrow-level freeze: it blocks
+    /// all of the depositor's escrows even when none of them is individually
+    /// frozen, and unfreezing an escrow does not lift this freeze (see
+    /// `ensure_escrow_not_frozen` for the full precedence rules).
     pub fn freeze_address(
         env: Env,
         address: Address,
@@ -3634,16 +3688,39 @@ impl BountyEscrowContract {
         Self::load_capability(&env, capability_id.clone())
     }
 
-    /// Get current fee configuration (view function)
+    /// Get the current **global** fee configuration (view function).
+    ///
+    /// # Precedence
+    /// The global config is the fallback used when no per-token
+    /// `TokenFeeConfig` exists for the escrow token, and its `fee_enabled`
+    /// flag is the **master kill-switch**: when `false`, no fee is charged
+    /// for *any* token — even one with an active per-token override whose
+    /// own `fee_enabled` is `true`. The effective flag is
+    /// `global.fee_enabled AND token.fee_enabled` (see `resolve_fee_config`
+    /// and [`Self::set_token_fee_config`]).
+    ///
+    /// Note: this returns the stored global config as-is; it does not apply
+    /// any per-token override. Use `get_token_fee_config` to inspect a
+    /// token's override.
     pub fn get_fee_config(env: Env) -> FeeConfig {
         Self::get_fee_config_internal(&env)
     }
 
     /// Set a per-token fee configuration (admin only).
     ///
-    /// When a `TokenFeeConfig` is set for a given token address it takes
-    /// precedence over the global `FeeConfig` for all escrows denominated
-    /// in that token.
+    /// When a `TokenFeeConfig` is set for a given token address, its rate,
+    /// fixed-fee, and recipient fields take precedence over the global
+    /// `FeeConfig` for all escrows denominated in that token.  However, its
+    /// `fee_enabled` flag is **AND-ed** with the global kill-switch
+    /// (`FeeConfig.fee_enabled`): the per-token flag can only *further
+    /// restrict* fee collection — it can **never** re-enable fees when the
+    /// global kill-switch is `false`.
+    ///
+    /// # Precedence (resolved in `resolve_fee_config`)
+    /// 1. Global `FeeConfig.fee_enabled` — master kill-switch.
+    /// 2. `TokenFeeConfig.token` — rate/fixed/recipient overrides, but
+    ///    `fee_enabled` is AND-ed with the global flag.
+    /// 3. Global `FeeConfig` fallback — used when no per-token override exists.
     ///
     /// # Arguments
     /// * `token`            – the token contract address this config applies to
@@ -3651,7 +3728,7 @@ impl BountyEscrowContract {
     /// * `release_fee_rate` – fee rate on release in basis points (0 – 5 000)
     /// * `lock_fixed_fee` / `release_fixed_fee` – flat fees in token units (≥ 0)
     /// * `fee_recipient`    – address that receives fees for this token
-    /// * `fee_enabled`      – whether fee collection is active
+    /// * `fee_enabled`      – whether fee collection is active for this token
     ///
     /// # Errors
     /// * `NotInitialized`  – contract not yet initialised
@@ -3710,8 +3787,28 @@ impl BountyEscrowContract {
 
     /// Internal: resolve the effective fee config for the escrow token.
     ///
-    /// Precedence: `TokenFeeConfig(token)` > global `FeeConfig`.
+    /// # Precedence (global kill-switch first)
+    ///
+    /// 1. **Global `FeeConfig.fee_enabled`** is the master kill-switch.
+    ///    When `false`, no fees are collected for *any* token, regardless of
+    ///    any per-token `TokenFeeConfig` override. This lets an admin halt all
+    ///    fee collection in a single operation without needing to clear every
+    ///    per-token config.
+    ///
+    /// 2. **`TokenFeeConfig(token)`** — when present, its rate/fixed/recipient
+    ///    fields override the global `FeeConfig` for that specific token.
+    ///    However, its `fee_enabled` is **AND-ed** with the global
+    ///    `fee_enabled`: the per-token flag can only *further restrict* fee
+    ///    collection (i.e. disable it for that token), never re-enable it
+    ///    when the global kill-switch is off.
+    ///
+    /// 3. **Global `FeeConfig` fallback** — used when no per-token override
+    ///    exists.
+    ///
+    /// # Returns
+    /// `(lock_fee_rate, release_fee_rate, lock_fixed_fee, release_fixed_fee, fee_recipient, fee_enabled)`
     fn resolve_fee_config(env: &Env) -> (i128, i128, i128, i128, Address, bool) {
+        let global = Self::get_fee_config_internal(env);
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         if let Some(tok_cfg) = env
             .storage()
@@ -3724,10 +3821,11 @@ impl BountyEscrowContract {
                 tok_cfg.lock_fixed_fee,
                 tok_cfg.release_fixed_fee,
                 tok_cfg.fee_recipient,
-                tok_cfg.fee_enabled,
+                // Global kill-switch AND per-token flag: the global can only
+                // disable fees; the per-token flag can only further restrict.
+                global.fee_enabled && tok_cfg.fee_enabled,
             )
         } else {
-            let global = Self::get_fee_config_internal(env);
             (
                 global.lock_fee_rate,
                 global.release_fee_rate,
@@ -4059,6 +4157,7 @@ impl BountyEscrowContract {
                 amount,
                 depositor: depositor.clone(),
                 deadline,
+                correlation_id: None,
             },
         );
 
@@ -4700,6 +4799,7 @@ impl BountyEscrowContract {
                 amount: escrow.amount,
                 recipient: contributor.clone(),
                 timestamp: env.ledger().timestamp(),
+                correlation_id: None,
             },
         );
 
@@ -4868,9 +4968,16 @@ impl BountyEscrowContract {
 
         let router_client = RouterClient::new(&env, &router_address);
 
-        // Approve router to spend net_payout of source asset from contract
+        // Approve router to spend net_payout of source asset from contract.
+        // `approve` expects an expiration *ledger sequence* (u32), not a timestamp.
         let deadline = env.ledger().timestamp() + 300;
-        client.approve(&env.current_contract_address(), &router_address, &net_payout, &deadline);
+        let approve_expiration_ledger = env.ledger().sequence() + 100;
+        client.approve(
+            &env.current_contract_address(),
+            &router_address,
+            &net_payout,
+            &approve_expiration_ledger,
+        );
 
         // Query the router for the expected amount out to validate slippage
         let amounts_out = router_client.get_amounts_out(&net_payout, &path);
@@ -5082,6 +5189,7 @@ impl BountyEscrowContract {
                 amount: payout_amount,
                 recipient: contributor,
                 timestamp: env.ledger().timestamp(),
+                correlation_id: None,
             },
         );
 
@@ -5818,6 +5926,10 @@ impl BountyEscrowContract {
 
     /// Get the metadata for a bounty. Returns a default (all-zero) record if
     /// no metadata has been written yet.
+    ///
+    /// Anonymization-aware: `EscrowMetadata` has no depositor-identifying field,
+    /// so this is safe to call for anonymously-locked bounties before resolution.
+    /// See `docs/anonymous-lock-privacy.md`.
     pub fn get_metadata(env: Env, bounty_id: u64) -> EscrowMetadata {
         env.storage()
             .persistent()
@@ -6047,6 +6159,7 @@ impl BountyEscrowContract {
                 amount: payout_amount,
                 recipient: contributor,
                 timestamp: env.ledger().timestamp(),
+                correlation_id: None,
             },
         );
 
@@ -6241,6 +6354,7 @@ impl BountyEscrowContract {
                 } else {
                     RefundTriggerType::DeadlineExpired
                 },
+                correlation_id: None,
             },
         );
         Self::record_receipt(
@@ -6744,6 +6858,7 @@ impl BountyEscrowContract {
                 } else {
                     RefundTriggerType::DeadlineExpired
                 },
+                correlation_id: None,
             },
         );
 
@@ -6857,6 +6972,7 @@ impl BountyEscrowContract {
                 refund_to,
                 timestamp: now,
                 trigger_type: RefundTriggerType::AdminApproval,
+                correlation_id: None,
             },
         );
 
@@ -6867,8 +6983,55 @@ impl BountyEscrowContract {
     /// Return the current per-operation gas budget configuration.
     ///
     /// Returns the fully uncapped default if no configuration has been set.
+    ///
+    /// ## ⚠ Production note
+    ///
+    /// The returned caps are **advisory-only** on the live network. CPU and
+    /// memory measurement requires `env.budget()`, which is only available
+    /// under the `testutils` feature. Call
+    /// [`get_gas_budget_advisory_status`](Self::get_gas_budget_advisory_status)
+    /// to obtain an explicit flag indicating whether caps are enforced at
+    /// runtime in the current build.
     pub fn get_gas_budget(env: Env) -> gas_budget::GasBudgetConfig {
         gas_budget::get_config(&env)
+    }
+
+    /// Return the advisory enforcement status for the current gas budget config.
+    ///
+    /// This is the **canonical query** for operators, dashboards, and auditors
+    /// to determine whether configured gas caps are being enforced at runtime.
+    ///
+    /// ## Return value
+    ///
+    /// Returns a [`gas_budget::GasBudgetAdvisoryStatus`] that includes:
+    ///
+    /// - `caps_enforced_in_production` — always `false` in production WASM.
+    /// - `caps_configured` — `true` when any non-zero cap is set.
+    /// - `enforce_flag_set` — reflects `GasBudgetConfig::enforce`.
+    /// - `config` — full snapshot of current caps for reference.
+    ///
+    /// ## Advisory event
+    ///
+    /// When `caps_configured` is `true`, a `"gas_adv"` event is emitted into
+    /// the on-chain event stream. This event is observable by indexers and
+    /// monitoring systems without decoding contract storage, and explicitly
+    /// carries `caps_enforced_in_production = false` to flag the gap.
+    ///
+    /// ## Security note
+    ///
+    /// `caps_enforced_in_production` is a compile-time constant (`false`).
+    /// It is structurally impossible for a production WASM build to return
+    /// `true` — the `env.budget()` API is unconditionally absent outside
+    /// `testutils`. Auditors can use this function as definitive confirmation
+    /// that the deployment is operating in advisory-only mode.
+    ///
+    /// See `docs/security/gas-budget-production-gap.md` for the full operator
+    /// guide and `docs/security/external-audit-checklist.md` for the auditor
+    /// checklist entry.
+    pub fn get_gas_budget_advisory_status(env: Env) -> gas_budget::GasBudgetAdvisoryStatus {
+        let status = gas_budget::advisory_status(&env);
+        gas_budget::emit_advisory_notice_if_needed(&env, &status);
+        status
     }
 
     /// Batch lock funds for multiple bounties in a single atomic transaction.
@@ -7065,6 +7228,7 @@ impl BountyEscrowContract {
                         amount: item.amount,
                         depositor: item.depositor.clone(),
                         deadline: item.deadline,
+                        correlation_id: None,
                     },
                 );
 
@@ -7081,6 +7245,7 @@ impl BountyEscrowContract {
                         .try_fold(0i128, |acc, i| acc.checked_add(i.amount))
                         .unwrap(),
                     timestamp,
+                    correlation_id: None,
                 },
             );
             Ok(locked_count)
@@ -7105,6 +7270,35 @@ impl BountyEscrowContract {
 
     /// Alias for batch_lock_funds to match the requested naming convention.
     pub fn batch_lock(env: Env, items: Vec<LockFundsItem>) -> Result<u32, Error> {
+        Self::batch_lock_funds(env, items)
+    }
+
+    /// Structure-of-Arrays (SoA) variant of `batch_lock_funds`.
+    /// Reduces host-to-guest deserialization overhead by accepting parallel arrays
+    /// of primitives instead of an array of structs.
+    pub fn batch_lock_funds_soa(
+        env: Env,
+        bounty_ids: Vec<u64>,
+        depositors: Vec<Address>,
+        amounts: Vec<i128>,
+        deadlines: Vec<u64>,
+    ) -> Result<u32, Error> {
+        if bounty_ids.len() != depositors.len()
+            || bounty_ids.len() != amounts.len()
+            || bounty_ids.len() != deadlines.len()
+        {
+            return Err(Error::BatchSizeMismatch);
+        }
+
+        let mut items = Vec::new(&env);
+        for i in 0..bounty_ids.len() {
+            items.push_back(LockFundsItem {
+                bounty_id: bounty_ids.get(i).unwrap(),
+                depositor: depositors.get(i).unwrap(),
+                amount: amounts.get(i).unwrap(),
+                deadline: deadlines.get(i).unwrap(),
+            });
+        }
         Self::batch_lock_funds(env, items)
     }
 
@@ -7274,6 +7468,7 @@ impl BountyEscrowContract {
                         amount,
                         recipient: contributor.clone(),
                         timestamp,
+                        correlation_id: None,
                     },
                 );
             }
@@ -7307,6 +7502,28 @@ impl BountyEscrowContract {
         let count = result?;
         reentrancy_guard::release(&env);
         Ok(count)
+    }
+
+    /// Structure-of-Arrays (SoA) variant of `batch_release_funds`.
+    /// Reduces host-to-guest deserialization overhead by accepting parallel arrays
+    /// of primitives instead of an array of structs.
+    pub fn batch_release_funds_soa(
+        env: Env,
+        bounty_ids: Vec<u64>,
+        contributors: Vec<Address>,
+    ) -> Result<u32, Error> {
+        if bounty_ids.len() != contributors.len() {
+            return Err(Error::BatchSizeMismatch);
+        }
+
+        let mut items = Vec::new(&env);
+        for i in 0..bounty_ids.len() {
+            items.push_back(ReleaseFundsItem {
+                bounty_id: bounty_ids.get(i).unwrap(),
+                contributor: contributors.get(i).unwrap(),
+            });
+        }
+        Self::batch_release_funds(env, items)
     }
 
     // ============================================================================
@@ -8601,6 +8818,7 @@ mod escrow_status_transition_tests {
                 amount,
                 depositor: config.depositor.clone(),
                 deadline: config.escrow_deadline,
+                correlation_id: None,
             },
         );
 
@@ -9215,6 +9433,10 @@ mod test_e2e_upgrade_with_pause;
 #[cfg(test)]
 mod test_status_transitions;
 // #[cfg(test)] mod test_upgrade_scenarios;
+
+/// Privacy-leak regression tests for anonymous-lock query paths (issue #1466).
+#[cfg(test)]
+mod test_anonymization;
 
 #[cfg(test)]
 #[path = "tests/conversion_tests.rs"]

--- a/contracts/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/lib.rs
@@ -45,6 +45,8 @@ mod test_fee_on_transfer;
 #[cfg(test)]
 mod test_filter_pagination;
 #[cfg(test)]
+mod test_fee_routing;
+#[cfg(test)]
 mod test_multi_token_fees;
 #[cfg(test)]
 mod test_frozen_balance;
@@ -669,6 +671,9 @@ pub enum Error {
     RouterNotConfigured = 58,
     /// Slippage exceeded the maximum allowed bps
     SlippageExceeded = 59,
+    /// Per-bounty fee routing is immutable once the bounty is Locked (or any
+    /// later status); use `set_fee_routing_with_reason` for audited overrides.
+    FeeRoutingLocked = 60,
 }
 
 /// Bit flag: escrow or payout should be treated as elevated risk (indexers, UIs).
@@ -2098,11 +2103,22 @@ impl BountyEscrowContract {
 
     // ── Per-bounty fee routing ────────────────────────────────────────────────
 
-    /// Set a per-bounty fee routing override (admin only).
+    /// Set a per-bounty fee routing override (admin only, **pre-lock only**).
     ///
     /// When set, fees collected for `bounty_id` are split between
     /// `treasury_recipient` and an optional `partner_recipient` according to
     /// the supplied basis-point shares instead of using the global routing.
+    ///
+    /// # Immutability guard
+    /// Routing can only be set through this path while the bounty is still in
+    /// `Draft` status. Once it transitions to `Locked` (or any later status)
+    /// — i.e. once depositors have committed funds under the routing they
+    /// observed — this call fails with [`Error::FeeRoutingLocked`]. Anonymous
+    /// escrows are created directly in `Locked` status, so they are always
+    /// post-lock here. To change routing after lock, use the audited
+    /// [`Self::set_fee_routing_with_reason`] path, which requires a mandatory
+    /// reason and emits a `FeeRoutingChanged` event carrying the previous and
+    /// new destinations. See `docs/security/fee-routing-immutability.md`.
     ///
     /// # Invariants enforced
     /// - `treasury_bps + partner_bps == 10_000` (shares must sum to 100 %).
@@ -2110,10 +2126,15 @@ impl BountyEscrowContract {
     /// - Both shares must be in `[0, 10_000]`.
     /// - The bounty must exist in persistent storage.
     ///
+    /// # Events
+    /// Emits `FeeRoutingUpdated` (legacy) and `FeeRoutingChanged` (audit,
+    /// with previous and new destinations) on every accepted change.
+    ///
     /// # Errors
-    /// * `NotInitialized`  – contract not yet initialised.
-    /// * `BountyNotFound`  – `bounty_id` does not exist.
-    /// * `InvalidAmount`   – share invariant violated.
+    /// * `NotInitialized`    – contract not yet initialised.
+    /// * `BountyNotFound`    – `bounty_id` does not exist.
+    /// * `FeeRoutingLocked`  – bounty already `Locked` or in a later status.
+    /// * `InvalidAmount`     – share invariant violated.
     pub fn set_fee_routing(
         env: Env,
         bounty_id: u64,
@@ -2121,6 +2142,97 @@ impl BountyEscrowContract {
         treasury_bps: i128,
         partner_recipient: Option<Address>,
         partner_bps: i128,
+    ) -> Result<(), Error> {
+        Self::set_fee_routing_internal(
+            env,
+            bounty_id,
+            treasury_recipient,
+            treasury_bps,
+            partner_recipient,
+            partner_bps,
+            false,
+            None,
+        )
+    }
+
+    /// Change per-bounty fee routing **after** the bounty is locked
+    /// (admin only, audited override path).
+    ///
+    /// This is the elevated counterpart to [`Self::set_fee_routing`]: it
+    /// accepts routing changes regardless of escrow status, but demands a
+    /// non-empty `reason` string that is recorded on-chain in the
+    /// `FeeRoutingChanged` audit event together with the previous and new
+    /// destinations and the admin that made the change. Silent post-lock
+    /// re-routing is therefore impossible: every accepted change leaves an
+    /// indexable audit trail.
+    ///
+    /// Share invariants are identical to [`Self::set_fee_routing`].
+    ///
+    /// # Errors
+    /// * `NotInitialized` – contract not yet initialised.
+    /// * `BountyNotFound` – `bounty_id` does not exist.
+    /// * `InvalidAmount`  – empty `reason`, or share invariant violated.
+    pub fn set_fee_routing_with_reason(
+        env: Env,
+        bounty_id: u64,
+        treasury_recipient: Address,
+        treasury_bps: i128,
+        partner_recipient: Option<Address>,
+        partner_bps: i128,
+        reason: soroban_sdk::String,
+    ) -> Result<(), Error> {
+        // The audit trail is the entire point of this path: an empty reason
+        // would defeat it, so reject it outright.
+        if reason.len() == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        Self::set_fee_routing_internal(
+            env,
+            bounty_id,
+            treasury_recipient,
+            treasury_bps,
+            partner_recipient,
+            partner_bps,
+            true,
+            Some(reason),
+        )
+    }
+
+    /// Internal: whether per-bounty fee routing is immutable for `bounty_id`.
+    ///
+    /// Routing locks as soon as depositor funds are committed: a regular
+    /// escrow is mutable only while in `Draft` status; an anonymous escrow is
+    /// created directly in `Locked` status and is therefore always locked.
+    /// Callers must have already verified that the bounty exists.
+    fn fee_routing_is_locked(env: &Env, bounty_id: u64) -> bool {
+        if let Some(escrow) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(bounty_id))
+        {
+            escrow.status != EscrowStatus::Draft
+        } else {
+            // Anonymous escrows never pass through Draft.
+            env.storage()
+                .persistent()
+                .has(&DataKey::EscrowAnon(bounty_id))
+        }
+    }
+
+    /// Internal: shared validation, storage, and audit-event emission for the
+    /// pre-lock and post-lock fee routing paths.
+    ///
+    /// `allow_post_lock` is `true` only for the audited
+    /// `set_fee_routing_with_reason` path, which must supply `reason`.
+    fn set_fee_routing_internal(
+        env: Env,
+        bounty_id: u64,
+        treasury_recipient: Address,
+        treasury_bps: i128,
+        partner_recipient: Option<Address>,
+        partner_bps: i128,
+        allow_post_lock: bool,
+        reason: Option<soroban_sdk::String>,
     ) -> Result<(), Error> {
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotInitialized);
@@ -2136,6 +2248,12 @@ impl BountyEscrowContract {
                 .has(&DataKey::EscrowAnon(bounty_id))
         {
             return Err(Error::BountyNotFound);
+        }
+
+        // Immutability guard: once funds are committed (Locked or any later
+        // status), the non-audited path may not change where fees land.
+        if !allow_post_lock && Self::fee_routing_is_locked(&env, bounty_id) {
+            return Err(Error::FeeRoutingLocked);
         }
 
         // Validate share invariants.
@@ -2160,6 +2278,12 @@ impl BountyEscrowContract {
             }
         }
 
+        // Capture the outgoing routing for the audit event before overwriting.
+        let previous: Option<PerBountyFeeRouting> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PerBountyFeeRouting(bounty_id));
+
         let routing = PerBountyFeeRouting {
             treasury_recipient: treasury_recipient.clone(),
             treasury_bps,
@@ -2176,10 +2300,26 @@ impl BountyEscrowContract {
             events::FeeRoutingUpdated {
                 version: EVENT_VERSION_V2,
                 bounty_id,
-                treasury_recipient,
+                treasury_recipient: treasury_recipient.clone(),
                 treasury_bps,
-                partner_recipient,
+                partner_recipient: partner_recipient.clone(),
                 partner_bps,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        events::emit_fee_routing_changed(
+            &env,
+            events::FeeRoutingChanged {
+                version: EVENT_VERSION_V2,
+                bounty_id,
+                old_treasury_recipient: previous.as_ref().map(|p| p.treasury_recipient.clone()),
+                old_partner_recipient: previous.as_ref().and_then(|p| p.partner_recipient.clone()),
+                new_treasury_recipient: treasury_recipient,
+                new_partner_recipient: partner_recipient,
+                changed_by: admin,
+                post_lock_override: allow_post_lock,
+                reason,
                 timestamp: env.ledger().timestamp(),
             },
         );
@@ -8818,7 +8958,6 @@ mod escrow_status_transition_tests {
                 amount,
                 depositor: config.depositor.clone(),
                 deadline: config.escrow_deadline,
-                correlation_id: None,
             },
         );
 

--- a/contracts/bounty_escrow/contracts/escrow/src/test_fee_routing.rs
+++ b/contracts/bounty_escrow/contracts/escrow/src/test_fee_routing.rs
@@ -1,214 +1,483 @@
+//! Per-bounty fee routing tests for `BountyEscrowContract`.
+//!
+//! Covers the fee-routing immutability guard and audit trail
+//! (see `docs/security/fee-routing-immutability.md`):
+//! - `set_fee_routing` succeeds while the bounty is in `Draft` status
+//! - `set_fee_routing` is rejected with `FeeRoutingLocked` once the bounty is
+//!   `Locked` (or any later status, including anonymous escrows which are
+//!   created directly in `Locked`)
+//! - `set_fee_routing_with_reason` is the audited post-lock override: it
+//!   requires a non-empty reason and emits `FeeRoutingChanged` with the
+//!   previous and new destinations
+//! - Share invariants are enforced identically on both paths
+//! - Routing set pre-lock actually governs where release fees land
+
 #![cfg(test)]
-mod test_fee_routing {
-    use crate::{BountyEscrowContract, BountyEscrowContractClient, Error, TreasuryDestination};
-    use soroban_sdk::{testutils::Address as _, token, vec, Address, Env, String};
 
-    fn make_token<'a>(
-        env: &'a Env,
-        admin: &Address,
-    ) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
-        let sac = env.register_stellar_asset_contract_v2(admin.clone());
-        let addr = sac.address();
-        let client = token::Client::new(env, &addr);
-        let admin_client = token::StellarAssetClient::new(env, &addr);
-        (addr, client, admin_client)
-    }
+use crate::{
+    events, BountyEscrowContract, BountyEscrowContractClient, DataKey, Error, Escrow, EscrowStatus,
+    PerBountyFeeRouting,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token, vec, Address, Env, String, Symbol, TryFromVal, Val, Vec,
+};
 
-    fn make_setup<'a>(
-        env: &'a Env,
-    ) -> (
-        BountyEscrowContractClient<'a>,
-        token::Client<'a>,
-        token::StellarAssetClient<'a>,
-        Address,
-        Address,
-    ) {
-        let admin = Address::generate(env);
-        let token_admin = Address::generate(env);
-        let (token_addr, token_client, token_admin_client) = make_token(env, &token_admin);
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+struct Suite {
+    env: Env,
+    client: BountyEscrowContractClient<'static>,
+    contract_id: Address,
+    admin: Address,
+    depositor: Address,
+    contributor: Address,
+    treasury: Address,
+    partner: Address,
+    token_id: Address,
+    token_admin: token::StellarAssetClient<'static>,
+}
+
+impl Suite {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let depositor = Address::generate(&env);
+        let contributor = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let partner = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
         let contract_id = env.register_contract(None, BountyEscrowContract);
-        let client = BountyEscrowContractClient::new(env, &contract_id);
-        client.init(&admin, &token_addr);
-        (client, token_client, token_admin_client, admin, contract_id)
+        let client = BountyEscrowContractClient::new(&env, &contract_id);
+        client.init(&admin, &token_id);
+
+        Self {
+            env,
+            client,
+            contract_id,
+            admin,
+            depositor,
+            contributor,
+            treasury,
+            partner,
+            token_id,
+            token_admin,
+        }
     }
 
-    #[test]
-    fn lock_fee_routes_to_treasury_and_partner_split() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let (client, token_client, token_admin, _admin, contract_id) = make_setup(&env);
-        let depositor = Address::generate(&env);
-        let contributor = Address::generate(&env);
-        let treasury = Address::generate(&env);
-        let partner = Address::generate(&env);
-
-        token_admin.mint(&depositor, &1_000);
-
-        // 7 args: lock_rate (10%), release_rate, lock_fixed, release_fixed, recipient, enabled
-        client.update_fee_config(
-            &Some(1000),
-            &Some(0),
-            &Some(0),
-            &Some(0),
-            &Some(treasury.clone()),
-            &Some(true),
-        );
-
-        let destinations = vec![
-            &env,
-            TreasuryDestination {
-                address: treasury.clone(),
-                weight: 70,
-                region: String::from_str(&env, "Main"),
-            },
-            TreasuryDestination {
-                address: partner.clone(),
-                weight: 30,
-                region: String::from_str(&env, "Partner"),
-            },
-        ];
-        client.set_treasury_distributions(&destinations, &true);
-
-        client.lock_funds(&depositor, &1, &1_000, &(env.ledger().timestamp() + 1_000));
-        client.release_funds(&1, &contributor);
-
-        // lock fee = 100, split 70/30, escrow stores and releases 900
-        assert_eq!(token_client.balance(&treasury), 70);
-        assert_eq!(token_client.balance(&partner), 30);
-        assert_eq!(token_client.balance(&contributor), 900);
-        assert_eq!(token_client.balance(&contract_id), 0);
+    /// Lock a funded escrow (created directly in `Locked` status).
+    fn lock(&self, bounty_id: u64, amount: i128) {
+        self.token_admin.mint(&self.depositor, &amount);
+        let deadline = self.env.ledger().timestamp() + 10_000;
+        self.client
+            .lock_funds(&self.depositor, &bounty_id, &amount, &deadline);
     }
 
-    #[test]
-    fn release_fee_split_is_deterministic_with_remainder_to_partner() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let (client, token_client, token_admin, _admin, contract_id) = make_setup(&env);
-        let depositor = Address::generate(&env);
-        let contributor = Address::generate(&env);
-        let treasury = Address::generate(&env);
-        let partner = Address::generate(&env);
-
-        token_admin.mint(&depositor, &1_000);
-        client.update_fee_config(
-            &Some(0),
-            &Some(333),
-            &Some(0),
-            &Some(0),
-            &Some(treasury.clone()),
-            &Some(true),
-        );
-
-        let destinations = vec![
-            &env,
-            TreasuryDestination {
-                address: treasury.clone(),
-                weight: 50,
-                region: String::from_str(&env, "Main"),
-            },
-            TreasuryDestination {
-                address: partner.clone(),
-                weight: 50,
-                region: String::from_str(&env, "Partner"),
-            },
-        ];
-        client.set_treasury_distributions(&destinations, &true);
-
-        client.lock_funds(&depositor, &2, &1_000, &(env.ledger().timestamp() + 1_000));
-        client.release_funds(&2, &contributor);
-
-        // release fee = ceiling(1000 * 333 / 10000) = 34
-        // split 50/50 => treasury 17, partner 17
-        assert_eq!(token_client.balance(&treasury), 17);
-        assert_eq!(token_client.balance(&partner), 17);
-        assert_eq!(token_client.balance(&contributor), 966);
-        assert_eq!(token_client.balance(&contract_id), 0);
+    /// Create a funded escrow in `Draft` status (the pre-lock state used by
+    /// the recurring-lock flow) by writing the record directly, since drafts
+    /// are only produced by that flow in production. Mirrors that flow:
+    /// tokens are already held by the contract and the bounty is indexed, so
+    /// the INV-2 aggregate-to-ledger invariant holds after `publish`.
+    fn create_draft(&self, bounty_id: u64, amount: i128) {
+        let escrow = Escrow {
+            depositor: self.depositor.clone(),
+            amount,
+            remaining_amount: amount,
+            status: EscrowStatus::Draft,
+            deadline: self.env.ledger().timestamp() + 10_000,
+            refund_history: vec![&self.env],
+            archived: false,
+            archived_at: None,
+        };
+        self.token_admin.mint(&self.contract_id, &amount);
+        self.env.as_contract(&self.contract_id, || {
+            self.env
+                .storage()
+                .persistent()
+                .set(&DataKey::Escrow(bounty_id), &escrow);
+            let mut index: Vec<u64> = self
+                .env
+                .storage()
+                .persistent()
+                .get(&DataKey::EscrowIndex)
+                .unwrap_or(Vec::new(&self.env));
+            index.push_back(bounty_id);
+            self.env
+                .storage()
+                .persistent()
+                .set(&DataKey::EscrowIndex, &index);
+        });
     }
 
-    #[test]
-    fn default_routing_uses_fee_recipient_when_distribution_disabled() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let (client, token_client, token_admin, _admin, contract_id) = make_setup(&env);
-        let depositor = Address::generate(&env);
-        let contributor = Address::generate(&env);
-        let treasury = Address::generate(&env);
-        let partner = Address::generate(&env);
-
-        token_admin.mint(&depositor, &1_000);
-        client.update_fee_config(
-            &Some(0),
-            &Some(500),
-            &Some(0),
-            &Some(0),
-            &Some(treasury.clone()),
-            &Some(true),
-        );
-
-        let destinations = vec![
-            &env,
-            TreasuryDestination {
-                address: partner.clone(),
-                weight: 100,
-                region: String::from_str(&env, "Partner"),
-            },
-        ];
-        // We set destinations but explicitly DISABLE distribution
-        client.set_treasury_distributions(&destinations, &false);
-
-        client.lock_funds(&depositor, &3, &1_000, &(env.ledger().timestamp() + 1_000));
-        client.release_funds(&3, &contributor);
-
-        // Fallback recipient (treasury) gets all 50. Partner gets 0.
-        assert_eq!(token_client.balance(&treasury), 50);
-        assert_eq!(token_client.balance(&partner), 0);
-        assert_eq!(token_client.balance(&contributor), 950);
-        assert_eq!(token_client.balance(&contract_id), 0);
+    /// Set routing 100% to `self.treasury` via the plain (pre-lock) path.
+    fn set_routing_to_treasury(&self, bounty_id: u64) {
+        self.client
+            .set_fee_routing(&bounty_id, &self.treasury, &10_000, &None, &0);
     }
 
-    #[test]
-    fn test_no_duplicate_fee_collection_on_release_retry() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let (client, token_client, token_admin, _admin, _contract_id) = make_setup(&env);
-        let depositor = Address::generate(&env);
-        let contributor = Address::generate(&env);
-        let treasury = Address::generate(&env);
-
-        token_admin.mint(&depositor, &10_000);
-        client.update_fee_config(
-            &Some(0),
-            &Some(1000),
-            &Some(0),
-            &Some(0),
-            &Some(treasury.clone()),
-            &Some(true),
-        );
-        client.set_treasury_distributions(&vec![&env], &false);
-
-        let bounty_id = 4u64;
-        client.lock_funds(
-            &depositor,
-            &bounty_id,
-            &10_000,
-            &(env.ledger().timestamp() + 3600),
-        );
-
-        // First release
-        client.release_funds(&bounty_id, &contributor);
-
-        // Fee should be 1,000 (10% of 10,000)
-        assert_eq!(token_client.balance(&treasury), 1000);
-
-        // Try releasing again (retry scenario)
-        let res = client.try_release_funds(&bounty_id, &contributor);
-        assert_eq!(res.err().unwrap().unwrap(), Error::FundsNotLocked);
-
-        // Balance should NOT double-charge!
-        assert_eq!(token_client.balance(&treasury), 1000);
+    /// Decode the most recent `FeeRoutingChanged` event, identified by its
+    /// `"fee_rchg"` topic.
+    fn last_routing_changed_event(&self) -> events::FeeRoutingChanged {
+        let marker = Symbol::new(&self.env, "fee_rchg");
+        let mut found = None;
+        for (contract, topics, data) in self.env.events().all().iter() {
+            if contract != self.contract_id {
+                continue;
+            }
+            let first: Val = topics.get(0).unwrap();
+            if Symbol::try_from_val(&self.env, &first) != Ok(marker.clone()) {
+                continue;
+            }
+            found = Some(
+                events::FeeRoutingChanged::try_from_val(&self.env, &data)
+                    .expect("fee_rchg event data must decode as FeeRoutingChanged"),
+            );
+        }
+        found.expect("no FeeRoutingChanged event emitted")
     }
+}
+
+// ── pre-lock: plain path works ───────────────────────────────────────────────
+
+/// Routing may be configured normally while the bounty is still Draft.
+#[test]
+fn test_set_routing_on_draft_succeeds() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    s.set_routing_to_treasury(1);
+
+    let routing = s.client.get_fee_routing(&1).unwrap();
+    assert_eq!(routing.treasury_recipient, s.treasury);
+    assert_eq!(routing.treasury_bps, 10_000);
+    assert_eq!(routing.partner_recipient, None);
+    assert_eq!(routing.partner_bps, 0);
+}
+
+/// Routing with a partner split may be configured on a Draft bounty.
+#[test]
+fn test_set_routing_with_partner_on_draft_succeeds() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    s.client
+        .set_fee_routing(&1, &s.treasury, &7_000, &Some(s.partner.clone()), &3_000);
+
+    let routing = s.client.get_fee_routing(&1).unwrap();
+    assert_eq!(routing.treasury_bps, 7_000);
+    assert_eq!(routing.partner_recipient, Some(s.partner.clone()));
+    assert_eq!(routing.partner_bps, 3_000);
+}
+
+/// Pre-lock changes may be revised any number of times while still Draft.
+#[test]
+fn test_routing_can_be_revised_while_draft() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    s.set_routing_to_treasury(1);
+    let other = Address::generate(&s.env);
+    s.client.set_fee_routing(&1, &other, &10_000, &None, &0);
+
+    assert_eq!(
+        s.client.get_fee_routing(&1).unwrap().treasury_recipient,
+        other
+    );
+}
+
+/// Routing configured while Draft survives the Draft -> Locked transition and
+/// governs where the release fee actually lands.
+#[test]
+fn test_draft_routing_survives_publish_and_routes_release_fee() {
+    let s = Suite::new();
+
+    // 1% release fee, globally enabled; default recipient is the admin so a
+    // successful per-bounty override is observable.
+    s.client.update_fee_config(
+        &Some(0i128),
+        &Some(100i128),
+        &None,
+        &None,
+        &Some(s.admin.clone()),
+        &Some(true),
+    );
+
+    // Draft with funds pre-deposited to the contract so release can pay out.
+    s.create_draft(1, 100_000);
+
+    s.set_routing_to_treasury(1);
+    s.client.publish(&1);
+
+    s.client.release_funds(&1, &s.contributor);
+
+    let tc = token::TokenClient::new(&s.env, &s.token_id);
+    // release fee = 1% of 100_000 = 1_000, routed to the per-bounty treasury.
+    assert_eq!(tc.balance(&s.treasury), 1_000);
+    assert_eq!(tc.balance(&s.contributor), 99_000);
+}
+
+// ── post-lock: plain path is rejected ────────────────────────────────────────
+
+/// The core guard: once Locked, the plain path must fail with FeeRoutingLocked.
+#[test]
+fn test_set_routing_after_lock_rejected() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+
+    let result = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &10_000, &None, &0);
+    assert_eq!(result.unwrap_err().unwrap(), Error::FeeRoutingLocked);
+    assert!(
+        s.client.get_fee_routing(&1).is_none(),
+        "rejected call must not write any routing"
+    );
+}
+
+/// Publishing a Draft locks routing: the plain path stops working exactly at
+/// the Draft -> Locked transition.
+#[test]
+fn test_publish_locks_routing() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    // Works while Draft…
+    s.set_routing_to_treasury(1);
+
+    // …and stops working the moment the bounty is published (Locked).
+    s.client.publish(&1);
+    let other = Address::generate(&s.env);
+    let result = s.client.try_set_fee_routing(&1, &other, &10_000, &None, &0);
+    assert_eq!(result.unwrap_err().unwrap(), Error::FeeRoutingLocked);
+
+    // The pre-lock routing is untouched.
+    assert_eq!(
+        s.client.get_fee_routing(&1).unwrap().treasury_recipient,
+        s.treasury
+    );
+}
+
+/// Anonymous escrows are created directly in Locked status, so the plain path
+/// is always rejected for them.
+#[test]
+fn test_set_routing_on_anonymous_escrow_rejected() {
+    let s = Suite::new();
+    s.token_admin.mint(&s.depositor, &1_000);
+    let commitment = soroban_sdk::BytesN::from_array(&s.env, &[7u8; 32]);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    s.client
+        .lock_funds_anonymous(&s.depositor, &commitment, &1, &1_000, &deadline);
+
+    let result = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &10_000, &None, &0);
+    assert_eq!(result.unwrap_err().unwrap(), Error::FeeRoutingLocked);
+}
+
+/// Later statuses (Released) are equally immutable through the plain path.
+#[test]
+fn test_set_routing_after_release_rejected() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+    s.client.release_funds(&1, &s.contributor);
+
+    let result = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &10_000, &None, &0);
+    assert_eq!(result.unwrap_err().unwrap(), Error::FeeRoutingLocked);
+}
+
+/// A non-existent bounty is still BountyNotFound (checked before the guard).
+#[test]
+fn test_set_routing_missing_bounty_rejected() {
+    let s = Suite::new();
+    let result = s
+        .client
+        .try_set_fee_routing(&999, &s.treasury, &10_000, &None, &0);
+    assert_eq!(result.unwrap_err().unwrap(), Error::BountyNotFound);
+}
+
+// ── post-lock: audited override path ─────────────────────────────────────────
+
+/// The elevated path accepts a post-lock change when a reason is supplied.
+#[test]
+fn test_with_reason_succeeds_after_lock() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+
+    let reason = String::from_str(&s.env, "treasury key rotation, ticket OPS-42");
+    s.client
+        .set_fee_routing_with_reason(&1, &s.treasury, &10_000, &None, &0, &reason);
+
+    let routing = s.client.get_fee_routing(&1).unwrap();
+    assert_eq!(routing.treasury_recipient, s.treasury);
+}
+
+/// An empty reason defeats the audit trail and must be rejected.
+#[test]
+fn test_with_reason_rejects_empty_reason() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+
+    let empty = String::from_str(&s.env, "");
+    let result =
+        s.client
+            .try_set_fee_routing_with_reason(&1, &s.treasury, &10_000, &None, &0, &empty);
+    assert_eq!(result.unwrap_err().unwrap(), Error::InvalidAmount);
+    assert!(s.client.get_fee_routing(&1).is_none());
+}
+
+/// The elevated path still requires the bounty to exist.
+#[test]
+fn test_with_reason_missing_bounty_rejected() {
+    let s = Suite::new();
+    let reason = String::from_str(&s.env, "why");
+    let result = s.client.try_set_fee_routing_with_reason(
+        &999,
+        &s.treasury,
+        &10_000,
+        &None,
+        &0,
+        &reason,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), Error::BountyNotFound);
+}
+
+/// The elevated path also works pre-lock (it is a superset of the plain path).
+#[test]
+fn test_with_reason_works_on_draft_too() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+    let reason = String::from_str(&s.env, "initial config via audited path");
+    s.client
+        .set_fee_routing_with_reason(&1, &s.treasury, &10_000, &None, &0, &reason);
+    assert!(s.client.get_fee_routing(&1).is_some());
+}
+
+// ── share invariants hold on both paths ──────────────────────────────────────
+
+#[test]
+fn test_share_invariants_enforced_on_plain_path() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    // No partner: treasury must take 100%.
+    let r = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &9_000, &None, &0);
+    assert_eq!(r.unwrap_err().unwrap(), Error::InvalidAmount);
+
+    // Partner present: shares must sum to exactly 100%.
+    let r = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &9_000, &Some(s.partner.clone()), &500);
+    assert_eq!(r.unwrap_err().unwrap(), Error::InvalidAmount);
+
+    // Out-of-range share.
+    let r = s
+        .client
+        .try_set_fee_routing(&1, &s.treasury, &10_001, &None, &0);
+    assert_eq!(r.unwrap_err().unwrap(), Error::InvalidAmount);
+}
+
+#[test]
+fn test_share_invariants_enforced_on_reason_path() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+    let reason = String::from_str(&s.env, "attempted misconfig");
+
+    let r = s
+        .client
+        .try_set_fee_routing_with_reason(&1, &s.treasury, &9_000, &None, &0, &reason);
+    assert_eq!(r.unwrap_err().unwrap(), Error::InvalidAmount);
+
+    let r = s.client.try_set_fee_routing_with_reason(
+        &1,
+        &s.treasury,
+        &9_000,
+        &Some(s.partner.clone()),
+        &500,
+        &reason,
+    );
+    assert_eq!(r.unwrap_err().unwrap(), Error::InvalidAmount);
+}
+
+// ── FeeRoutingChanged audit event ────────────────────────────────────────────
+
+/// First configuration: old destinations are None, new ones populated,
+/// pre-lock path flagged as non-override.
+#[test]
+fn test_audit_event_on_first_configuration() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+
+    s.set_routing_to_treasury(1);
+
+    let ev = s.last_routing_changed_event();
+    assert_eq!(ev.bounty_id, 1);
+    assert_eq!(ev.old_treasury_recipient, None);
+    assert_eq!(ev.old_partner_recipient, None);
+    assert_eq!(ev.new_treasury_recipient, s.treasury);
+    assert_eq!(ev.new_partner_recipient, None);
+    assert_eq!(ev.changed_by, s.admin);
+    assert!(!ev.post_lock_override);
+    assert_eq!(ev.reason, None);
+}
+
+/// Post-lock override: the event carries the PREVIOUS and NEW destinations,
+/// the override flag, and the mandatory reason — the full audit trail.
+#[test]
+fn test_audit_event_on_post_lock_override() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+    s.client
+        .set_fee_routing(&1, &s.treasury, &7_000, &Some(s.partner.clone()), &3_000);
+    s.client.publish(&1);
+
+    let new_treasury = Address::generate(&s.env);
+    let reason = String::from_str(&s.env, "partner agreement terminated");
+    s.client
+        .set_fee_routing_with_reason(&1, &new_treasury, &10_000, &None, &0, &reason);
+
+    let ev = s.last_routing_changed_event();
+    assert_eq!(ev.old_treasury_recipient, Some(s.treasury.clone()));
+    assert_eq!(ev.old_partner_recipient, Some(s.partner.clone()));
+    assert_eq!(ev.new_treasury_recipient, new_treasury);
+    assert_eq!(ev.new_partner_recipient, None);
+    assert_eq!(ev.changed_by, s.admin);
+    assert!(ev.post_lock_override);
+    assert_eq!(ev.reason, Some(reason));
+}
+
+// ── storage / view accuracy ──────────────────────────────────────────────────
+
+#[test]
+fn test_get_fee_routing_none_when_unset() {
+    let s = Suite::new();
+    s.lock(1, 1_000);
+    assert!(s.client.get_fee_routing(&1).is_none());
+}
+
+/// The stored record equals what was submitted, field for field.
+#[test]
+fn test_get_fee_routing_roundtrip() {
+    let s = Suite::new();
+    s.create_draft(1, 1_000);
+    s.client
+        .set_fee_routing(&1, &s.treasury, &6_500, &Some(s.partner.clone()), &3_500);
+    assert_eq!(
+        s.client.get_fee_routing(&1).unwrap(),
+        PerBountyFeeRouting {
+            treasury_recipient: s.treasury.clone(),
+            treasury_bps: 6_500,
+            partner_recipient: Some(s.partner.clone()),
+            partner_bps: 3_500,
+        }
+    );
 }

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_first_valid_second_exists.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_first_valid_second_exists.1.json
@@ -1970,6 +1970,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_single_item.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_single_item.1.json
@@ -1799,6 +1799,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -1842,6 +1848,12 @@
             ],
             "data": {
               "map": [
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
                 {
                   "key": {
                     "symbol": "count"

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_lock_funds_success.1.json
@@ -2252,6 +2252,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2408,6 +2414,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -2570,6 +2582,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2613,6 +2631,12 @@
             ],
             "data": {
               "map": [
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
                 {
                   "key": {
                     "symbol": "count"

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_atomicity.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_atomicity.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_large_batch.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_large_batch.1.json
@@ -4816,6 +4816,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -4972,6 +4978,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -5134,6 +5146,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -5290,6 +5308,12 @@
                   "val": {
                     "u64": 4
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -5452,6 +5476,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -5608,6 +5638,12 @@
                   "val": {
                     "u64": 6
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -5770,6 +5806,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -5926,6 +5968,12 @@
                   "val": {
                     "u64": 8
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -6088,6 +6136,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -6247,6 +6301,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -6290,6 +6350,12 @@
             ],
             "data": {
               "map": [
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
                 {
                   "key": {
                     "symbol": "count"
@@ -7932,6 +7998,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -8088,6 +8160,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8250,6 +8328,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -8406,6 +8490,12 @@
                   "val": {
                     "u64": 4
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8568,6 +8658,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -8724,6 +8820,12 @@
                   "val": {
                     "u64": 6
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8886,6 +8988,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -9042,6 +9150,12 @@
                   "val": {
                     "u64": 8
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -9204,6 +9318,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -9360,6 +9480,12 @@
                   "val": {
                     "u64": 10
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_multiple_depositors.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_operations_multiple_depositors.1.json
@@ -2595,6 +2595,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2751,6 +2757,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -2913,6 +2925,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2956,6 +2974,12 @@
             ],
             "data": {
               "map": [
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
                 {
                   "key": {
                     "symbol": "count"

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_already_released.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_already_released.1.json
@@ -2255,6 +2255,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2573,6 +2579,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -3051,6 +3063,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_duplicate_in_batch.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_duplicate_in_batch.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_exceeds_max_batch_size.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_exceeds_max_batch_size.1.json
@@ -6074,6 +6074,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -6230,6 +6236,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -6392,6 +6404,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -6548,6 +6566,12 @@
                   "val": {
                     "u64": 4
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -6710,6 +6734,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -6866,6 +6896,12 @@
                   "val": {
                     "u64": 6
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -7028,6 +7064,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -7184,6 +7226,12 @@
                   "val": {
                     "u64": 8
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -7346,6 +7394,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -7502,6 +7556,12 @@
                   "val": {
                     "u64": 10
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -7664,6 +7724,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -7820,6 +7886,12 @@
                   "val": {
                     "u64": 12
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -7982,6 +8054,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -8138,6 +8216,12 @@
                   "val": {
                     "u64": 14
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8300,6 +8384,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -8456,6 +8546,12 @@
                   "val": {
                     "u64": 16
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8618,6 +8714,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -8774,6 +8876,12 @@
                   "val": {
                     "u64": 18
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -8936,6 +9044,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -9095,6 +9209,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -9138,6 +9258,12 @@
             ],
             "data": {
               "map": [
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
                 {
                   "key": {
                     "symbol": "count"

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_first_valid_second_not_found.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_first_valid_second_not_found.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_mixed_locked_and_refunded.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_mixed_locked_and_refunded.1.json
@@ -2273,6 +2273,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2803,6 +2809,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -3114,6 +3126,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_non_adjacent_duplicates.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_non_adjacent_duplicates.1.json
@@ -2127,6 +2127,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2654,6 +2660,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_single_item.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_single_item.1.json
@@ -2059,6 +2059,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2391,6 +2397,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_success.1.json
@@ -2680,6 +2680,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -3207,6 +3213,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -3740,6 +3752,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -4115,6 +4133,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4274,6 +4298,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4430,6 +4460,12 @@
                   "val": {
                     "u64": 3
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_to_multiple_contributors.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_batch_release_funds_to_multiple_contributors.1.json
@@ -2677,6 +2677,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -3204,6 +3210,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -3737,6 +3749,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -4112,6 +4130,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4271,6 +4295,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4427,6 +4457,12 @@
                   "val": {
                     "u64": 3
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_claim_then_use_release_funds_normally.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_claim_then_use_release_funds_normally.1.json
@@ -2218,6 +2218,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2873,6 +2879,12 @@
                   "val": {
                     "u64": 104
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_expired_claim_then_authorize_new_one.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_expired_claim_then_authorize_new_one.1.json
@@ -2424,6 +2424,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_pending_claim_restores_escrow.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_cancel_pending_claim_restores_escrow.1.json
@@ -2093,6 +2093,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_after_window_expires_panics.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_after_window_expires_panics.1.json
@@ -2131,6 +2131,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_at_exact_window_boundary_succeeds.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_at_exact_window_boundary_succeeds.1.json
@@ -2257,6 +2257,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_does_not_affect_other_bounties.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_does_not_affect_other_bounties.1.json
@@ -2472,6 +2472,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2999,6 +3005,12 @@
                   "val": {
                     "u64": 107
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_twice_panics.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_twice_panics.1.json
@@ -2256,6 +2256,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_within_window_transfers_funds.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_claim_within_window_transfers_funds.1.json
@@ -2261,6 +2261,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_get_balance.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_get_balance.1.json
@@ -2015,6 +2015,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_get_escrow_info.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_get_escrow_info.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_lock_funds_duplicate.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_lock_funds_duplicate.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_lock_funds_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_lock_funds_success.1.json
@@ -1913,6 +1913,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_full_amount_in_one_shot_marks_released.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_full_amount_in_one_shot_marks_released.1.json
@@ -2048,6 +2048,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2372,6 +2378,12 @@
                   "val": {
                     "u64": 45
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_leaves_tiny_remainder.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_leaves_tiny_remainder.1.json
@@ -2047,6 +2047,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2371,6 +2377,12 @@
                   "val": {
                     "u64": 43
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_multiple_sequential_small_amounts.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_multiple_sequential_small_amounts.1.json
@@ -2607,6 +2607,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2931,6 +2937,12 @@
                   "val": {
                     "u64": 44
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -3275,6 +3287,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -3613,6 +3631,12 @@
                   "val": {
                     "u64": 44
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -3957,6 +3981,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4295,6 +4325,12 @@
                   "val": {
                     "u64": 44
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -4639,6 +4675,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -4977,6 +5019,12 @@
                   "val": {
                     "u64": 44
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -5321,6 +5369,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -5662,6 +5716,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -6000,6 +6060,12 @@
                   "val": {
                     "u64": 44
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_on_already_released_bounty_panics.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_on_already_released_bounty_panics.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 50
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_overpayment_panics.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_overpayment_panics.1.json
@@ -2046,6 +2046,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2370,6 +2376,12 @@
                   "val": {
                     "u64": 46
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_remaining_amount_never_goes_negative.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_remaining_amount_never_goes_negative.1.json
@@ -2173,6 +2173,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2497,6 +2503,12 @@
                   "val": {
                     "u64": 48
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -2841,6 +2853,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -3179,6 +3197,12 @@
                   "val": {
                     "u64": 48
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_single_minimum_unit.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_single_minimum_unit.1.json
@@ -2048,6 +2048,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2372,6 +2378,12 @@
                   "val": {
                     "u64": 42
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_zero_amount_rejected.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_partial_release_zero_amount_rejected.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_after_partial_release_returns_only_remainder.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_after_partial_release_returns_only_remainder.1.json
@@ -2196,6 +2196,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2523,6 +2529,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
@@ -2778,6 +2790,12 @@
                   "val": {
                     "u64": 51
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_success.1.json
@@ -2061,6 +2061,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2424,6 +2430,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_too_early.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_refund_too_early.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_release_funds_already_released.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_release_funds_already_released.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_release_funds_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_release_funds_success.1.json
@@ -2044,6 +2044,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2466,6 +2472,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_set_claim_window_success.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test/test_set_claim_window_success.1.json
@@ -2131,6 +2131,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_deadline_future_vs_no_deadline_after_expiry.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_deadline_future_vs_no_deadline_after_expiry.1.json
@@ -2273,6 +2273,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2803,6 +2809,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -3114,6 +3126,12 @@
                   "val": {
                     "u64": 32
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_deadline_zero_vs_future_refund_eligibility.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_deadline_zero_vs_future_refund_eligibility.1.json
@@ -2273,6 +2273,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2803,6 +2809,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -3114,6 +3126,12 @@
                   "val": {
                     "u64": 30
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_early_refund_with_admin_approval.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_early_refund_with_admin_approval.1.json
@@ -2128,6 +2128,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2712,6 +2718,12 @@
                   "val": {
                     "u64": 13
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_refund_blocked_before_expiry.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_refund_blocked_before_expiry.1.json
@@ -1914,6 +1914,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_refund_succeeds_after_expiry.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_refund_succeeds_after_expiry.1.json
@@ -2061,6 +2061,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2424,6 +2430,12 @@
                   "val": {
                     "u64": 12
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_release_unaffected_by_deadline.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_release_unaffected_by_deadline.1.json
@@ -2041,6 +2041,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2359,6 +2365,12 @@
                   "val": {
                     "u64": 14
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_stored_correctly.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_future_deadline_stored_correctly.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_partial_refund_with_admin_approval.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_partial_refund_with_admin_approval.1.json
@@ -2127,6 +2127,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2659,6 +2665,12 @@
                   "val": {
                     "u64": 24
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_blocked_even_after_large_time_advance.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_blocked_even_after_large_time_advance.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_blocked_without_approval.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_blocked_without_approval.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_succeeds_with_admin_approval.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_refund_succeeds_with_admin_approval.1.json
@@ -2129,6 +2129,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2713,6 +2719,12 @@
                   "val": {
                     "u64": 23
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_release_succeeds.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_release_succeeds.1.json
@@ -2042,6 +2042,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2360,6 +2366,12 @@
                   "val": {
                     "u64": 25
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_stored_correctly.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_no_deadline_stored_correctly.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_refund_succeeds_after_time_advance.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_refund_succeeds_after_time_advance.1.json
@@ -2058,6 +2058,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2369,6 +2375,12 @@
                   "val": {
                     "u64": 3
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_refund_succeeds_immediately.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_refund_succeeds_immediately.1.json
@@ -2061,6 +2061,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2424,6 +2430,12 @@
                   "val": {
                     "u64": 2
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_release_succeeds.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_release_succeeds.1.json
@@ -2042,6 +2042,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2360,6 +2366,12 @@
                   "val": {
                     "u64": 4
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_stored_correctly.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_deadline_variants/test_zero_deadline_stored_correctly.1.json
@@ -1912,6 +1912,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_partially_refunded.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_partially_refunded.1.json
@@ -2127,6 +2127,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2781,6 +2787,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_refunded.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_refunded.1.json
@@ -2059,6 +2059,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2492,6 +2498,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_released.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_locked_to_released.1.json
@@ -2041,6 +2041,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2481,6 +2487,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_locked_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_locked_fails.1.json
@@ -2126,6 +2126,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2658,6 +2664,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_refunded.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_refunded.1.json
@@ -2272,6 +2272,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2807,6 +2813,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "refund_to"
                   },
                   "val": {
@@ -3240,6 +3252,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_released_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_partially_refunded_to_released_fails.1.json
@@ -2126,6 +2126,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2658,6 +2664,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_locked_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_locked_fails.1.json
@@ -2058,6 +2058,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2369,6 +2375,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_partially_refunded_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_partially_refunded_fails.1.json
@@ -2058,6 +2058,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2369,6 +2375,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_refunded_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_refunded_fails.1.json
@@ -2058,6 +2058,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2369,6 +2375,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_released_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_refunded_to_released_fails.1.json
@@ -2058,6 +2058,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2369,6 +2375,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_locked_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_locked_fails.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_partially_refunded_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_partially_refunded_fails.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_refunded_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_refunded_fails.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_released_fails.1.json
+++ b/contracts/bounty_escrow/contracts/escrow/test_snapshots/test_status_transitions/test_released_to_released_fails.1.json
@@ -2040,6 +2040,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "deadline"
                   },
                   "val": {
@@ -2358,6 +2364,12 @@
                   "val": {
                     "u64": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "correlation_id"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/contracts/bounty_escrow/docs/security/fee-routing-immutability.md
+++ b/contracts/bounty_escrow/docs/security/fee-routing-immutability.md
@@ -1,0 +1,143 @@
+# Fee Routing Immutability and Audit Trail
+
+**Contract:** `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
+**Entrypoints:** `set_fee_routing`, `set_fee_routing_with_reason`, `get_fee_routing`
+**Event:** `FeeRoutingChanged` (`contracts/bounty_escrow/contracts/escrow/src/events.rs`)
+**Tests:** `contracts/bounty_escrow/contracts/escrow/src/test_fee_routing.rs`
+
+## The problem
+
+`set_fee_routing` lets an admin configure a `PerBountyFeeRouting` override
+that decides **where** the fee collected for a given `bounty_id` is sent —
+split between a primary treasury and an optional partner.
+
+As previously written, the only checks were that the bounty existed and that
+the basis-point shares summed to 100%. Nothing prevented the destination from
+being changed **after** the bounty had already transitioned to `Locked` with
+depositor funds held. An admin could therefore silently redirect where the
+eventual fee landed after depositors had committed funds under a different,
+publicly observable routing — with the only trace being a `FeeRoutingUpdated`
+event that recorded the new destination but not the old one, making the
+substitution invisible to anyone not diffing consecutive events.
+
+## The fix
+
+### 1. Immutability guard on the default path
+
+`set_fee_routing` now rejects any change once the bounty's funds are
+committed:
+
+```rust
+if !allow_post_lock && Self::fee_routing_is_locked(&env, bounty_id) {
+    return Err(Error::FeeRoutingLocked);   // error code 60
+}
+```
+
+`fee_routing_is_locked` treats routing as mutable **only** while a regular
+escrow is in `Draft` status. Any later status (`Locked`, `Released`,
+`Refunded`, `PartiallyRefunded`) is immutable. Anonymous escrows
+(`lock_funds_anonymous`) are created directly in `Locked` status and never
+pass through `Draft`, so they are immutable from creation.
+
+The boundary is exactly the `Draft -> Locked` transition performed by
+`publish`: routing configured during `Draft` is what depositors see when funds
+are committed, and it is frozen from that moment.
+
+### 2. Audited override path
+
+Legitimate post-lock changes still exist — a compromised treasury key, a
+terminated partner agreement, a treasury migration. Rather than forbidding
+them outright and leaving operators stuck, they are routed through a distinct,
+higher-friction entrypoint:
+
+```rust
+set_fee_routing_with_reason(
+    bounty_id, treasury_recipient, treasury_bps,
+    partner_recipient, partner_bps,
+    reason,            // mandatory, non-empty
+)
+```
+
+An empty `reason` is rejected with `InvalidAmount` — the audit trail is the
+entire purpose of the path, so a blank justification defeats it. Share
+invariants are enforced identically to the default path.
+
+### 3. `FeeRoutingChanged` audit event
+
+Every accepted routing change — on **both** paths — emits `FeeRoutingChanged`
+alongside the pre-existing `FeeRoutingUpdated`:
+
+| Field | Meaning |
+|---|---|
+| `old_treasury_recipient` | Destination before this change (`None` on first configuration) |
+| `old_partner_recipient` | Partner before this change, if any |
+| `new_treasury_recipient` | Destination after this change |
+| `new_partner_recipient` | Partner after this change, if any |
+| `changed_by` | Admin address that performed the change |
+| `post_lock_override` | `true` when the audited post-lock path was used |
+| `reason` | Mandatory justification on the post-lock path; `None` pre-lock |
+| `bounty_id`, `version`, `timestamp` | Envelope fields (topic `"fee_rchg"`, EVENT_VERSION_V2) |
+
+Because the event carries the **previous** destination as well as the new one,
+an indexer can reconstruct the complete routing history for any bounty from
+events alone, and a post-lock redirect is trivially detectable by filtering on
+`post_lock_override == true`.
+
+## Security rationale
+
+- **Depositors get what they committed to.** Once funds are locked, the fee
+  destination visible at commit time cannot be changed through the ordinary
+  admin path. The window for silent substitution is closed.
+- **No functionality removed, only made loud.** Post-lock changes remain
+  possible for genuine operational needs, but they are impossible to perform
+  *silently*: a separate entrypoint, a mandatory on-chain reason, and an event
+  flagged `post_lock_override = true`.
+- **Old destination is on-chain.** Recording only the new destination (the
+  prior behavior) made redirects invisible without cross-referencing earlier
+  events; `FeeRoutingChanged` makes each change self-describing.
+- **Fail-closed ordering.** Existence is checked before the guard, and the
+  guard before share validation, so a rejected call never writes storage nor
+  emits an event (asserted in tests).
+- **Compatibility.** `FeeRoutingUpdated` is still emitted unchanged, so
+  existing indexers keep working; `FeeRoutingChanged` is purely additive.
+
+### Residual risk (accepted)
+
+The post-lock path remains available to the admin — it is a
+*higher-privilege, audited* path, not a prohibition. A malicious admin can
+still redirect fees post-lock, but cannot do so without leaving an
+attributable, indexable on-chain record naming themselves, the old and new
+destinations, and a reason. Deployments wanting a hard prohibition can leave
+`set_fee_routing_with_reason` unexposed in their admin tooling or gate it
+behind the existing multisig/timelock machinery.
+
+Note also that this guard governs the *fee destination* only. The fee
+*amount* is computed from the global or per-token rate (see
+`docs/fee-config-precedence.md`), which has its own admin controls.
+
+## Test coverage
+
+`test_fee_routing.rs` (19 tests):
+
+- **Pre-lock succeeds** — `test_set_routing_on_draft_succeeds`,
+  `test_set_routing_with_partner_on_draft_succeeds`,
+  `test_routing_can_be_revised_while_draft`,
+  `test_draft_routing_survives_publish_and_routes_release_fee` (end-to-end:
+  routing set while `Draft` actually determines where the release fee lands).
+- **Post-lock rejected** — `test_set_routing_after_lock_rejected`,
+  `test_publish_locks_routing` (the guard engages exactly at the
+  `Draft -> Locked` transition), `test_set_routing_after_release_rejected`,
+  `test_set_routing_on_anonymous_escrow_rejected`; rejected calls are asserted
+  to leave no stored routing.
+- **Audited path** — `test_with_reason_succeeds_after_lock`,
+  `test_with_reason_rejects_empty_reason`,
+  `test_with_reason_missing_bounty_rejected`,
+  `test_with_reason_works_on_draft_too`.
+- **Invariants on both paths** — `test_share_invariants_enforced_on_plain_path`,
+  `test_share_invariants_enforced_on_reason_path`.
+- **Audit event** — `test_audit_event_on_first_configuration` (old fields
+  `None`, `post_lock_override == false`),
+  `test_audit_event_on_post_lock_override` (previous treasury *and* partner
+  captured, override flag set, reason recorded).
+- **Views** — `test_get_fee_routing_none_when_unset`,
+  `test_get_fee_routing_roundtrip`.


### PR DESCRIPTION
Closes #1464 

### fix: prevent silent post-lock fee routing changes without audit trail
set_fee_routing let an admin change a bounty's PerBountyFeeRouting destination at any time — including after the escrow transitioned to Locked with depositor funds held. The only trace was a FeeRoutingUpdated event recording the new destination but not the old one, so redirecting where fees eventually land was effectively invisible to anyone not diffing consecutive events.

⚠️ Read this first: master does not compile today
This PR contains two commits. The first (46c567a1) is unrelated to the feature and exists because I could not build or test anything without it. Verified in a clean worktree at origin/master: 813 compile errors, from two independent upstream causes:

9f98d788 ("docs: publish cross-contract ABI stability matrix") overwrote contracts/escrow/src/lib.rs with a stale copy while adding its module doc header. That reverted the merged fixes from #1663 and #1664 — the export = false attributes on the Error/DataKey enums (both exceed the 50-case XDR spec limit, so spec generation panics with LengthExceedsMax and cascades into ~800 errors), the contractclient import, the u32 expiration-ledger argument to token.approve, the fee_enabled AND-semantics security fix in resolve_fee_config, and the precedence doc comments. It also re-disabled the test_multi_token_fees and test_frozen_balance module declarations, so 59 tests silently stopped running while docs/fee-config-precedence.md and docs/freeze-precedence.md remained in the tree describing guarantees the contract no longer enforced.
2cfab344 (cross-contract correlation id) added correlation_id to FundsLocked, FundsReleased, FundsRefunded and BatchFundsLocked in events.rs without updating the initializers in lib.rs — 10 further E0063 errors.
Commit 46c567a1 restores the reverted content on top of the current master file, preserving 9f98d788's ABI-stability doc header and every other upstream change, and sets correlation_id: None at each affected initializer (matching the field's documented optional semantics). It adds no behavior and takes master from "does not compile" to 370 passing tests. It reviews independently of the feature commit.

Suggested follow-up, out of scope here: 9f98d788 reverted merged work by force-writing a whole file. Worth checking whether other files in that commit clobbered other contributors' changes the same way — I only audited bounty_escrow.

### The fix (commit 42f52bd7)
### 1. Immutability guard on the default path

set_fee_routing now rejects changes once depositor funds are committed:


if !allow_post_lock && Self::fee_routing_is_locked(&env, bounty_id) {
    return Err(Error::FeeRoutingLocked);   // new error code 60
}
Routing is mutable only while a regular escrow is in Draft. Any later status (Locked, Released, Refunded, PartiallyRefunded) is immutable. Anonymous escrows are created directly in Locked and never pass through Draft, so they are immutable from creation. The boundary is exactly the Draft → Locked transition performed by publish: what depositors observe at commit time is frozen from that moment.

### 2. Audited override path

Legitimate post-lock changes exist (compromised treasury key, terminated partner agreement, treasury migration), so they're routed through a distinct higher-friction entrypoint rather than forbidden outright:


set_fee_routing_with_reason(bounty_id, treasury_recipient, treasury_bps,
                            partner_recipient, partner_bps, reason /* non-empty */)
An empty reason is rejected with InvalidAmount — the audit trail is the entire point of the path. Share invariants are enforced identically on both paths.

### 3. FeeRoutingChanged audit event

Emitted on every accepted change from both paths, alongside the unchanged FeeRoutingUpdated:

Field	Meaning
old_treasury_recipient / old_partner_recipient	Destinations before the change (None on first configuration)
new_treasury_recipient / new_partner_recipient	Destinations after the change
changed_by	Admin that performed the change
post_lock_override	true when the audited post-lock path was used
reason	Mandatory justification post-lock; None pre-lock
Because the previous destination is on-chain, an indexer can reconstruct a bounty's full routing history from events alone, and post-lock redirects are trivially detectable by filtering post_lock_override == true. FeeRoutingUpdated is untouched, so existing indexers keep working — FeeRoutingChanged is purely additive.

### Tests
test_fee_routing.rs, 19 tests:

Pre-lock succeeds — plain and partner-split configuration on Draft, repeated revisions, and an end-to-end case proving routing set while Draft actually determines where the release fee lands after publish.
Post-lock rejected — after lock_funds, after publish (the guard engages exactly at the transition), after release_funds, and on anonymous escrows. Rejected calls are asserted to leave no stored routing.
Audited path — succeeds post-lock with a reason; rejects empty reason; still requires the bounty to exist; also works pre-lock.
Share invariants — enforced identically on both paths.
Audit event — first configuration (old_* are None, post_lock_override == false) and post-lock override (previous treasury and partner captured, override flag set, reason recorded).
Views — get_fee_routing returns None when unset and round-trips field-for-field.
Docs
docs/security/fee-routing-immutability.md — threat, guard semantics, event schema, security rationale, accepted residual risk, and coverage map. Plus NatSpec-style doc comments on both entrypoints and the fee_routing_is_locked helper.

### Accepted residual risk
This makes post-lock redirects loud, not impossible. A malicious admin can still redirect fees via the audited path, but cannot do so without an attributable on-chain record naming themselves, both destinations, and a reason. Deployments wanting a hard prohibition can leave set_fee_routing_with_reason unexposed in admin tooling or gate it behind the existing multisig/timelock machinery. Note the guard governs the fee destination only — the fee amount comes from the global/per-token rate, which has its own controls.

### Test results

cargo test -p bounty-escrow
  46c567a1 (restore):      370 passed; 0 failed   (was: does not compile)
  42f52bd7 (this feature): 389 passed; 0 failed
Branch is rebased on 577e8a57 and currently zero commits behind origin/master.