### PR TITLE
fix: stabilize gas optimization guardrails with snapshot API and retry determinism (#1632)

### DIFF
--- a/soroban/contracts/stream/GAS_REGRESSION_GUARDRAILS.md
+++ b/soroban/contracts/stream/GAS_REGRESSION_GUARDRAILS.md
@@ -71,6 +71,8 @@ Captures Soroban budget meters before and after an operation.
 - Returns identical values for same binary, same `Env` state, same operation
 - Uses `saturating_sub` to prevent underflow
 - Does not modify the operation being measured
+- Works correctly **with or without** a prior `reset_budget()` call — the delta
+  is always relative to the current counter state
 
 **Gas-Sensitive Execution Paths:**
 
@@ -83,6 +85,28 @@ Captures Soroban budget meters before and after an operation.
    - Cost: ~100 CPU instructions (SDK estimate)
    - Sensitivity: SDK version, host implementation
    - Regression Surface: Soroban SDK changes to budget accounting
+
+### 4. snapshot() / delta_from() Two-Step API
+
+Allows splitting measurement into explicit pre/post snapshots.
+
+**Key Properties:**
+- `snapshot()` captures current budget counters at a point in time
+- `delta_from(before)` computes resources consumed between the snapshot and now
+- Equivalent to `measure()` when used correctly (verified by test)
+- Useful for measuring setup + operation separately
+
+**Gas-Sensitive Execution Paths:**
+
+1. **Snapshot Capture (`snapshot()`)**:
+   - Cost: 2 budget reads (same as `measure()` before half)
+   - Sensitivity: SDK version, host implementation
+   - Regression Surface: Soroban SDK changes to budget accounting
+
+2. **Delta Computation (`delta_from()`)**:
+   - Cost: 2 budget reads + saturating arithmetic
+   - Sensitivity: None (pure Rust arithmetic)
+   - Regression Surface: None (pure Rust code)
 
 ## Gas-Sensitive Execution Paths
 
@@ -204,6 +228,66 @@ Captures Soroban budget meters before and after an operation.
 - Assertion: No resource leaks or state corruption
 - Regression Surface: Fixture lifecycle management
 
+### Edge Case 6: Snapshot API Correctness
+
+**Behavior:** The `snapshot()` + `delta_from()` two-step API produces the same
+result as the atomic `measure()` helper.
+
+**Guardrails:**
+- Test: `snapshot_delta_matches_measure`
+- Assertion: snapshot+delta_from yields identical result to measure()
+- Regression Surface: Budget accounting inconsistency
+
+### Edge Case 7: Snapshot State Reflection
+
+**Behavior:** `snapshot()` returns values that accurately reflect the current
+budget state at the time of the call.
+
+**Guardrails:**
+- Test: `snapshot_reflects_current_budget`
+- Assertion: Snapshot after reset shows zero; after work shows increased counters
+- Regression Surface: Snapshot returning stale values
+
+### Edge Case 8: Measurement Without Prior Reset
+
+**Behavior:** Calling `measure()` without a prior `reset_budget()` correctly
+captures the delta from the current counter state, not from zero.
+
+**Guardrails:**
+- Test: `measure_without_prior_reset_produces_correct_delta`
+- Assertion: Delta matches measurement from a fresh fixture with reset
+- Regression Surface: Measurement assuming zeroed budget
+
+### Edge Case 9: Determinism Across Retries
+
+**Behavior:** The same operation produces identical gas measurements across
+independent simulated "reruns" — exactly as would happen in CI retries.
+
+**Guardrails:**
+- Test: `determinism_across_simulated_reruns`
+- Assertion: All 5 reruns produce identical BudgetDelta values
+- Regression Surface: SDK nondeterminism, fixture state leakage
+
+### Edge Case 10: Sequential Accumulation Without Resets
+
+**Behavior:** Multiple `measure()` calls without intervening `reset_budget()`
+correctly accumulate — each captures only the delta from the previous end state.
+
+**Guardrails:**
+- Test: `sequential_measurements_without_resets_accumulate`
+- Assertion: Identical sequential operations produce identical deltas
+- Regression Surface: Measurement cross-contamination
+
+### Edge Case 11: Debug Representation
+
+**Behavior:** `GasRegressionFixture` implements `std::fmt::Debug` for ergonomic
+use in assertions, logging, and panic messages.
+
+**Guardrails:**
+- Test: `fixture_debug_representation`
+- Assertion: Debug string is non-empty and contains the type name
+- Regression Surface: Accidental removal of Debug derive
+
 ## Regression Surface
 
 ### What Constitutes a Regression
@@ -226,6 +310,10 @@ A gas regression is detected when:
    - Detected by: `cross_fixture_no_contamination_shared_env_default`
    - Indicates: Shared mutable state bug
 
+5. **Retry Determinism Failure**: Same operation produces different results across reruns
+   - Detected by: `determinism_across_simulated_reruns`
+   - Indicates: SDK nondeterminism, environment contamination, or test infrastructure bug
+
 ### Protected Against
 
 The guardrails protect against:
@@ -235,6 +323,7 @@ The guardrails protect against:
 3. **Host Changes**: Soroban host implementation changes
 4. **Fixture Bugs**: Any regression in the test infrastructure itself
 5. **Environment Contamination**: Tests affecting each other
+6. **Retry Nondeterminism**: Tests producing different results across CI retries
 
 ### Not Protected Against
 
@@ -254,7 +343,9 @@ For the same binary build, the following are guaranteed deterministic:
 1. **Fixture Creation**: `GasRegressionFixture::new()` always produces identical initial state
 2. **Budget Reset**: `reset_budget()` always produces zero state
 3. **Measurement**: Same operation + same inputs = identical `BudgetDelta`
-4. **Contract Operations**: Same contract call + same inputs = identical gas cost
+4. **Snapshot**: `snapshot()` at the same fixture state returns identical values
+5. **Delta Computation**: `delta_from(before)` produces identical results for the same operation sequence
+6. **Contract Operations**: Same contract call + same inputs = identical gas cost
 
 ### What is NOT Deterministic
 
@@ -318,6 +409,48 @@ assert!(d_batch.cpu > d_single.cpu);
 
 **Guardrails:** Ensures batch operations scale predictably.
 
+### Pattern 4: Snapshot-Based Split Measurement
+
+```rust
+let fix = GasRegressionFixture::new();
+
+// Capture baseline before setup
+let before_setup = fix.snapshot();
+
+// Perform setup (not measured separately)
+let admin = Address::generate(&fix.env);
+let token_contract = fix.env.register_stellar_asset_contract_v2(admin.clone());
+
+// Measure operation cost from setup baseline
+let setup_cost = fix.delta_from(before_setup);
+
+// Reset and measure specific operation
+fix.reset_budget();
+let d_operation = measure(&fix.env, || {
+    token_sac.mint(&admin, &1_000);
+});
+```
+
+**Guardrails:** Enables measuring setup and operation costs separately.
+
+### Pattern 5: Determinism Across Retries Verification
+
+```rust
+let mut results = Vec::new();
+for _ in 0..5 {
+    let fix = GasRegressionFixture::new();
+    // ... setup ...
+    fix.reset_budget();
+    let d = measure(&fix.env, || { operation() });
+    results.push(d);
+}
+assert_eq!(results[0], results[1]);
+// All results must be identical — this is the retry-determinism guarantee
+```
+
+**Guardrails:** Verifies the test infrastructure produces identical results
+across independent runs (simulating CI retries).
+
 ## Test Coverage Summary
 
 | Category | Tests | Purpose |
@@ -330,8 +463,9 @@ assert!(d_batch.cpu > d_single.cpu);
 | Reproducibility Across Runs | 2 | Verify same-process reproducibility |
 | Cross-Fixture Non-Contamination | 2 | Verify no state leak between fixtures |
 | Contract-Level Gas Regression | 4 | Verify fixture works with real contracts |
-| Documented Regression Surface | 3 | Pin down baseline costs |
-| **Total** | **32** | **Comprehensive coverage** |
+| Documented Regression Surface | 2 | Pin down baseline costs (noop, address generation) |
+| Snapshot API & Extended Determinism | 6 | Verify snapshot API, retry determinism, debug impl |
+| **Total** | **37** | **Comprehensive coverage** |
 
 ## Running the Guardrails
 

--- a/soroban/contracts/stream/src/lib.rs
+++ b/soroban/contracts/stream/src/lib.rs
@@ -100,8 +100,30 @@ pub fn measure<F: FnOnce()>(env: &Env, f: F) -> BudgetDelta {
 ///   identical gas measurements on the same binary.
 /// - Fixture creation is O(1) and does not interact with ledger state.
 /// - No shared mutable state between fixture instances.
+///
+/// # Determinism Across Retries and Rerenders
+///
+/// For the **same binary build**, all of the following are guaranteed deterministic:
+///
+/// | Aspect | Guarantee |
+/// |--------|-----------|
+/// | Fixture creation | `new()` always produces identical initial budget state |
+/// | Budget reset | `reset_budget()` always produces zero state |
+/// | Measurement delta | Same operation + same inputs = identical `BudgetDelta` |
+/// | Snapshot delta | `snapshot()` + operation + delta = identical result |
+///
+/// Cross-binary, cross-SDK-version, and cross-compiler-flag builds **may** differ.
+/// This is expected and does not indicate a regression.
 pub struct GasRegressionFixture {
     pub env: Env,
+}
+
+impl core::fmt::Debug for GasRegressionFixture {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GasRegressionFixture")
+            .field("env", &"<Env>")
+            .finish()
+    }
 }
 
 impl GasRegressionFixture {
@@ -136,8 +158,68 @@ impl GasRegressionFixture {
     ///
     /// Always call this immediately before the operation being measured to
     /// ensure only that operation's cost is captured.
+    ///
+    /// # Determinism
+    ///
+    /// After `reset_budget()`, the budget counters are **always** at zero,
+    /// regardless of prior fixture history. This is verified by
+    /// `reproducibility_reset_produces_canonical_state`.
     pub fn reset_budget(&self) {
         self.env.cost_estimate().budget().reset_unlimited();
+    }
+
+    /// Captures the current budget meters as a raw starting point.
+    ///
+    /// Use this when you need to record a budget baseline at one point in
+    /// execution and compute the delta later. This is useful for measuring
+    /// setup + operation separately.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let fix = GasRegressionFixture::new();
+    /// let before = fix.snapshot();
+    /// // perform setup + operation
+    /// let delta = fix.delta_from(before);
+    /// assert!(delta.has_positive_cost());
+    /// ```
+    ///
+    /// # Determinism
+    ///
+    /// For the same fixture state, `snapshot()` always returns the same pair
+    /// of values on the same binary.
+    pub fn snapshot(&self) -> BudgetDelta {
+        BudgetDelta {
+            cpu: self.env.cost_estimate().budget().cpu_instruction_cost(),
+            mem: self.env.cost_estimate().budget().memory_bytes_cost(),
+        }
+    }
+
+    /// Computes the budget delta from a previously captured snapshot to the current state.
+    ///
+    /// This is the inverse of [`snapshot()`](Self::snapshot): it returns the resources
+    /// consumed between the two points. The result uses `saturating_sub` so it never
+    /// underflows even if the budget was reset between the snapshot and this call.
+    ///
+    /// # Determinism
+    ///
+    /// For the same sequence of operations between `snapshot()` and `delta_from()`,
+    /// this always returns identical values on the same binary.
+    pub fn delta_from(&self, before: BudgetDelta) -> BudgetDelta {
+        BudgetDelta {
+            cpu: self
+                .env
+                .cost_estimate()
+                .budget()
+                .cpu_instruction_cost()
+                .saturating_sub(before.cpu),
+            mem: self
+                .env
+                .cost_estimate()
+                .budget()
+                .memory_bytes_cost()
+                .saturating_sub(before.mem),
+        }
     }
 }
 

--- a/soroban/contracts/stream/tests/gas_regression.rs
+++ b/soroban/contracts/stream/tests/gas_regression.rs
@@ -990,3 +990,197 @@ fn regression_baseline_reset_matches_fresh_fixture() {
         "reset fixture memory must match fresh fixture memory"
     );
 }
+
+// =============================================================================
+// 11. SNAPSHOT API & EXTENDED DETERMINISM
+// =============================================================================
+
+/// The `snapshot()` + `delta_from()` API must produce the same result as `measure()`.
+///
+/// **What this proves**: The two-step snapshot workflow is equivalent to the
+/// atomic `measure()` helper. This allows callers to split measurement from
+/// operation when they need to capture setup + operation separately.
+#[test]
+fn snapshot_delta_matches_measure() {
+    let fix = GasRegressionFixture::new();
+    fix.reset_budget();
+
+    // === Using measure() ===
+    let d_measure = measure(&fix.env, || {
+        let _addr = Address::generate(&fix.env);
+    });
+
+    // === Using snapshot() + delta_from() ===
+    fix.reset_budget();
+    let before = fix.snapshot();
+    let _addr2 = Address::generate(&fix.env);
+    let d_snapshot = fix.delta_from(before);
+
+    assert_eq!(
+        d_measure, d_snapshot,
+        "snapshot+delta_from must produce identical result to measure()"
+    );
+}
+
+/// The `snapshot()` method must return values that represent the current budget state.
+///
+/// **What this proves**: The snapshot accurately reflects the budget counters
+/// at the time of the call, making it a reliable baseline for delta computation.
+#[test]
+fn snapshot_reflects_current_budget() {
+    let fix = GasRegressionFixture::new();
+    fix.reset_budget();
+
+    let s0 = fix.snapshot();
+    assert_eq!(s0.cpu, 0, "snapshot after reset must show zero CPU");
+    assert_eq!(s0.mem, 0, "snapshot after reset must show zero memory");
+
+    // Consume some budget
+    let _addr = Address::generate(&fix.env);
+    let s1 = fix.snapshot();
+
+    assert!(
+        s1.cpu > s0.cpu,
+        "snapshot after address generation must show increased CPU; before={}, after={}",
+        s0.cpu,
+        s1.cpu
+    );
+}
+
+/// Calling `measure()` without a prior `reset_budget()` must still produce
+/// correct deltas — the delta is relative to the current counter state.
+///
+/// **What this proves**: The `measure()` helper does not depend on a zeroed
+/// budget. It captures relative deltas regardless of the starting counter values.
+/// This is important for measuring specific operations within a larger setup.
+#[test]
+fn measure_without_prior_reset_produces_correct_delta() {
+    let fix = GasRegressionFixture::new();
+
+    // Perform some setup operations that consume gas
+    for _ in 0..10 {
+        let _addr = Address::generate(&fix.env);
+    }
+
+    // Measure WITHOUT reset — delta should reflect only the measured operation
+    let d = measure(&fix.env, || {
+        let _addr = Address::generate(&fix.env); // one more address
+    });
+
+    // The delta must be positive (address generation costs something)
+    assert!(
+        d.has_positive_cost(),
+        "measure() without prior reset must still capture a positive delta"
+    );
+
+    // Verify determinism: running the same measurement again must match
+    let fix2 = GasRegressionFixture::new();
+    fix2.reset_budget();
+    let d_fresh = measure(&fix2.env, || {
+        let _addr = Address::generate(&fix2.env);
+    });
+
+    assert_eq!(
+        d, d_fresh,
+        "address generation delta must be deterministic regardless of prior fixture state"
+    );
+}
+
+/// The fixture must produce deterministic results across simulated "reruns"
+/// — creating a fixture, performing operations, and measuring the same
+/// operation across multiple independent runs.
+///
+/// **What this proves**: If a test is run multiple times (e.g., in CI retries),
+/// each run produces identical gas measurements for the same operation.
+/// This is the foundation of "deterministic across retries and rerenders."
+#[test]
+fn determinism_across_simulated_reruns() {
+    // Simulate 5 independent "reruns" of the same test logic
+    let mut results: Vec<BudgetDelta> = Vec::new();
+
+    for _run in 0..5 {
+        let fix = GasRegressionFixture::new();
+        let admin = Address::generate(&fix.env);
+
+        // Register a token contract as setup (not measured)
+        let token_contract = fix.env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_sac = token::StellarAssetClient::new(&fix.env, &token_id);
+
+        // Measure the same operation in each "rerun"
+        fix.reset_budget();
+        let d = measure(&fix.env, || {
+            token_sac.mint(&admin, &1_000);
+        });
+
+        results.push(d);
+    }
+
+    // All reruns must produce identical deltas
+    let first = &results[0];
+    for (i, d) in results.iter().enumerate().skip(1) {
+        assert_eq!(
+            first, d,
+            "rerun {} must produce identical delta to rerun 0; deterministic property violated \
+             across simulated retries",
+            i
+        );
+    }
+}
+
+/// Measurements taken without intervening budget resets accumulate correctly.
+///
+/// **What this proves**: If you call `measure()` multiple times without
+/// `reset_budget()` between them, each call captures only the delta from
+/// the previous measurement's end state. The total of all deltas equals
+/// the cost of running all operations together.
+#[test]
+fn sequential_measurements_without_resets_accumulate() {
+    let fix = GasRegressionFixture::new();
+    fix.reset_budget();
+
+    // Measure three operations sequentially WITHOUT resetting between
+    let d1 = measure(&fix.env, || {
+        let _addr = Address::generate(&fix.env);
+    });
+    let d2 = measure(&fix.env, || {
+        let _addr = Address::generate(&fix.env);
+    });
+    let d3 = measure(&fix.env, || {
+        let _addr = Address::generate(&fix.env);
+    });
+
+    // Each individual delta must be positive
+    assert!(d1.has_positive_cost(), "d1 must be positive");
+    assert!(d2.has_positive_cost(), "d2 must be positive");
+    assert!(d3.has_positive_cost(), "d3 must be positive");
+
+    // The deltas should be equal since they're the same operation
+    assert_eq!(
+        d1, d2,
+        "identical sequential operations must produce identical deltas"
+    );
+    assert_eq!(
+        d1, d3,
+        "identical sequential operations must produce identical deltas"
+    );
+}
+
+/// The fixture must implement [`std::fmt::Debug`] for ergonomic use in
+/// assertions and logging.
+///
+/// **What this proves**: The custom `Debug` implementation on
+/// `GasRegressionFixture` compiles and produces a non-empty representation.
+#[test]
+fn fixture_debug_representation() {
+    let fix = GasRegressionFixture::new();
+    let debug_str = format!("{:?}", fix);
+    assert!(
+        !debug_str.is_empty(),
+        "Debug representation must not be empty"
+    );
+    assert!(
+        debug_str.contains("GasRegressionFixture"),
+        "Debug representation must include the type name"
+    );
+}


### PR DESCRIPTION
## Overview

This PR stabilizes the gas optimization guardrails in the `grainlify-stream` crate by adding a new snapshot API, hardening the test infrastructure, and explicitly verifying determinism across retries/rerenders. The existing behavior is fully preserved.

## Related Issue

Closes #1632

## Changes

### Snapshot API (snapshot() / delta_from())

- [ADD] `snapshot()` method on `GasRegressionFixture` - captures current budget counters at a point in time
- [ADD] `delta_from(before)` method - computes resources consumed between a snapshot and the current state
- Equivalent to the existing `measure()` helper when used together (verified by test)

### Manual Debug Implementation

- [ADD] Custom `std::fmt::Debug` impl for `GasRegressionFixture` (Soroban's `Env` doesn't implement Debug in SDK v23)
- Enables ergonomic use in assertions, logging, and panic messages

### New Gas Regression Tests (6 tests added, 31 to 37 total)

| Test | What it proves |
|------|---------------|
| snapshot_delta_matches_measure | Snapshot API is equivalent to measure() |
| snapshot_reflects_current_budget | Snapshots reflect real-time budget state |
| measure_without_prior_reset_produces_correct_delta | measure() works without reset_budget() |
| determinism_across_simulated_reruns | Identical results across 5 independent simulated CI retries |
| sequential_measurements_without_resets_accumulate | Sequential measurements correctly capture per-step deltas |
| fixture_debug_representation | Debug output is non-empty and contains type name |

### Documentation Updates

- 6 new edge cases documented in GAS_REGRESSION_GUARDRAILS.md
- 2 new usage patterns (Snapshot-Based Split Measurement, Determinism Across Retries)
- Updated test count from 32 to 37 with corrected category breakdown
- Added Retry Determinism Failure to regression surface

## Verification Results

```
cargo test --package grainlify-stream
37/37 passed (0 failed, 0 warnings, 0 errors)
```

| Acceptance Criteria | Status |
| --- | --- |
| Current behavior still works | All 31 existing tests pass unchanged |
| Edge-case behavior visible in tests/docs | 6 new tests + 6 new edge cases documented |
| Backward compatible with current repo | No breaking API changes, all existing patterns preserved |
| Deterministic across retries and rerenders | Verified by determinism_across_simulated_reruns |
